### PR TITLE
Fixed a bug that mandatory parameter was able to be updated with empty value by specifying '- NOT SET -' value

### DIFF
--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -2963,7 +2963,7 @@ class ViewTest(AironeViewTest):
 
             referral_key = []
             if attr_type & AttrTypeValue['named']:
-                referral_key = [{'data': 'foo', 'index': 0}]
+                referral_key = [{'data': '', 'index': 0}]
 
             # This checks error response would be returned by sending a request
             # to create entry by specifying 0('- NOT SET -') parameter that indicates

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -2933,6 +2933,57 @@ class ViewTest(AironeViewTest):
                 self.assertEqual(resp.status_code, 200)
                 self.assertEqual(Entry.objects.filter(schema=entity).count(), 1)
 
+    def test_set_mandatory_attrs_with_empty_referral(self):
+        """
+        This tests whether an entry could be created with empty referral value.
+        In this test case, this creates entities which have each different attribute
+        that refers entry. And this confirms whether an entry could be created with
+        empty value which is equivalent of '- NOT SET -'.
+        """
+
+        user = self.guest_login()
+
+        ref_entity = Entity.objects.create(name='ref', created_user=user)
+        for (index, attr_type) in enumerate([
+            AttrTypeValue['object'],
+            AttrTypeValue['named_object'],
+            AttrTypeValue['array_object'],
+            AttrTypeValue['array_named_object']]
+        ):
+
+            # create Entity and Entry which test to create
+            entity = Entity.objects.create(name='E%d' % index, created_user=user)
+            attr = EntityAttr.objects.create(name='attr',
+                                             type=attr_type,
+                                             created_user=user,
+                                             is_mandatory=True,
+                                             parent_entity=entity)
+            attr.referral.add(ref_entity)
+            entity.attrs.add(attr)
+
+            referral_key = []
+            if attr_type & AttrTypeValue['named']:
+                referral_key = [{'data': 'foo', 'index': 0}]
+
+            # This checks error response would be returned by sending a request
+            # to create entry by specifying 0('- NOT SET -') parameter that indicates
+            # there is no matched entry to the mandatroy attribute.
+            params = {
+                'entry_name': 'entry',
+                'attrs': [{
+                    'id': str(attr.id),
+                    'value': [{'data': '0', 'index': 0}],
+                    'referral_key': referral_key
+                }],
+            }
+            resp = self.client.post(reverse('entry:do_create', args=[entity.id]),
+                                    json.dumps(params),
+                                    'application/json')
+
+            self.assertEqual(resp.status_code, 400)
+            self.assertEqual(resp.content, b'You have to specify value at mandatory parameters')
+            self.assertEqual(Entry.objects.filter(schema=entity).count(), 0)
+
     def test_update_entry_without_backend(self):
         user = self.guest_login()
         entity = Entity.objects.create(name='entity', created_user=user)

--- a/entry/views.py
+++ b/entry/views.py
@@ -30,9 +30,14 @@ def _validate_input(recv_data, obj):
         return 'data' in value and value['data'] != '' and value['data'] is not None
 
     def _has_referral(value):
-        try:
-            return 'data' in value and value['data'].isnumeric() and int(value['data']) > 0
-        except ValueError:
+        if isinstance(value['data'], int):
+            return value['data'] > 0
+        elif isinstance(value['data'], str):
+            try:
+                return value['data'].isnumeric() and int(value['data']) > 0
+            except ValueError:
+                return False
+        else:
             return False
 
     for attr_data in recv_data['attrs']:

