### PR TITLE
Added processing to re-register elasticsearch data for entries that refer to an entry which name is changed

### DIFF
--- a/api_v1/job/views.py
+++ b/api_v1/job/views.py
@@ -45,12 +45,12 @@ class JobAPI(APIView):
             }
         }
 
-        query = {
-            'user': user,
-            'created_at__gte': time_threashold,
-        }
+        query = Q(
+            Q(user=user, created_at__gte=time_threashold),
+            ~Q(operation__in=Job.HIDDEN_OPERATIONS)
+        )
         jobs = [
-            x.to_json() for x in Job.objects.filter(**query).order_by('-created_at')
+            x.to_json() for x in Job.objects.filter(query).order_by('-created_at')
             [:JOB_CONFIG.MAX_LIST_NAV]]
 
         return Response({

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -403,6 +403,7 @@ def export_entries(self, job_id):
     if not job.is_canceled():
         job.update(Job.STATUS['DONE'])
 
+
 @app.task(bind=True)
 def register_referrals(self, job_id):
     job = Job.objects.get(id=job_id)

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -2968,6 +2968,7 @@ class ModelTest(AironeTestCase):
         entry.attrs.get(schema__name='attr-deleted').delete()
 
         # tests of get_attrv method
-        self.assertEqual(entry.get_attrv('attr'), entry.attrs.first().get_latest_value())
+        self.assertEqual(entry.get_attrv('attr'),
+                         entry.attrs.get(schema__name='attr').get_latest_value())
         self.assertIsNone(entry.get_attrv('attr-deleted'))
         self.assertIsNone(entry.get_attrv('invalid-attribute-name'))

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -611,14 +611,18 @@ class ViewTest(AironeViewTest):
 
         # checks job was created
         job = Job.objects.filter(user=user)
-        self.assertEqual(job.count(), 1)
+        self.assertEqual(job.count(), 2)
 
         # checks each parameters of the job are as expected
-        obj = job.first()
-        self.assertEqual(obj.target.id, entry.id)
-        self.assertEqual(obj.target_type, Job.TARGET_ENTRY)
-        self.assertEqual(obj.status, Job.STATUS['DONE'])
-        self.assertEqual(obj.operation, JobOperation.EDIT_ENTRY.value)
+        job_expectations = [
+            {'operation': JobOperation.EDIT_ENTRY, 'status': Job.STATUS['DONE']},
+            {'operation': JobOperation.REGISTER_REFERRALS, 'status': Job.STATUS['PREPARING']},
+        ]
+        for expectation in job_expectations:
+            obj = job.get(operation=expectation['operation'].value)
+            self.assertEqual(obj.target.id, entry.id)
+            self.assertEqual(obj.target_type, Job.TARGET_ENTRY)
+            self.assertEqual(obj.status, expectation['status'])
 
         # checks specify part of attribute parameter then set AttributeValue
         # which is only specified one

--- a/job/views.py
+++ b/job/views.py
@@ -40,7 +40,9 @@ def index(request):
             'passed_time': (
                 x.updated_at - x.created_at
             ).seconds if x.is_finished() else (datetime.now(timezone.utc) - x.created_at).seconds,
-        } for x in Job.objects.filter(user=user).order_by('-created_at')[:limitation]
+        } for x in Job.objects.filter(user=user) \
+                .exclude(operation__in=Job.HIDDEN_OPERATIONS) \
+                .order_by('-created_at')[:limitation]
             if (x.operation in export_operations or
                 (x.operation not in export_operations and x.target and x.target.is_active) or
                 (x.operation is JobOperation.DELETE_ENTRY.value and x.target))]


### PR DESCRIPTION
This fixes a bug that search result is different from Database's one when the entry's name which is referred from search result entry attribute is changed.

These are changes in this PR.

  - [x] Added processing to update elasticsearch data for entries which refer to updated one
  - [x] Added a test to check search result entry name is same with updated one
  - [x] Added a test of new operation's Job (REGISTER_REFERRALS)
  - [x] Fixed API `[get] /api/v1/job` not to show hidden job
  - [x] Added a test for above fix