### PR TITLE
Change implementation about editing Entity to disable to edit type of EntityAttr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.4.0
+
+### Changed
+* Change implementation about editing Entity to disable to edit type of EntityAttr
+
 ## v2.3.1
 
 ### Fixed

--- a/dashboard/tests/test_import.py
+++ b/dashboard/tests/test_import.py
@@ -90,9 +90,9 @@ class ImportTest(AironeViewTest):
         # checks that warning messagees were outputted
         self.assertEqual(len(warning_messages), 3)
         self.assertTrue(re.match(r"^.*Entity.*Mandatory key doesn't exist$",
-                                 warning_messages[0]))
-        self.assertTrue(re.match(r"^.*EntityAttr.*Mandatory key doesn't exist$",
-                                 warning_messages[1]))
+                                 str(warning_messages[0])))
+        self.assertEqual("The parameter 'type' is mandatory when a new EntityAtter create",
+                         str(warning_messages[1]))
         self.assertEqual(str(warning_messages[2]), "refer to invalid entity object")
 
         self.assertEqual(Entity.objects.count(), 2)

--- a/entity/admin.py
+++ b/entity/admin.py
@@ -43,7 +43,7 @@ class EntityAttrResource(AironeModelResource):
     _IMPORT_INFO = {
         'header':               ['id', 'name', 'type', 'refer', 'entity',
                                  'created_user', 'is_mandatory'],
-        'mandatory_keys':       ['name', 'type', 'entity', 'created_user'],
+        'mandatory_keys':       ['name', 'entity', 'created_user'],
         'resource_module':      'entity.admin',
         'resource_model_name':  'EntityAttrResource',
     }
@@ -78,5 +78,13 @@ class EntityAttrResource(AironeModelResource):
 
         if data['refer'] and not Entity.objects.filter(name=data['refer']).exists():
             raise RuntimeError('refer to invalid entity object')
+
+        # The processing fails when 'type' parameter is not existed for creating a new instance
+        if not instance.pk and not data['type']:
+            raise RuntimeError("The parameter 'type' is mandatory when a new EntityAtter create")
+
+        # Do not allow to change type when instance is already created
+        if instance.pk:
+            data['type'] = instance.type
 
         super(EntityAttrResource, self).import_obj(instance, data, dry_run)

--- a/entity/models.py
+++ b/entity/models.py
@@ -24,10 +24,9 @@ class EntityAttr(ACLBase):
         super(ACLBase, self).__init__(*args, **kwargs)
         self.objtype = ACLObjType.EntityAttr
 
-    def is_updated(self, name, type, is_mandatory, is_delete_in_chain, index, refs):
+    def is_updated(self, name, is_mandatory, is_delete_in_chain, index, refs):
         # checks each parameters that are different between current object parameters
         if (self.name != name or
-                self.type != int(type) or
                 self.is_mandatory != is_mandatory or
                 self.is_delete_in_chain != is_delete_in_chain or
                 self.index != int(index) or

--- a/entity/tests/test_complex_view.py
+++ b/entity/tests/test_complex_view.py
@@ -355,9 +355,7 @@ class ComplexViewTest(AironeViewTest):
                                 json.dumps(params),
                                 'application/json')
 
+        # These check that request was succeeded, but attr type and values
+        # which are registered at that Attribute  would not be changed.
         self.assertEqual(resp.status_code, 200)
-
-        # checks that the cache will be updated after updating attr_type
-        ref_entries = ref_entry.get_referred_objects()
-        self.assertEqual(list(ref_entries), [])
-        self.assertEqual(ref_entries.count(), 0)
+        self.assertEqual(list(ref_entry.get_referred_objects()), [entry])

