### PR TITLE
This is a feature to get an AttributeValue in the specific Attribute of Entry with a small number of SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.2.0
+
+### Added
+* Added a method in Entry to get an AttributeValue from Entry object with a small number of SQL
+
 ## v2.1.0
 
 ### Added

--- a/entry/models.py
+++ b/entry/models.py
@@ -1375,3 +1375,15 @@ class Entry(ACLBase):
                 return False
 
         return True
+
+    def get_attrv(self, attr_name):
+        """This returns specified attribute's value without permission check. Because
+        this prioritizes performance (less frequency of sending query to Database) over
+        authorization safety.Don't to use this before permissoin check of specified attribute.
+        """
+        return AttributeValue.objects.filter(
+            is_latest=True,
+            parent_attr__name=attr_name,
+            parent_attr__is_active=True,
+            parent_attr__entry=self
+        ).first()


### PR DESCRIPTION
This is necessary especially for making a some custome view on the premise of fixing data structure. In this case, it's better to get attribute value without authorization check for the perspective of performance.

In usual, a latest AttributeValue in the specific Attribute of Entry would be got by following processing.
```
attr = entry.filter(condition_query).first()
if attr and user.has_permission(attr, ACLType.Readable):
  attrv = attr.get_latest_value()
```

But this small processing sends 5 SQL to Database as below.
https://gist.github.com/userlocalhost/16d89769a54e31537fbaa204aef48e33#file-case1_usual_way

The `get_attrv()` method which is added in this PR sends only 1 query at the expense of authorization check of Attribute.
```
attrv = entry.get_attrv(attrname)
```
https://gist.github.com/userlocalhost/16d89769a54e31537fbaa204aef48e33#file-case2_using_get_attrv