### PR TITLE
Added description to CHANGELOG for fixing UI bugfix about date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.3.1
+
+### Fixed
+* Fixed a problem that date value won't be shown at advanced search result
+
 ## v2.3.0
 
 ### Added


### PR DESCRIPTION
A problem that date value won't be shown at advanced search result was
fixed in the past (see also: #41). But this is not described in the CHANGELOG.
This  commit wrote it.