### PR TITLE
implement an API that returns update history of entry's attribute values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.1.0
 
 ### Added
+* Added an API endpoint that returns change history of specific entry's attribute.
 * Added a feature to be able to confirm job of deleting entry from Job list view (#10)
 
 ## v2.0.1

--- a/api_v1/entry/urls.py
+++ b/api_v1/entry/urls.py
@@ -5,4 +5,5 @@ from . import views
 urlpatterns = [
     url(r'^search$', views.EntrySearchAPI.as_view()),
     url(r'^referral$', views.EntryReferredAPI.as_view()),
+    url(r'^update_history$', views.UpdateHistory.as_view()),
 ]

--- a/api_v1/entry/views.py
+++ b/api_v1/entry/views.py
@@ -1,5 +1,9 @@
+import pytz
+
 from api_v1.auth import AironeTokenAuth
 from airone.lib.profile import airone_profile
+from django.conf import settings
+from django.db.models import Q
 
 from rest_framework import status
 from rest_framework.response import Response
@@ -10,6 +14,9 @@ from rest_framework.authentication import SessionAuthentication
 from entity.models import Entity
 from entry.models import Entry
 from entry.settings import CONFIG as CONFIG_ENTRY
+
+from datetime import datetime
+
 from user.models import User
 
 
@@ -83,3 +90,90 @@ class EntryReferredAPI(APIView):
             })
 
         return Response({'result': ret_data}, content_type='application/json; charset=UTF-8')
+
+
+class UpdateHistory(APIView):
+    authentication_classes = (AironeTokenAuth, BasicAuthentication, SessionAuthentication,)
+
+    @airone_profile
+    def get(self, request):
+        # validate whether mandatory parameters are specified
+        p_attr = request.GET.get('attribute')
+        if not p_attr:
+            return Response("'attribute' parameter is required",
+                            status=status.HTTP_400_BAD_REQUEST)
+
+        # both entry and entry_id parameters accept str and connma separated array
+        p_entry = request.GET.get('entry', '')
+        p_entry_id = request.GET.get('entry_id', '')
+        if not (p_entry or p_entry_id):
+            return Response("Either 'entries' or 'entry_ids' parameter is required",
+                            status=status.HTTP_400_BAD_REQUEST)
+
+        # Set variables that describe timerange to filter the result of AttributeValue with them.
+        older_than = datetime.now(pytz.timezone(settings.TIME_ZONE))
+        p_older_than = request.GET.get('older_than')
+        if p_older_than:
+            try:
+                older_than = (datetime
+                              .strptime(p_older_than, CONFIG_ENTRY.TIME_FORMAT)
+                              .replace(tzinfo=pytz.timezone(settings.TIME_ZONE)))
+            except ValueError:
+                return Response((
+                    "The older_than parameter accepts for following format "
+                    "'YYYY-MM-DDTHH:MM:SS'"), status=status.HTTP_400_BAD_REQUEST)
+
+        # The initial datetime(1900/01/01 00:00:00) represents good enough past time to compare
+        # with the created time of AttributeValue. We could handle minimum time by using
+        # 'datetime.MIN', but some library and service couldn't deal with this time.
+        # (c.f. https://dev.mysql.com/doc/refman/5.7/en/datetime.html)
+        newer_than = datetime(1900, 1, 1, tzinfo=pytz.timezone(settings.TIME_ZONE))
+        p_newer_than = request.GET.get('newer_than')
+        if p_newer_than:
+            try:
+                newer_than = (datetime
+                              .strptime(p_newer_than, CONFIG_ENTRY.TIME_FORMAT)
+                              .replace(tzinfo=pytz.timezone(settings.TIME_ZONE)))
+            except ValueError:
+                return Response((
+                    "The newer_than parameter accepts for following format "
+                    "'YYYY-MM-DDTHH:MM:SS'"), status=status.HTTP_400_BAD_REQUEST)
+
+        # get target entries to get update history
+        q_base = Q(is_active=True)
+        p_entity = request.GET.get('entity')
+        if p_entity:
+            q_base &= Q(schema__name=p_entity)
+
+        target_entries = Entry.objects.filter(q_base, (
+            Q(name__in=p_entry.split(',')) | Q(id__in=[int(x) for x in p_entry_id.split(',') if x])
+        ))
+        if not target_entries.exists():
+            return Response('There is no entry with which matches specified parameters',
+                            status=status.HTTP_400_BAD_REQUEST)
+
+        results = []
+        for entry in target_entries:
+            attr = entry.attrs.filter(schema__name=p_attr, is_active=True).first()
+            if not attr:
+                return Response('There is no attribute(%s) in entry(%s)' % (p_attr, entry.name),
+                                status=status.HTTP_400_BAD_REQUEST)
+
+            result = {
+                'entity': {'id': entry.schema.id, 'name': entry.schema.name},
+                'entry': {'id': entry.id, 'name': entry.name},
+                'attribute': {'id': attr.id, 'name': attr.schema.name, 'history': []},
+            }
+            for attrv in (attr.values
+                          .filter(created_time__gt=newer_than, created_time__lt=older_than)
+                          .order_by('-created_time')[:CONFIG_ENTRY.MAX_HISTORY_COUNT]):
+                result['attribute']['history'].append({
+                    'value': attrv.get_value(with_metainfo=True)['value'],
+                    'updated_at': attrv.created_time,
+                    'updated_username': attrv.created_user.username,
+                    'updated_userid': attrv.created_user.id,
+                })
+
+            results.append(result)
+
+        return Response(results)