--- a/entity/tests/test_model.py
+++ b/entity/tests/test_model.py
@@ -145,7 +145,6 @@ class ModelTest(TestCase):
         # initialize params which is same with the EntityAttr `attr`
         params = {
             'name': attr.name,
-            'type': attr.type,
             'refs': [entity.id],
             'index': attr.index,
             'is_mandatory': attr.is_mandatory,
@@ -158,11 +157,6 @@ class ModelTest(TestCase):
         # check to change name parameter
         changed_params = copy(params)
         changed_params['name'] = 'name (changed)'
-        self.assertTrue(attr.is_updated(**changed_params))
-
-        # check to change type parameter
-        changed_params = copy(params)
-        changed_params['type'] = AttrTypeValue['string']
         self.assertTrue(attr.is_updated(**changed_params))
 
         # check to change referrals parameter

--- a/entity/tests/test_model.py
+++ b/entity/tests/test_model.py
@@ -1,11 +1,12 @@
 from airone.lib.types import AttrTypeValue
 from copy import copy
 
+from airone.lib.test import DisableStderr
 from django.test import TestCase
 from user.models import User
 from entity.models import Entity
 from entity.models import EntityAttr
-from entity.admin import EntityResource
+from entity.admin import EntityResource, EntityAttrResource
 
 
 class ModelTest(TestCase):
@@ -117,8 +118,7 @@ class ModelTest(TestCase):
 
     def test_import_without_permission_parameter(self):
         user = User.objects.create(username='another_user')
-
-        entity = Entity(name='origin_name', created_user=user, is_public=False)
+        entity = Entity.objects.create(name='origin_name', created_user=user, is_public=False)
         entity.save()
 
         EntityResource.import_data_from_request({
@@ -130,6 +130,94 @@ class ModelTest(TestCase):
 
         self.assertEqual(Entity.objects.count(), 1)
         self.assertEqual(Entity.objects.last().name, 'origin_name')
+
+    def test_import_entity_attr_with_changing_type(self):
+        """
+        This checks the attribute type wouldn't be changed by specifying type.
+        """
+        user = self._test_user
+        entity = Entity.objects.create(name='Entity', created_user=user, is_public=False)
+        entity_attr = EntityAttr.objects.create(**{
+            'name': 'attr',
+            'type': AttrTypeValue['string'],
+            'created_user': user,
+            'parent_entity': entity,
+        })
+        entity.attrs.add(entity_attr)
+
+        EntityAttrResource.import_data_from_request({
+            'id': entity_attr.id,
+            'name': 'changed-attr',
+            'type': AttrTypeValue['array_string'],
+            'entity': entity.name,
+            'created_user': user.username
+        }, user)
+
+        entity_attr.refresh_from_db()
+        self.assertEqual(entity_attr.name, 'changed-attr')
+        self.assertEqual(entity_attr.type, AttrTypeValue['string'])
+
+    def test_import_entity_attr_without_specifying_type(self):
+        """
+        This import EntityAttr without specifying type parameter.
+        """
+        user = self._test_user
+        entity = Entity.objects.create(name='Entity', created_user=user, is_public=False)
+        entity_attr = EntityAttr.objects.create(**{
+            'name': 'attr',
+            'type': AttrTypeValue['string'],
+            'created_user': user,
+            'parent_entity': entity,
+        })
+        entity.attrs.add(entity_attr)
+
+        EntityAttrResource.import_data_from_request({
+            'id': entity_attr.id,
+            'name': 'changed-attr',
+            'entity': entity.name,
+            'created_user': user.username
+        }, user)
+
+        entity_attr.refresh_from_db()
+        self.assertEqual(entity_attr.name, 'changed-attr')
+        self.assertEqual(entity_attr.type, AttrTypeValue['string'])
+
+    def test_import_entity_attr_without_specifying_id(self):
+        """
+        This checks an attribute would be created by importing.
+        """
+        user = self._test_user
+        entity = Entity.objects.create(name='Entity', created_user=user, is_public=False)
+
+        EntityAttrResource.import_data_from_request({
+            'name': 'attr',
+            'type': AttrTypeValue['array_string'],
+            'entity': entity.name,
+            'created_user': user.username
+        }, user)
+
+        entity.refresh_from_db()
+        self.assertEqual([(x.name, x.type) for x in entity.attrs.all()],
+                         [('attr', AttrTypeValue['array_string'])])
+
+    def test_import_entity_attr_without_specifying_id_and_type(self):
+        """
+        This checks an attribute wouldn't be created by importing because of luck of parameters
+        """
+        user = self._test_user
+        entity = Entity.objects.create(name='Entity', created_user=user, is_public=False)
+
+        # This processing would be failed because 'type' parameter is necessary for creating
+        # a new EntityAttr instance by importing processing.
+        with DisableStderr():
+            EntityAttrResource.import_data_from_request({
+                'name': 'attr',
+                'entity': entity.name,
+                'created_user': user.username
+            }, user)
+
+        # This checks EntityAttr would not be created
+        self.assertFalse(EntityAttr.objects.filter(parent_entity=entity, is_active=True).exists())
 
     def test_is_update_method(self):
         user = User.objects.create(username='another_user')

--- a/entity/views.py
+++ b/entity/views.py
@@ -166,28 +166,16 @@ def do_edit(request, entity_id, recv_data):
 
             params = {
                 'name': attr['name'],
-                'type': attr['type'],
                 'refs': [int(x) for x in attr['ref_ids']],
                 'index': attr['row_index'],
                 'is_mandatory': attr['is_mandatory'],
                 'is_delete_in_chain': attr['is_delete_in_chain'],
             }
             if attr_obj.is_updated(**params):
-                # Especially if the type of Attribute is changed, clear the latest flag
-                # for each latest values if the attribute type is changed.
-                if attr_obj.type != int(attr['type']):
-                    attr_obj.unset_latest_flag()
-
                 attr_obj.name = attr['name']
-                attr_obj.type = attr['type']
                 attr_obj.is_mandatory = attr['is_mandatory']
                 attr_obj.is_delete_in_chain = attr['is_delete_in_chain']
                 attr_obj.index = int(attr['row_index'])
-
-                # the case of an attribute that has referral entry
-                attr_obj.referral.clear()
-                if int(attr['type']) & AttrTypeValue['object']:
-                    [attr_obj.referral.add(Entity.objects.get(id=x)) for x in attr['ref_ids']]
 
                 attr_obj.save()
 

--- a/templates/edit_entity_content.html
+++ b/templates/edit_entity_content.html
@@ -40,7 +40,7 @@
             <td>
               <div class='row'>
                 <div class='col-4'>
-                  <select class="attr_type">
+                  <select class="attr_type" disabled="true">
                     {% for type in attr_types %}
                     <option value="{{ type.TYPE }}" {% if attr.type == type.TYPE %}selected="selected"{% endif %}>{{ type.NAME }}</option>
                     {% endfor %}


### PR DESCRIPTION
Close: #39 

This PR fix to unable to change Attributes type of Entity according to #39 as below. The way to edit an Entity object is not only edit page of Entity, its type could be altered by importing. By this PR, the types of EntityAttr unable to be changed.

<img width="1095" alt="スクリーンショット 2020-10-14 11 08 09" src="https://user-images.githubusercontent.com/469934/95935207-ade8a200-0e0d-11eb-8bb8-0530c56fd707.png">
This is a screenshot of editing Entity. Appending attribute can set type, but existed one cannot do it.