### PR TITLE
Updated CHANGELOG for adding new AttributeType 'array_group'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.3.0
+
+### Added
+* Added new AttributeType `array group` that could contain multiple Group referral in an Attribute value
+
 ## v2.2.0
 
 ### Added


### PR DESCRIPTION
This adds description of change which is added by #36 after v2.2.0.