### PR TITLE
Fixed problem to get AttributeValue which is associated with deleted EntityAttr

### DIFF
--- a/entry/models.py
+++ b/entry/models.py
@@ -1467,11 +1467,13 @@ class Entry(ACLBase):
     def get_attrv(self, attr_name):
         """This returns specified attribute's value without permission check. Because
         this prioritizes performance (less frequency of sending query to Database) over
-        authorization safety.Don't to use this before permissoin check of specified attribute.
+        authorization safety.
+
+        CAUTION: Don't use this before permissoin check of specified attribute.
         """
         return AttributeValue.objects.filter(
             is_latest=True,
             parent_attr__name=attr_name,
-            parent_attr__is_active=True,
-            parent_attr__entry=self
+            parent_attr__schema__is_active=True,
+            parent_attr__parent_entry=self
         ).first()

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -3027,12 +3027,11 @@ class ModelTest(AironeTestCase):
             # set value to testing attribute
             attr.add_value(user, 'hoge')
 
-        # remove Attribute attr-deleted
-        entry.attrs.get(schema__name='attr-deleted').delete()
+        # remove EntityAttr attr-deleted
+        entity.attrs.get(name='attr-deleted').delete()
 
         # tests of get_attrv method
-        self.assertEqual(entry.get_attrv('attr'),
-                         entry.attrs.get(schema__name='attr').get_latest_value())
+        self.assertEqual(entry.get_attrv('attr').value, 'hoge')
         self.assertIsNone(entry.get_attrv('attr-deleted'))
         self.assertIsNone(entry.get_attrv('invalid-attribute-name'))
 


### PR DESCRIPTION
Close: #45 

This commit fixes a problem that Entry.get_attrv may return
AttributeValue of Attribute which is associated with deleted EntityAttr.

In the previous implementation, get_attrv returns AttributeValue of
active Attribute. But, once EntityAttr would be deleted (technically
is_active flag is down) by editing an Entity, Attribute instances which
is associated with it wouldn't be deleted immediately. That would be
reflected until a changed Entity's Entry is accessed. And deleting an
Attribute of active EntityAttr is also operationally unexpected.

Therefore, this changed condition to get AttributeValues through
`get_attrv` method to return AttributeValue that refers self entry and
also refers active EntityAttr which is specified by name argument.