### PR TITLE
Fixed the Refer of EntityAttr failing to import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## in development
 
 ### Fixed
+* Fixed the Refer of EntityAttr failing to import
 * Fixed the upper limit when using offset of GET entry API
 * Fixed for API request without token results in exception error
 

--- a/dashboard/tests/fixtures/entity.yaml
+++ b/dashboard/tests/fixtures/entity.yaml
@@ -11,4 +11,4 @@ EntityAttr:
 - {created_user: admin, entity: entity, id: 6, is_mandatory: '0', name: attr-arr-str,
   refer: '', type: 1026}
 - {created_user: admin, entity: entity, id: 7, is_mandatory: '0', name: attr-arr-obj,
-  refer: entity2, type: 1025}
+  refer: "entity1,entity2", type: 1025}

--- a/dashboard/tests/test_import.py
+++ b/dashboard/tests/test_import.py
@@ -8,11 +8,15 @@ from django.conf import settings
 from entity.models import Entity, EntityAttr
 from entry.models import Entry, Attribute, AttributeValue
 from user.models import User
+from acl.models import ACLBase
 
 
 class ImportTest(AironeViewTest):
     def test_import_entity(self):
         self.admin_login()
+
+        user = User.objects.get(username='admin')
+        ACLBase.objects.create(id=10, name='entity1', created_user=user)
 
         fp = self.open_fixture_file('entity.yaml')
         resp = self.client.post(reverse('dashboard:do_import'), {'file': fp})
@@ -44,6 +48,8 @@ class ImportTest(AironeViewTest):
         self.assertEqual(entity.attrs.get(name='attr-arr-obj').type, atype.AttrTypeArrObj)
         self.assertFalse(entity.attrs.get(name='attr-str').is_mandatory)
         self.assertTrue(entity.attrs.get(name='attr-obj').is_mandatory)
+        self.assertEqual(entity.attrs.get(name='attr-obj').referral.count(), 1)
+        self.assertEqual(entity.attrs.get(name='attr-arr-obj').referral.count(), 2)
 
     def test_import_entity_with_unnecessary_param(self):
         self.admin_login()

--- a/entity/admin.py
+++ b/entity/admin.py
@@ -3,7 +3,6 @@ from django.contrib import admin
 from .models import EntityAttr
 from .models import Entity
 from user.models import User
-from acl.models import ACLBase
 from airone.lib.resources import AironeModelResource
 
 admin.site.register(EntityAttr)
@@ -54,7 +53,7 @@ class EntityAttrResource(AironeModelResource):
     user = fields.Field(column_name='created_user', attribute='created_user',
                         widget=widgets.ForeignKeyWidget(User, 'username'))
     refer = fields.Field(column_name='refer', attribute='referral',
-                         widget=widgets.ManyToManyWidget(model=ACLBase, field='name'))
+                         widget=widgets.ManyToManyWidget(model=Entity, field='name'))
     entity = fields.Field(column_name='entity',
                           attribute='parent_entity',
                           widget=widgets.ForeignKeyWidget(model=Entity, field='name'))
@@ -76,7 +75,8 @@ class EntityAttrResource(AironeModelResource):
         if not Entity.objects.filter(name=data['entity']).exists():
             raise RuntimeError('failed to identify entity object')
 
-        if data['refer'] and not Entity.objects.filter(name=data['refer']).exists():
+        if data['refer'] and not all([Entity.objects.filter(name=x).exists()
+                                     for x in data['refer'].split(',')]):
             raise RuntimeError('refer to invalid entity object')
 
         # The processing fails when 'type' parameter is not existed for creating a new instance


### PR DESCRIPTION
Verification was failing when there were multiple the Refer of EntityAttr.
If there is an ACLBase with the same name as EntityAttr,
multiple the Refer of EntityAttr was being registerd.

close: https://github.com/dmm-com/airone/issues/65