### PR TITLE
Fixed a problem that escaped HTML special characters are shown at edit entry page

### DIFF
--- a/static/js/airone_constants.js
+++ b/static/js/airone_constants.js
@@ -48,3 +48,14 @@ var gettext = function(key, lang) {
     return DEFAULT_DICTIONARY[key];
   }
 };
+
+/* This is necessary because the HTML special characters which are set in the variable in Jinja2
+ * is encoded. When you want to use it in the JavaScript processing, you have to wrap it using
+ * this method to show all text properly. */
+function unescapeHtml(safe) {
+  return safe.replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}

--- a/templates/edit_entry/attrs.html
+++ b/templates/edit_entry/attrs.html
@@ -16,7 +16,7 @@
 
       {% if attr.type|bitwise_and:attr_type_value.named %}
         <div class='col-3'>
-          <input type='text' class='referral_key' attr_id="{{ attr.id }}"></input>
+          <input type='text' class='form-control referral_key' attr_id="{{ attr.id }}"></input>
         </div>
         <div class='col-7'>
       {% else %}
@@ -40,10 +40,10 @@
           {% endif %}
         </select>
 
-        <input type="text" class="narrow_down_referral" placeholder="絞り込み" style="width: 100%" use_api="True" attr_id="{{ attr.id }}"/>
+        <input type="text" class="form-control narrow_down_referral" placeholder="絞り込み" style="width: 100%" use_api="True" attr_id="{{ attr.id }}"/>
 
             {% else %}
-              <input type='text' class='attr_value' attr_id='{{ attr.id }}' index='0'/>
+              <input type='text' class='form-control attr_value' attr_id='{{ attr.id }}' index='0'/>
             {% endif %}
 
           </div>
@@ -56,7 +56,7 @@
       <div class='row attr_referral' {% if attr.is_mandatory %}mandatory="true"{% endif %}>
       {% if attr.type|bitwise_and:attr_type_value.named %}
         <div class='col-3'>
-          <input type='text' class='referral_key' attr_id="{{ attr.id }}" value="{{ attr.last_value }}" enabled="True" index="0"></input>
+          <input type='text' class='form-control referral_key' attr_id="{{ attr.id }}" value="{{ attr.last_value }}" enabled="True" index="0"></input>
         </div>
         <div class='col-9'>
       {% else %}
@@ -79,14 +79,14 @@
           {% endif %}
         </select>
 
-        <input type="text" class="narrow_down_referral" placeholder="絞り込み" style="width: 100%" use_api="True" attr_id="{{ attr.id }}"/>
+        <input type="text" class="form-control narrow_down_referral" placeholder="絞り込み" style="width: 100%" use_api="True" attr_id="{{ attr.id }}"/>
 
         </div>
       </div>
 
     {% elif attr.type == attr_type.textarea %}
 
-      <textarea class="attr_value" attr_id="{{ attr.id }}" enabled="True" cols="80" rows="10" {%if attr.is_mandatory%}mandatory="true"{%endif%}>{{ attr.last_value }}</textarea>
+      <textarea class="form-control attr_value" attr_id="{{ attr.id }}" enabled="True" cols="80" rows="10" {%if attr.is_mandatory%}mandatory="true"{%endif%}>{{ attr.last_value }}</textarea>
 
     {% elif attr.type == attr_type.date %}
 
@@ -114,7 +114,7 @@
 
     {% else %}
 
-      <input type="text" class="attr_value" attr_id="{{ attr.id }}" enabled="True" value="{{ attr.last_value }}" {%if attr.is_mandatory%}mandatory="true"{%endif%}/>
+      <input type="text" class="form-control attr_value" attr_id="{{ attr.id }}" enabled="True" value="{{ attr.last_value }}" {%if attr.is_mandatory%}mandatory="true"{%endif%}/>
 
     {% endif %}
   </td>