--- a/api_v1/tests/entry/test_update_history.py
+++ b/api_v1/tests/entry/test_update_history.py
@@ -1,0 +1,303 @@
+import pytz
+
+from django.conf import settings
+
+from airone.lib.test import AironeViewTest
+from airone.lib.types import AttrTypeValue
+from datetime import date, datetime, timedelta
+from entity.models import Entity, EntityAttr
+from entry.models import Entry
+from entry.settings import CONFIG as CONFIG_ENTRY
+from group.models import Group
+
+
+class APITest(AironeViewTest):
+    def setUp(self):
+        super(APITest, self).setUp()
+
+        self.user = self.guest_login()
+        self.group = Group.objects.create(name='group')
+
+        ref_entity = Entity.objects.create(name='Referred Entity', created_user=self.user)
+        ref_entry = Entry.objects.create(name='referred_entry', schema=ref_entity,
+                                         created_user=self.user)
+
+        self.entity = Entity.objects.create(name='entity', created_user=self.user)
+        self.test_attrs = {
+            'str': {
+                'type': AttrTypeValue['string'],
+                # These values will be saved as each different AttributeValue for checking
+                # result order of update history API response.
+                'set_values': ['1', '2', '3'],
+                'ret_values': ['3', '2', '1'],
+            },
+            'obj': {
+                'type': AttrTypeValue['object'],
+                'set_values': [ref_entry],
+                'ret_values': [{'id': ref_entry.id, 'name': ref_entry.name}],
+            },
+            'map': {
+                'type': AttrTypeValue['named_object'],
+                'set_values': [{'name': 'hoge', 'id': ref_entry}],
+                'ret_values': [{'hoge': {'id': ref_entry.id, 'name': ref_entry.name}}],
+            },
+            'arr_str': {
+                'type': AttrTypeValue['array_string'],
+                'set_values': [['foo', 'bar']],
+                'ret_values': [['foo', 'bar'], []],
+            },
+            'arr_obj': {
+                'type': AttrTypeValue['array_object'],
+                'set_values': [[ref_entry]],
+                'ret_values': [[{'id': ref_entry.id, 'name': ref_entry.name}], []],
+            },
+            'arr_map': {
+                'type': AttrTypeValue['array_named_object'],
+                'set_values': [[{'name': 'foo', 'id': ref_entry}]],
+                'ret_values': [[{'foo': {'id': ref_entry.id, 'name': ref_entry.name}}], []],
+            },
+            'group': {
+                'type': AttrTypeValue['group'],
+                'set_values': [str(self.group.id)],
+                'ret_values': [{'id': self.group.id, 'name': self.group.name}],
+            },
+            'bool': {
+                'type': AttrTypeValue['boolean'],
+                'set_values': [True],
+                'ret_values': [True],
+            },
+            'text': {
+                'type': AttrTypeValue['text'],
+                'set_values': ['text'],
+                'ret_values': ['text'],
+            },
+            'date': {
+                'type': AttrTypeValue['date'],
+                'set_values': [date(2020, 1, 1)],
+                'ret_values': ['2020-01-01'],
+            }
+        }
+
+        # register all attributes which are declared as test_attrs
+        for (name, info) in self.test_attrs.items():
+            attr = EntityAttr.objects.create(name=name,
+                                             type=info['type'],
+                                             created_user=self.user,
+                                             parent_entity=self.entity)
+
+            if info['type'] & AttrTypeValue['object']:
+                attr.referral.add(ref_entity)
+
+            self.entity.attrs.add(attr)
+
+    def test_with_fully_set_value(self):
+        # create test entry and set each values
+        entry = Entry.objects.create(name='entry', schema=self.entity, created_user=self.user)
+        entry.complement_attrs(self.user)
+
+        for (name, info) in self.test_attrs.items():
+            # set values for each attributes
+            attr = entry.attrs.get(schema__name=name)
+            for value in info['set_values']:
+                attr.add_value(self.user, value)
+
+            resp = self.client.get('/api/v1/entry/update_history', {
+                'attribute': name,
+                'entry': entry.name,
+            })
+
+            self.assertEqual(resp.status_code, 200)
+            retdata = resp.json()
+
+            # check resp data has expected parameters
+            self.assertEqual(len(retdata), 1)
+            self.assertEqual(retdata[0]['entity'], {'id': self.entity.id, 'name': self.entity.name})
+            self.assertEqual(retdata[0]['entry'], {'id': entry.id, 'name': entry.name})
+            self.assertEqual(retdata[0]['attribute']['id'], attr.id)
+            self.assertEqual(retdata[0]['attribute']['name'], attr.name)
+
+            # check values has expected parameters
+            attr_history = retdata[0]['attribute']['history']
+
+            # This confirms each types result has expected values
+            self.assertEqual([x['value'] for x in attr_history], info['ret_values'])
+
+            # This confirms each value results has following metadata
+            metadatas = ['updated_at', 'updated_username', 'updated_userid']
+            self.assertTrue(all([(k in x for k in metadatas) for x in attr_history]))
+
+            # Check result of specifying 'entry-id' would be same with the one of specyfing 'entry'
+            resp_alter = self.client.get('/api/v1/entry/update_history', {
+                'attribute': name,
+                'entry_id': entry.id,
+            })
+            self.assertEqual(retdata, resp_alter.json())
+
+    def test_without_set_value(self):
+        # create test entry and set each values
+        entry = Entry.objects.create(name='entry', schema=self.entity, created_user=self.user)
+        entry.complement_attrs(self.user)
+
+        for (name, info) in self.test_attrs.items():
+            resp = self.client.get('/api/v1/entry/update_history', {
+                'attribute': name,
+                'entry': entry.name,
+            })
+
+            self.assertEqual(resp.status_code, 200)
+            retdata = resp.json()
+
+            # check resp data has expected parameters
+            attr = entry.attrs.get(schema__name=name)
+            self.assertEqual(len(retdata), 1)
+            self.assertEqual(retdata[0]['entity'], {'id': self.entity.id, 'name': self.entity.name})
+            self.assertEqual(retdata[0]['entry'], {'id': entry.id, 'name': entry.name})
+            self.assertEqual(retdata[0]['attribute']['id'], attr.id)
+            self.assertEqual(retdata[0]['attribute']['name'], attr.name)
+
+            # check values has expected parameters
+            attr_history = retdata[0]['attribute']['history']
+            if info['type'] & AttrTypeValue['array']:
+                self.assertEqual(len(attr_history), 1)
+                self.assertEqual(attr_history[0]['value'], [])
+                self.assertEqual(attr_history[0]['updated_username'], self.user.username)
+                self.assertEqual(attr_history[0]['updated_userid'], self.user.id)
+            else:
+                self.assertEqual(attr_history, [])
+
+    def test_without_mandatory_params(self):
+        # call update_history API without attribute parameter
+        resp = self.client.get('/api/v1/entry/update_history')
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(str(resp.content, 'utf-8'), '"\'attribute\' parameter is required"')
+
+        # call update_history API without both entry and entryid parameters
+        resp = self.client.get('/api/v1/entry/update_history', {
+            'attribute': 'test-attribute'
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(str(resp.content, 'utf-8'),
+                         '"Either \'entries\' or \'entry_ids\' parameter is required"')
+
+    def test_with_invalid_params(self):
+        # create a test entry to use this test-suite
+        entry = Entry.objects.create(name='entry', schema=self.entity, created_user=self.user)
+        entry.complement_attrs(self.user)
+
+        # call API request with invalid entry
+        resp = self.client.get('/api/v1/entry/update_history', {
+            'attribute': 'test-attr',
+            'entry': 'invalid-entry-name',
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(str(resp.content, 'utf-8'),
+                         '"There is no entry with which matches specified parameters"')
+
+        # call API request with invalid attribute
+        resp = self.client.get('/api/v1/entry/update_history', {
+            'attribute': 'invalid-attribute',
+            'entry': entry.name,
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(str(resp.content, 'utf-8'),
+                         '"There is no attribute(invalid-attribute) in entry(entry)"')
+
+    def test_with_entity_params(self):
+        # create a test entry to use this test-suite
+        entry = Entry.objects.create(name='entry', schema=self.entity, created_user=self.user)
+        entry.complement_attrs(self.user)
+
+        # This creates another entity that has same name attribute with 'entity'
+        # which is created in setUp method. And this test will create same name entry with
+        # 'entry' which is created before.
+        another_entity = Entity.objects.create(name='AnotherEntity', created_user=self.user)
+        another_entity.attrs.add(EntityAttr.objects.create(**{
+            'name': 'str',
+            'type': AttrTypeValue['string'],
+            'created_user': self.user,
+            'parent_entity': another_entity,
+        }))
+        another_entry = Entry.objects.create(name='entry', schema=another_entity,
+                                             created_user=self.user)
+        another_entry.complement_attrs(self.user)
+
+        # call API request without entity parameter at first to check
+        # both entries' information would be returned.
+        resp = self.client.get('/api/v1/entry/update_history', {
+            'attribute': 'str',
+            'entry': 'entry',
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual([x['entity'] for x in resp.json()], [
+            {'id': self.entity.id, 'name': self.entity.name},
+            {'id': another_entity.id, 'name': another_entity.name},
+        ])
+
+        # call API request with entity parameter to check reuslt would be filterd
+        resp = self.client.get('/api/v1/entry/update_history', {
+            'entity': another_entity.name,
+            'attribute': 'str',
+            'entry': 'entry',
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual([x['entity'] for x in resp.json()], [
+            {'id': another_entity.id, 'name': another_entity.name},
+        ])
+
+    def test_maximum_number_of_history(self):
+        entry = Entry.objects.create(name='entry', schema=self.entity, created_user=self.user)
+        entry.complement_attrs(self.user)
+
+        # set attribute value which is overflowing number of CONFIG_ENTRY['MAX_HISTORY_COUNT']
+        attr = entry.attrs.get(schema__name='str')
+        for i in range(CONFIG_ENTRY.MAX_HISTORY_COUNT + 1):
+            attr.add_value(self.user, str(i))
+
+        resp = self.client.get('/api/v1/entry/update_history', {
+            'attribute': 'str',
+            'entry': entry.name,
+        })
+        self.assertEqual(resp.status_code, 200)
+        attr_history = resp.json()[0]['attribute']['history']
+
+        # check the number of returning attribute values are fewer than the number of its
+        # which is stored in database because it's over CONFIG_ENTRY.MAX_HISTORY_COUNT.
+        self.assertEqual(attr.values.count(), CONFIG_ENTRY.MAX_HISTORY_COUNT + 1)
+        self.assertEqual(len(attr_history), CONFIG_ENTRY.MAX_HISTORY_COUNT)
+
+    def test_narrow_down_time_range_to_get(self):
+        entry = Entry.objects.create(name='entry', schema=self.entity, created_user=self.user)
+        entry.complement_attrs(self.user)
+
+        attr = entry.attrs.get(schema__name='str')
+
+        attrvs = [attr.add_value(self.user, x) for x in ['initial value', 'second value']]
+
+        # This is test processing to pretend that both Values are set at different times.
+        reference_time = datetime.now().replace(tzinfo=pytz.timezone(settings.TIME_ZONE))
+        attrvs[0].created_time = reference_time - timedelta(seconds=5)
+        attrvs[1].created_time = reference_time + timedelta(seconds=5)
+        for attrv in attrvs:
+            attrv.save(update_fields=['created_time'])
+
+        # This tests that only former AttributeValue would be returned by setting older_than param
+        resp = self.client.get('/api/v1/entry/update_history', {
+            'attribute': 'str',
+            'entry': entry.name,
+            'older_than': reference_time.strftime(CONFIG_ENTRY.TIME_FORMAT),
+        })
+        self.assertEqual(resp.status_code, 200)
+        attr_history = resp.json()[0]['attribute']['history']
+        self.assertEqual(len(attr_history), 1)
+        self.assertEqual(attr_history[0]['value'], 'initial value')
+
+        # This tests that only latter AttributeValue would be returned by setting newer_than param
+        resp = self.client.get('/api/v1/entry/update_history', {
+            'attribute': 'str',
+            'entry': entry.name,
+            'newer_than': reference_time.strftime(CONFIG_ENTRY.TIME_FORMAT),
+        })
+        self.assertEqual(resp.status_code, 200)
+        attr_history = resp.json()[0]['attribute']['history']
+        self.assertEqual(len(attr_history), 1)
+        self.assertEqual(attr_history[0]['value'], 'second value')

--- a/entry/settings.py
+++ b/entry/settings.py
@@ -15,4 +15,5 @@ CONFIG = Settings({
     'ESCAPE_CHARACTERS': ['(', ')', '<', '"', '{', '[', '#', '~', '@', '+', '*', '.', '?'],
     'ESCAPE_CHARACTERS_REFERRALS_ENTRY': ['$', '(', '^', '|', '[', '+', '*', '.', '?'],
     'ESCAPE_CHARACTERS_ENTRY_LIST': ['$', '(', '^', '\\', '|', '[', '+', '*', '.', '?'],
+    'TIME_FORMAT': '%Y-%m-%dT%H:%M:%S',
 })


### PR DESCRIPTION
## Abstract
This implemented a new API (`[GET] /api/v1/entry/update_history`) that returns entry's update history.

## Execution Result

### case1 (basic usage)
This gets result of attribute history for `attr` by using this new API.
```
$ curl -X GET \
-H "Authorization: Token ${ACCESS_TOKEN}" \
"http://localhost:8080/api/v1/entry/update_history?entity=TestEntity&entry=test01&attribute=attr"
```
<img width="538" alt="スクリーンショット 2020-03-13 14 24 20" src="https://user-images.githubusercontent.com/469934/76592343-62e47480-6536-11ea-8f65-dd65e30803bf.png">

### case2 (advanced usage)
This gets result of attribute history for `attr` which were older than `2020/03/11 01:00:00` by using this new API.
```
$ curl -X GET \
-H "Authorization: Token ${ACCESS_TOKEN}" \
"http://localhost:8080/api/v1/entry/update_history?entity=TestEntity&entry=test01&attribute=attr&older_than=2020-03-11T01:00:00"
```
<img width="698" alt="スクリーンショット 2020-03-13 14 25 42" src="https://user-images.githubusercontent.com/469934/76592385-8d363200-6536-11ea-8fc6-c0f1b1e03fbf.png">
