### PR TITLE
This fixes a problem of ACL inheritance

### DIFF
--- a/api_v1/tests/test_api.py
+++ b/api_v1/tests/test_api.py
@@ -834,5 +834,9 @@ class APITest(AironeViewTest):
         entry = Entry.objects.get(id=resp.json()['result'])
         attr = entry.attrs.first()
 
+        # Check whether only permitted users and groups has authorization
         self.assertTrue(all([u.has_permission(entry, ACLType.Full) for u in users.values()]))
         self.assertTrue(all([u.has_permission(attr, ACLType.Full) for u in users.values()]))
+        self.assertFalse(any([u.has_permission(attr, ACLType.Full) for u
+                              in User.objects.filter(is_active=True, is_superuser=False)
+                              if u.username not in ['_u1', '_u2']]))

--- a/entry/models.py
+++ b/entry/models.py
@@ -863,11 +863,11 @@ class Entry(ACLBase):
     def clear_cache(self, cache_key):
         cache.delete("%s_%s" % (self.id, cache_key))
 
-    def add_attribute_from_base(self, base, user):
+    def add_attribute_from_base(self, base, request_user):
         if not isinstance(base, EntityAttr):
             raise TypeError('Variable "base" is incorrect type')
 
-        if not isinstance(user, User):
+        if not isinstance(request_user, User):
             raise TypeError('Variable "user" is incorrect type')
 
         # While an Attribute object which corresponding to base EntityAttr has been already
@@ -890,21 +890,20 @@ class Entry(ACLBase):
 
         attr = Attribute.objects.create(name=base.name,
                                         schema=base,
-                                        created_user=user,
+                                        created_user=request_user,
                                         parent_entry=self,
                                         is_public=base.is_public,
                                         default_permission=base.default_permission)
 
-        # inherites permissions of base object for user
-        [[user.permissions.add(getattr(attr, acltype.name))
-            for acltype in ACLType.availables() if permission.name == acltype.name]
+        # inherits permissions of base object for user
+        [[user.permissions.add(getattr(attr, permission.name))
             for permission in user.get_acls(base)]
+            for user in User.objects.filter(is_active=True)]
 
-        # inherites permissions of base object for each groups
-        [[[group.permissions.add(getattr(attr, acltype.name))
-            for acltype in ACLType.availables() if permission.name == acltype.name]
+        # inherits permissions of base object for each groups
+        [[group.permissions.add(getattr(attr, permission.name))
             for permission in group.get_acls(base)]
-            for group in user.groups.all()]
+            for group in Group.objects.all()]
 
         self.attrs.add(attr)
 

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -1,6 +1,3 @@
-from unittest.mock import patch
-from unittest.mock import Mock
-
 from group.models import Group
 from datetime import date
 from django.core.cache import cache
@@ -8,7 +5,6 @@ from django.conf import settings
 from entity.models import Entity, EntityAttr
 from entry.models import Entry, Attribute, AttributeValue
 from entry.settings import CONFIG
-from entry import tasks
 from user.models import User
 from airone.lib.acl import ACLObjType, ACLType
 from airone.lib.types import AttrTypeStr, AttrTypeObj, AttrTypeArrStr, AttrTypeArrObj

--- a/group/models.py
+++ b/group/models.py
@@ -18,4 +18,4 @@ class Group(DjangoGroup):
 
     def has_permission(self, target_obj, permission_level):
         return any([permission_level.id <= x.get_aclid() for x
-            in self.permissions.all() if target_obj.id == x.get_objid()])
+                    in self.permissions.all() if target_obj.id == x.get_objid()])

--- a/group/models.py
+++ b/group/models.py
@@ -15,3 +15,7 @@ class Group(DjangoGroup):
         self.is_active = False
         self.name = "%s_deleted_%s" % (self.name, datetime.now().strftime("%Y%m%d_%H%M%S"))
         self.save()
+
+    def has_permission(self, target_obj, permission_level):
+        return any([permission_level.id <= x.get_aclid() for x
+            in self.permissions.all() if target_obj.id == x.get_objid()])


### PR DESCRIPTION
The root cause is permissions of individual users and groups were not inherited when a new Attribute is created from EntityAttr. Previous implementation only inherit permissions of operation user and groups that user is belonged to. This commit fixes this problem by inherit permissions of all users and groups (and also refactored some inefficient implementation).
(c.f. #28)