--- a/templates/edit_entry/content.html
+++ b/templates/edit_entry/content.html
@@ -9,7 +9,7 @@
         <tr>
           <td>エントリ名</td>
           <td>
-            <input type="text" name="entry_name" value="{{ entry.name }}"/>
+            <input type="text" class="form-control" name="entry_name" value="{{ entry.name }}"/>
           {% if entry.is_deleted %}
             [削除済]
           {% elif entry.status|bitwise_and:STATUS_ENTRY.EDITING %}

--- a/templates/edit_entry/js.html
+++ b/templates/edit_entry/js.html
@@ -341,7 +341,7 @@ $('button[name=add_attr]').on('click', function() {
     {% for value in attr.last_value %}
       {% if attr.type == attr_type.array_string %}
         value_setter = function(new_column) {
-          new_column.find('.attr_value').val('{{ value }}');
+          new_column.find('.attr_value').val(unescapeHtml('{{ value }}'));
           new_column.find('.attr_value').attr('enabled', 'True');
         };
 
@@ -354,7 +354,7 @@ $('button[name=add_attr]').on('click', function() {
             elem_select.children('option').remove();
 
             elem_select.append($('<option />').val(0).text('- NOT SET -'));
-            elem_select.append($('<option />').val({{ value.id }}).text('{{ value.name }}').attr('selected', 'True'));
+            elem_select.append($('<option />').val({{ value.id }}).text(unescapeHtml('{{ value.name }}')).attr('selected', 'True'));
           {% endif %}
 
           // set flags to specify this value will be registered to server
@@ -364,7 +364,7 @@ $('button[name=add_attr]').on('click', function() {
           elem_select.attr('unfetched_value', 'true');
 
           // set name of list element to specify selected value
-          new_column.find('li').text('{{ value.name|truncatechars:config.entry.MAX_LABEL_STRING }}');
+          new_column.find('li').text(unescapeHtml('{{ value.name|truncatechars:config.entry.MAX_LABEL_STRING }}'));
         }
 
       {% elif attr.type == attr_type.array_named_entry %}
@@ -378,12 +378,12 @@ $('button[name=add_attr]').on('click', function() {
             elem_select.children('option').remove();
 
             elem_select.append($('<option />').val(0).text('- NOT SET -'));
-            elem_select.append($('<option />').val({{ value.referral.id }}).text('{{ value.referral.name }}').attr('selected', 'True'));
+            elem_select.append($('<option />').val({{ value.referral.id }}).text(unescapeHtml('{{ value.referral.name }}')).attr('selected', 'True'));
           {% endif %}
 
           // set name of list element to specify selected value
-          new_column.find('li').text('{{ value.referral.name|truncatechars:config.entry.MAX_LABEL_STRING }}');
-          elem_referral_key.val('{{ value.value }}');
+          new_column.find('li').text(unescapeHtml('{{ value.referral.name|truncatechars:config.entry.MAX_LABEL_STRING }}'));
+          elem_referral_key.val(unescapeHtml('{{ value.value }}'));
 
           // set enabled flag and index to each parameters
           elem_referral_key.attr('enabled', 'True');


### PR DESCRIPTION
## Abstract
This fixes #12 

## Changes
* Added a JavaScript function `unescapeHtml` that unescape HTML special characters.
* Wrap each texts which are stored at Jinja2 variable by `unescapeHtml` where they are set to input text value.
* Added identifier for each text input elements to apply Bootstrap style-sheet.

## Result of this change
According to an entry that has HTML special characters for each attributes like this.
<img width="789" alt="スクリーンショット 2020-02-21 16 02 25" src="https://user-images.githubusercontent.com/469934/75014622-10c9a980-54ca-11ea-8fa1-c4b477dab5d4.png">

I confirmed that every attributes are shown correctly at edit page as below.
<img width="1175" alt="スクリーンショット 2020-02-21 16 03 06" src="https://user-images.githubusercontent.com/469934/75014717-4a9ab000-54ca-11ea-8ec5-9b3708ea0464.png">
