### PR TITLE
don't calling yaml.load() without Loader

### DIFF
--- a/entity/tests/test_view.py
+++ b/entity/tests/test_view.py
@@ -510,7 +510,7 @@ class ViewTest(AironeViewTest):
         resp = self.client.get(reverse('entity:export'))
         self.assertEqual(resp.status_code, 200)
 
-        obj = yaml.load(resp.content)
+        obj = yaml.load(resp.content, Loader=yaml.SafeLoader)
         self.assertTrue(isinstance(obj, dict))
         self.assertEqual(sorted(obj.keys()), ['Entity', 'EntityAttr'])
         self.assertEqual(len(obj['EntityAttr']), 3)
@@ -564,7 +564,7 @@ class ViewTest(AironeViewTest):
         resp = self.client.get(reverse('entity:export'))
         self.assertEqual(resp.status_code, 200)
 
-        obj = yaml.load(resp.content)
+        obj = yaml.load(resp.content, Loader=yaml.SafeLoader)
         self.assertEqual(len(obj['Entity']), 2)
         self.assertEqual(len(obj['EntityAttr']), 2)
         self.assertTrue([x for x in obj['Entity'] if x['name'] == entity1.name])
@@ -586,7 +586,7 @@ class ViewTest(AironeViewTest):
         resp = self.client.get(reverse('entity:export'))
         self.assertEqual(resp.status_code, 200)
 
-        obj = yaml.load(resp.content)
+        obj = yaml.load(resp.content, Loader=yaml.SafeLoader)
         self.assertEqual(len(obj['Entity']), 1)
         self.assertEqual(obj['Entity'][0]['name'], 'entity1')
 

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -957,7 +957,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(job.status, Job.STATUS['DONE'])
         self.assertEqual(job.text, 'entry_ほげ.yaml')
 
-        obj = yaml.load(job.get_cache())
+        obj = yaml.load(job.get_cache(), Loader=yaml.SafeLoader)
         self.assertTrue(entity.name in obj)
 
         self.assertEqual(len(obj[entity.name]), 1)
@@ -986,7 +986,7 @@ class ViewTest(AironeViewTest):
 
         resp = self.client.get(reverse('entry:export', args=[entity.id]))
         self.assertEqual(resp.status_code, 200)
-        obj = yaml.load(Job.objects.last().get_cache())
+        obj = yaml.load(Job.objects.last().get_cache(), Loader=yaml.SafeLoader)
 
         # check permitted attributes exist in the result
         self.assertTrue(all([x in obj['ほげ'][0]['attrs'] for x in ['foo', 'bar']]))

--- a/group/tests/test_view.py
+++ b/group/tests/test_view.py
@@ -205,7 +205,7 @@ class ViewTest(AironeViewTest):
         resp = self.client.get(reverse('group:export'))
         self.assertEqual(resp.status_code, 200)
 
-        obj = yaml.load(resp.content)
+        obj = yaml.load(resp.content, Loader=yaml.SafeLoader)
         self.assertTrue(isinstance(obj, dict))
 
         self.assertEqual(len(obj['User']), 3)
@@ -233,7 +233,7 @@ class ViewTest(AironeViewTest):
         resp = self.client.get(reverse('group:export'))
         self.assertEqual(resp.status_code, 200)
 
-        obj = yaml.load(resp.content)
+        obj = yaml.load(resp.content, Loader=yaml.SafeLoader)
 
         self.assertEqual(len(obj['User']), self._get_active_user_count())
         self.assertEqual(len(obj['Group']), 2)

--- a/group/views.py
+++ b/group/views.py
@@ -204,7 +204,7 @@ def import_user_and_group(request):
 @check_superuser
 def do_import_user_and_group(request, context):
     try:
-        data = yaml.load(context)
+        data = yaml.load(context, Loader=yaml.SafeLoader)
     except (yaml.parser.ParserError, yaml.scanner.ScannerError):
         return HttpResponse("Couldn't parse uploaded file", status=400)
 


### PR DESCRIPTION
Restricting warnings, fix some test codes.

### before

