### PR TITLE
Don't display useless Warning messages from django.test.Client

### DIFF
--- a/airone/lib/test.py
+++ b/airone/lib/test.py
@@ -1,4 +1,5 @@
 import inspect
+import sys
 import os
 
 from django.test import TestCase, Client, override_settings
@@ -60,3 +61,16 @@ class AironeViewTest(AironeTestCase):
         test_base_path = os.path.dirname(test_file_path)
 
         return open("%s/fixtures/%s" % (test_base_path, fname), 'r')
+
+
+def disable_stderr(func):
+    def wrapper(*args, **kwargs):
+        tmp_stderr = sys.stderr
+        f = open(os.devnull, 'w')
+        sys.stderr = f
+        r = func(*args, **kwargs)
+        sys.stderr = tmp_stderr
+        f.close()
+        return r
+
+    return wrapper

--- a/airone/lib/test.py
+++ b/airone/lib/test.py
@@ -63,14 +63,12 @@ class AironeViewTest(AironeTestCase):
         return open("%s/fixtures/%s" % (test_base_path, fname), 'r')
 
 
-def disable_stderr(func):
-    def wrapper(*args, **kwargs):
-        tmp_stderr = sys.stderr
-        f = open(os.devnull, 'w')
-        sys.stderr = f
-        r = func(*args, **kwargs)
-        sys.stderr = tmp_stderr
-        f.close()
-        return r
+class DisableStderr(object):
+    def __enter__(self):
+        self.tmp_stderr = sys.stderr
+        self.f = open(os.devnull, 'w')
+        sys.stderr = self.f
 
-    return wrapper
+    def __exit__(self, *arg, **kwargs):
+        sys.stderr = self.tmp_stderr
+        self.f.close()

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -19,6 +19,7 @@ from airone.lib.types import AttrTypeArrStr, AttrTypeArrObj
 from airone.lib.types import AttrTypeNamedObj, AttrTypeArrNamedObj
 from airone.lib.types import AttrTypeValue
 from airone.lib.test import AironeViewTest
+from airone.lib.test import disable_stderr
 from airone.lib.acl import ACLType
 
 from unittest.mock import patch
@@ -1814,7 +1815,9 @@ class ViewTest(AironeViewTest):
                     },
                 ],
             }
-            resp = self.client.post(reverse('entry:do_create', args=[entity.id]),
+
+            disable_stderr_post = disable_stderr(self.client.post)
+            resp = disable_stderr_post(reverse('entry:do_create', args=[entity.id]),
                                     json.dumps(params),
                                     'application/json')
 
@@ -2578,6 +2581,7 @@ class ViewTest(AironeViewTest):
                  'value': [{'data': '2018-13-30', 'index': 0}], 'referral_key': []},
             ],
         }
+
         resp = self.client.post(reverse('entry:do_create', args=[entity.id]),
                                 json.dumps(params),
                                 'application/json')
@@ -2856,7 +2860,9 @@ class ViewTest(AironeViewTest):
                         {'data': 'foo', 'index': 0}] if x.type & AttrTypeValue['named'] else [],
                 } for x in entity.attrs.all()],
             }
-            resp = self.client.post(reverse('entry:do_create', args=[entity.id]),
+
+            disable_stderr_post = disable_stderr(self.client.post)
+            resp = disable_stderr_post(reverse('entry:do_create', args=[entity.id]),
                                     json.dumps(params),
                                     'application/json')
 

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -19,8 +19,9 @@ from airone.lib.types import AttrTypeArrStr, AttrTypeArrObj
 from airone.lib.types import AttrTypeNamedObj, AttrTypeArrNamedObj
 from airone.lib.types import AttrTypeValue
 from airone.lib.test import AironeViewTest
-from airone.lib.test import disable_stderr
+from airone.lib.test import DisableStderr
 from airone.lib.acl import ACLType
+
 
 from unittest.mock import patch
 from unittest.mock import Mock
@@ -1816,10 +1817,10 @@ class ViewTest(AironeViewTest):
                 ],
             }
 
-            disable_stderr_post = disable_stderr(self.client.post)
-            resp = disable_stderr_post(reverse('entry:do_create', args=[entity.id]),
-                                    json.dumps(params),
-                                    'application/json')
+            with DisableStderr():
+                resp = self.client.post(reverse('entry:do_create', args=[entity.id]),
+                                        json.dumps(params),
+                                        'application/json')
 
             self.assertEqual(resp.status_code, 200)
 
