### PR TITLE
set default AMQP user for Celery as 'airone'.

### DIFF
--- a/airone/settings.py
+++ b/airone/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = '(ch@ngeMe)'
 
 # Celery settings
-CELERY_BROKER_URL = 'amqp://guest:guest@localhost//'
+CELERY_BROKER_URL = 'amqp://airone:password@localhost//'
 
 #: Only add pickle to this list if your broker is secured
 #: from unwanted access (see userguide/security.html)


### PR DESCRIPTION
Use 'airone' user for default AMQP setting.