```
$ python manage.py test
Creating test database for alias 'default'...
[INFO]	asctime:2020-02-19 14:31:29,570	module:urls	message:advanced API endpoints are unavailable	process:83933	thread:4637306304
[INFO]	asctime:2020-02-19 14:31:29,575	module:urls	message:There is no URL dispatcher of custom-view	process:83933	thread:4637306304
System check identified no issues (0 silenced).
...........................................[INFO]	asctime:2020-02-19 14:31:36,426	module:ldap	message:Failed to authenticate user(ldap_user) in LDAP	process:83933	thread:4637306304
..[ERROR]	asctime:2020-02-19 14:31:36,669	module:ldap	message:('unable to open socket', [(LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('::1', 389, 0, 0)), (LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('127.0.0.1', 389))])	process:83933	thread:4637306304
[INFO]	asctime:2020-02-19 14:31:36,670	module:ldap	message:Failed to authenticate user(invalid_user) in LDAP	process:83933	thread:4637306304
[ERROR]	asctime:2020-02-19 14:31:36,675	module:ldap	message:('unable to open socket', [(LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('::1', 389, 0, 0)), (LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('127.0.0.1', 389))])	process:83933	thread:4637306304
[INFO]	asctime:2020-02-19 14:31:36,675	module:ldap	message:Failed to authenticate user(guest) in LDAP	process:83933	thread:4637306304
..................................................................................../Users/takano-mitsuhiro/GitHub/airone/entity/tests/test_view.py:513: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  obj = yaml.load(resp.content)
./Users/takano-mitsuhiro/GitHub/airone/entity/tests/test_view.py:589: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  obj = yaml.load(resp.content)
./Users/takano-mitsuhiro/GitHub/airone/entity/tests/test_view.py:567: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  obj = yaml.load(resp.content)
.................................................................................................s................(invalid literal for int() with base 10: '') attr_data: {'id': '2507', 'type': '1025', 'referral_key': [], 'value': [{'data': '', 'index': 0}]}
...................../Users/takano-mitsuhiro/GitHub/airone/entry/tests/test_view.py:960: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  obj = yaml.load(job.get_cache())
/Users/takano-mitsuhiro/GitHub/airone/entry/tests/test_view.py:989: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  obj = yaml.load(Job.objects.last().get_cache())
..........s........................................(invalid literal for int() with base 10: '') attr_data: {'id': '2926', 'type': '1025', 'referral_key': [], 'value': [{'data': '', 'index': 0}]}
......................./Users/takano-mitsuhiro/GitHub/airone/group/tests/test_view.py:208: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  obj = yaml.load(resp.content)
./Users/takano-mitsuhiro/GitHub/airone/group/tests/test_view.py:236: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  obj = yaml.load(resp.content)
.../Users/takano-mitsuhiro/GitHub/airone/group/views.py:207: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  data = yaml.load(context)
...........................................................................
----------------------------------------------------------------------
Ran 419 tests in 244.260s

OK (skipped=2)
Destroying test database for alias 'default'...
```


### after

```
$ python manage.py test
Creating test database for alias 'default'...
[INFO]	asctime:2020-02-19 15:03:09,318	module:urls	message:advanced API endpoints are unavailable	process:87425	thread:4622564800
[INFO]	asctime:2020-02-19 15:03:09,323	module:urls	message:There is no URL dispatcher of custom-view	process:87425	thread:4622564800
System check identified no issues (0 silenced).
...........................................[INFO]	asctime:2020-02-19 15:03:15,337	module:ldap	message:Failed to authenticate user(ldap_user) in LDAP	process:87425	thread:4622564800
..[ERROR]	asctime:2020-02-19 15:03:15,562	module:ldap	message:('unable to open socket', [(LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('::1', 389, 0, 0)), (LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('127.0.0.1', 389))])	process:87425	thread:4622564800
[INFO]	asctime:2020-02-19 15:03:15,562	module:ldap	message:Failed to authenticate user(invalid_user) in LDAP	process:87425	thread:4622564800
[ERROR]	asctime:2020-02-19 15:03:15,567	module:ldap	message:('unable to open socket', [(LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('::1', 389, 0, 0)), (LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('127.0.0.1', 389))])	process:87425	thread:4622564800
[INFO]	asctime:2020-02-19 15:03:15,567	module:ldap	message:Failed to authenticate user(guest) in LDAP	process:87425	thread:4622564800
.......................................................................................................................................................................................s................(invalid literal for int() with base 10: '') attr_data: {'value': [{'index': 0, 'data': ''}], 'id': '2508', 'referral_key': [], 'type': '1025'}
...............................s........................................(invalid literal for int() with base 10: '') attr_data: {'value': [{'index': 0, 'data': ''}], 'id': '2926', 'referral_key': [], 'type': '1025'}
......................................................................................................
----------------------------------------------------------------------
Ran 419 tests in 263.136s

OK (skipped=2)
Destroying test database for alias 'default'...
```