@@ -2861,10 +2862,10 @@ class ViewTest(AironeViewTest):
                 } for x in entity.attrs.all()],
             }
 
-            disable_stderr_post = disable_stderr(self.client.post)
-            resp = disable_stderr_post(reverse('entry:do_create', args=[entity.id]),
-                                    json.dumps(params),
-                                    'application/json')
+            with DisableStderr():
+                resp = self.client.post(reverse('entry:do_create', args=[entity.id]),
+                                        json.dumps(params),
+                                        'application/json')
 
             self.assertEqual(resp.status_code, 200)
             entry = Entry.objects.get(name=entry_name, schema=entity)


### PR DESCRIPTION
Suppresses output of unnecessary error messages they came from `django.test.Client`.

#### before

```
$ python manage.py test
Creating test database for alias 'default'...
[INFO]	asctime:2020-02-19 18:38:46,921	module:urls	message:advanced API endpoints are unavailable	process:23693	thread:4520889792
[INFO]	asctime:2020-02-19 18:38:46,925	module:urls	message:There is no URL dispatcher of custom-view	process:23693	thread:4520889792
System check identified no issues (0 silenced).
...........................................[INFO]	asctime:2020-02-19 18:38:55,395	module:ldap	message:Failed to authenticate user(ldap_user) in LDAP	process:23693	thread:4520889792
..[ERROR]	asctime:2020-02-19 18:38:55,644	module:ldap	message:('unable to open socket', [(LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('::1', 389, 0, 0)), (LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('127.0.0.1', 389))])	process:23693	thread:4520889792
[INFO]	asctime:2020-02-19 18:38:55,644	module:ldap	message:Failed to authenticate user(invalid_user) in LDAP	process:23693	thread:4520889792
[ERROR]	asctime:2020-02-19 18:38:55,649	module:ldap	message:('unable to open socket', [(LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('::1', 389, 0, 0)), (LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('127.0.0.1', 389))])	process:23693	thread:4520889792
[INFO]	asctime:2020-02-19 18:38:55,649	module:ldap	message:Failed to authenticate user(guest) in LDAP	process:23693	thread:4520889792
.......................................................................................................................................................................................s................(invalid literal for int() with base 10: '') attr_data: {'id': '2507', 'value': [{'data': '', 'index': 0}], 'type': '1025', 'referral_key': []}
...............................s........................................(invalid literal for int() with base 10: '') attr_data: {'id': '2926', 'value': [{'data': '', 'index': 0}], 'type': '1025', 'referral_key': []}
......................................................................................................
----------------------------------------------------------------------
Ran 419 tests in 245.239s
```

#### after

```
$ python manage.py test
Creating test database for alias 'default'...
[INFO]  asctime:2020-02-26 14:08:37,785 module:urls     message:advanced API endpoints are unavailable  process:37344   thread:4502900160
[INFO]  asctime:2020-02-26 14:08:37,793 module:urls     message:There is no URL dispatcher of custom-view       process:37344   thread:4502900160
System check identified no issues (0 silenced).
...........................................[INFO]       asctime:2020-02-26 14:08:44,462 module:ldap     message:Failed to authenticate user(ldap_user) in LDAP  process:37344   thread:4502900160
..[ERROR]       asctime:2020-02-26 14:08:44,676 module:ldap     message:('unable to open socket', [(LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('::1', 389, 0, 0)), (LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('127.0.0.1', 389))])     process:37344   thread:4502900160
[INFO]  asctime:2020-02-26 14:08:44,676 module:ldap     message:Failed to authenticate user(invalid_user) in LDAP       process:37344   thread:4502900160
[ERROR] asctime:2020-02-26 14:08:44,679 module:ldap     message:('unable to open socket', [(LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('::1', 389, 0, 0)), (LDAPSocketOpenError('socket connection error while opening: [Errno 61] Connection refused',), ('127.0.0.1', 389))])     process:37344   thread:4502900160
[INFO]  asctime:2020-02-26 14:08:44,680 module:ldap     message:Failed to authenticate user(guest) in LDAP      process:37344   thread:4502900160
.......................................................................................................................................................................................s...............................................s..............................................................................................................................................
----------------------------------------------------------------------
Ran 419 tests in 233.525s

OK (skipped=2)
Destroying test database for alias 'default'...
```