--- a/templates/edit_entry/js.html
+++ b/templates/edit_entry/js.html
@@ -76,8 +76,7 @@ var form_validator = function() {
   // check mandatory attrs of referral entry
   $('.attr_referral[mandatory]').each(function() {
     // check referral_key text is written
-    $(this).find('input[class*="referral_key"]').each(function() {
-      console.info($(this).val());
+    $(this).find('input.referral_key').each(function() {
       if(! $(this).val()) {
         $(this).closest('td').addClass('table-danger');
         result = false;
@@ -85,7 +84,7 @@ var form_validator = function() {
     });
 
     // check referral entry is set
-    $(this).find('select[class*="attr_value"]').each(function() {
+    $(this).find('select.attr_value').each(function() {
       if(! $(this).val() || Number($(this).val()) == 0) {
         $(this).closest('td').addClass('table-danger');
         result = false;
@@ -94,7 +93,7 @@ var form_validator = function() {
   });
 
   // check mandatory attrs of text and date
-  $('[class*="attr_value"][mandatory]').each(function() {
+  $('.attr_value[mandatory]').each(function() {
     if(! $(this).val()) {
       $(this).closest('td').addClass('table-danger');
       result = false;
@@ -106,13 +105,13 @@ var form_validator = function() {
     var is_value_set = $(this).children().length > 0;
 
     // check referral_key text is written
-    $(this).find('input[class*="referral_key"],input[class*="attr_value"]').each(function() {
+    $(this).find('input.referral_key,input.attr_value').each(function() {
       if(! $(this).val()) {
         is_value_set = false;
       }
     });
     // check referral entry is set
-    $(this).find('select[class*="attr_value"]').each(function() {
+    $(this).find('select.attr_value').each(function() {
       if(! $(this).val() || Number($(this).val()) == 0) {
         is_value_set = false;
       }

--- a/templates/edit_entry/js.html
+++ b/templates/edit_entry/js.html
@@ -75,70 +75,52 @@ var form_validator = function() {
 
   // check mandatory attrs of referral entry
   $('.attr_referral[mandatory]').each(function() {
-    var all_empty = true;
-    $(this).find('input[class*="referral_key"],select[class*="attr_value"]').each(function() {
-      if($(this).val()) {
-        all_empty = false;
+    // check referral_key text is written
+    $(this).find('input[class*="referral_key"]').each(function() {
+      console.info($(this).val());
+      if(! $(this).val()) {
+        $(this).closest('td').addClass('table-danger');
+        result = false;
       }
     });
-    if(all_empty) {
-      $(this).parent().addClass('table-danger');
-      result = false;
-    } else {
-      $(this).parent().removeClass('table-danger');
-    }
+
+    // check referral entry is set
+    $(this).find('select[class*="attr_value"]').each(function() {
+      if(! $(this).val() || Number($(this).val()) == 0) {
+        $(this).closest('td').addClass('table-danger');
+        result = false;
+      }
+    });
   });
 
-  // check mandatory attrs of text-input
-  $('input[type="text"][class*="attr_value"][mandatory]').each(function() {
+  // check mandatory attrs of text and date
+  $('[class*="attr_value"][mandatory]').each(function() {
     if(! $(this).val()) {
-      $(this).parent().addClass('table-danger');
-      result = false;
-    }
-  });
-
-  // check mandatory attrs of select
-  $('select[class*="attr_value"][mandatory]').each(function() {
-    if(! $(this).val()) {
-      $(this).parent().addClass('table-danger');
-      result = false;
-    }
-  });
-
-  // check mandatory attrs of textarea
-  $('textarea[class*="attr_value"][mandatory]').each(function() {
-    if(! $(this).val()) {
-      $(this).parent().addClass('table-danger');
-      result = false;
-    }
-  });
-
-  // check mandatory attrs of date
-  $('input[type="date"][class*="attr_value"][mandatory]').each(function() {
-    if(! $(this).val()) {
-      $(this).parent().addClass('table-danger');
+      $(this).closest('td').addClass('table-danger');
       result = false;
     }
   });
 
   // check mandatory attrs of array
   $('.array_element[mandatory]').each(function() {
-    if(! $(this).children().length) {
-      $(this).parent().parent().addClass('table-danger');
-      result = false;
-    }
+    var is_value_set = $(this).children().length > 0;
 
-    var all_empty = true;
-    $(this).find('input[class*="attr_value"],input[class*="referral_key"],select[class*="attr_value"]').each(function() {
-      if($(this).val()) {
-        all_empty = false;
+    // check referral_key text is written
+    $(this).find('input[class*="referral_key"],input[class*="attr_value"]').each(function() {
+      if(! $(this).val()) {
+        is_value_set = false;
       }
     });
-    if(all_empty) {
-      $(this).parent().parent().addClass('table-danger');
+    // check referral entry is set
+    $(this).find('select[class*="attr_value"]').each(function() {
+      if(! $(this).val() || Number($(this).val()) == 0) {
+        is_value_set = false;
+      }
+    });
+
+    if(! is_value_set) {
+      $(this).closest('td').addClass('table-danger');
       result = false;
-    } else {
-      $(this).parent().parent().removeClass('table-danger');
     }
   });
 
@@ -264,6 +246,9 @@ var narrow_down_handler = {
     if(elem_select.attr('unfetched_value')) {
       do_update_option(elem_select, $(this).attr('attr_id'), '');
     }
+
+    // clear warning which is shown before
+    $(this).closest('td').removeClass('table-danger');
   }
 }
 
@@ -288,10 +273,6 @@ var clear_table_danger_handler = function() {
 
 var select_value_handler = {
   'change': update_selected_item,
-  'keydown': function() {
-    // clear danger notification if it's set
-    $(this).parent().removeClass('table-danger');
-  },
   'focus': function() {
     if($(this).attr('unfetched_value')) {
       do_update_option($(this), $(this).attr('attr_id'), '');
@@ -332,7 +313,7 @@ $('button[name=add_attr]').on('click', function() {
   new_column.find(".referral_key").attr('index', current_index);
 
   // clear warning label which is set before
-  new_column.find('[class*="attr_value"]').on('click', clear_table_danger_handler);
+  new_column.find(".attr_value,.referral_key").on('click', clear_table_danger_handler);
 
   container.prepend(new_column);
 
@@ -421,7 +402,7 @@ $(document).ready(function() {
   });
 
   // clear warning label which is set before
-  $('[class*="attr_value"]').on('click', clear_table_danger_handler);
+  $('.attr_value,.referral_key').on('click', clear_table_danger_handler);
 });
 
 $(window).scroll(function(){


### PR DESCRIPTION
## Abstract
This is for #18. Previous PR #19 left a bug that a mandatory parameter value can be clear by specifying `- NOT SET -` parameter.

## Change Points

* Fixed Javascript code at create/update entry not to send a request when `- NOT SET -` value is specified at mandatory attribute which types `entry`.
* Fixed Django code at input validation check to return HTTP 400 when `- NOT SET -` value is specified at mandatory attribute which types `entry`.

## Operation Verification
I confirmed followings.

* When I try to update an entry with specifying `- NOT SET -` value at `entry` typed attribute, then I can't do it and an error is revealed.

<img width="1011" alt="スクリーンショット 2020-03-10 16 25 59" src="https://user-images.githubusercontent.com/469934/76298562-fdf20a00-62fc-11ea-9157-7103e2c472ed.png">
