### PR TITLE
Fixed a problem that date value won't be shown at advanced search result

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Here is the documentation to setup the development environment of AirOne.
 ## Installation of AirOne
 You have to install Python3.5+ to run AirOne like below (for the case of `ubuntu`).
 ```
-user@hostname:~$ $ sudo apt-get install python3 python3-pip virtualenv
+user@hostname:~$ sudo apt-get install python3 python3-pip virtualenv
 ```
 
 And you have to install RabbitMQ for executing heavy processing as background task using [Celery](http://docs.celeryproject.org/) and Memcached for caching backend.
 ```
-user@hostname:~$ $ sudo apt-get install rabbitmq-server memcached mysql-server python-dev libmysqlclient-dev
+user@hostname:~$ sudo apt-get install rabbitmq-server memcached mysql-server python-dev libmysqlclient-dev
 ```
 
 Then, you can install libraries on which AieOne depends by following after cloning this repository. But we recommand you to setup airone on the separated environment using virtualenv not to pollute system-wide python environment.
@@ -109,14 +109,14 @@ user@hostname:~$ sudo apt-get install -y oracle-java13-installer
 
 The way to install elasticsearch is quite easy like that.
 ```
-user@hostname:~$ wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.8.6.tar.gz
-user@hostname:~$ tar -xvf elasticsearch-6.8.6.tar.gz
+user@hostname:~$ wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.8.12.tar.gz
+user@hostname:~$ tar -xvf elasticsearch-6.8.12.tar.gz
 ```
 
 After installing it, you have to change configuration to accept connecting from AirOne nodes.
 ```diff
---- elasticsearch-6.8.6/config/elasticsearch.yml.old        2020-01-29 10:19:40.511687943 +0900
-+++ elasticsearch-6.8.6/config/elasticsearch.yml            2020-01-29 10:41:23.103687943 +0900
+--- elasticsearch-6.8.12/config/elasticsearch.yml.old        2020-01-29 10:19:40.511687943 +0900
++++ elasticsearch-6.8.12/config/elasticsearch.yml            2020-01-29 10:41:23.103687943 +0900
 @@ -52,7 +52,7 @@
  #
  # Set the bind address to a specific IP (IPv4 or IPv6):
@@ -135,7 +135,7 @@ user@hostname:~$ sudo sysctl vm.max_map_count=262144
 
 Finally, you can run ElasticSearch service like that.
 ```
-user@hostname:~$ elasticsearch-6.8.6/bin/elasticsearch
+user@hostname:~$ elasticsearch-6.8.12/bin/elasticsearch
 ```
 
 ## Run Nginx (Optional)

--- a/templates/advanced_search/result.html
+++ b/templates/advanced_search/result.html
@@ -69,8 +69,8 @@
           {% elif attr.type == attr_type.boolean %}
             <td>{{ attr.value }}</td>
 
-            {% elif attr.type == attr_type.date %}
-              <td>{{ attr.value|date:"Y-m-d" }}</td>
+          {% elif attr.type == attr_type.date %}
+            <td>{{ attr.value }}</td>
 
           {% elif attr.type == attr_type.entry %}
             <td><a href='/entry/show/{{ attr.value.id }}'>{{ attr.value.name }}</a></td>


### PR DESCRIPTION
Close: https://github.com/dmm-com/airone/issues/40

This fixes the problem that a value which is registered in a date typed
attribute won't be shown at the result page of advanced search. That was
because the "make_search_results" method that retrieves data which is
registered in an elasticsearch returns string typed value for date
typed one. But template expects this value will be date type.

This removes "date" filter to align with the type which is returned by
'make_search_results". And declares elasticsearch version that we
confirmed to work well (and trivial errors) in the README.

## Verification Results
I confirmed registered `date` typed value at an Entry will be shown at the result of advanced search as below.
<img width="980" alt="スクリーンショット 2020-10-08 15 54 57" src="https://user-images.githubusercontent.com/469934/95425190-ddfff300-097e-11eb-9141-ac3e6051330a.png">
<img width="603" alt="スクリーンショット 2020-10-08 15 55 05" src="https://user-images.githubusercontent.com/469934/95425199-e0fae380-097e-11eb-8be5-bcc1fb99622b.png">