### PR TITLE
Refactored authentication API handler for HTTP basic authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## in development
 
+* Refactored the API handler for authentication to optimize DB query
+
 ## v2.5.1
 
 ### Fixed

--- a/api_v1/tests/user/test_api.py
+++ b/api_v1/tests/user/test_api.py
@@ -47,9 +47,6 @@ class APITest(AironeViewTest):
         self.assertEqual(resp.json()['results'], str(token))
 
     def test_refresh_token_using_invalid_token(self):
-        user = User.objects.create(username='guest')
-        token = Token.objects.create(user=DjangoUser.objects.get(id=user.id))
-
         resp = self.client.get('/api/v1/user/access_token', **{
             'HTTP_AUTHORIZATION': 'Token %s' % 'invlaid-token',
         })

--- a/api_v1/tests/user/test_api.py
+++ b/api_v1/tests/user/test_api.py
@@ -1,5 +1,7 @@
+import base64
 from airone.lib.test import AironeViewTest
 
+from rest_framework import HTTP_HEADER_ENCODING
 from rest_framework.authtoken.models import Token
 
 from user.models import User
@@ -42,3 +44,16 @@ class APITest(AironeViewTest):
         })
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()['results'], str(token))
+
+    def test_get_token_with_password(self):
+        user = User.objects.create(username='test-user')
+        user.set_password('password')
+        user.save()
+
+        auth_byte = (f'%s:%s' % ('test-user', 'password')).encode(HTTP_HEADER_ENCODING)
+        auth_info = base64.b64encode(auth_byte).decode(HTTP_HEADER_ENCODING)
+
+        resp = self.client.get('/api/v1/user/access_token', **{
+            'HTTP_AUTHORIZATION': 'Basic %s' % auth_info,
+        })
+        self.assertEqual(resp.status_code, 200)

--- a/api_v1/tests/user/test_api.py
+++ b/api_v1/tests/user/test_api.py
@@ -50,7 +50,7 @@ class APITest(AironeViewTest):
         user.set_password('password')
         user.save()
 
-        auth_byte = (f'%s:%s' % ('test-user', 'password')).encode(HTTP_HEADER_ENCODING)
+        auth_byte = ('%s:%s' % ('test-user', 'password')).encode(HTTP_HEADER_ENCODING)
         auth_info = base64.b64encode(auth_byte).decode(HTTP_HEADER_ENCODING)
 
         resp = self.client.get('/api/v1/user/access_token', **{

--- a/api_v1/user/views.py
+++ b/api_v1/user/views.py
@@ -2,6 +2,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_protect
 from django.contrib.auth.models import User as DjangoUser
 
+from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.authtoken.models import Token
 from rest_framework.authentication import BasicAuthentication
@@ -18,9 +19,11 @@ class AccessTokenAPI(APIView):
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, format=None):
-        user = DjangoUser.objects.get(id=request.user.id)
+        user = AironeUser.objects.filter(id=request.user.id).first()
+        if not user:
+            return Response({'msg': 'failed to identify user'}, status=status.HTTP_400_BAD_REQUEST)
 
-        return Response({'results': str(AironeUser(id=user.id).token)})
+        return Response({'results': str(user.token)})
 
     @method_decorator(csrf_protect)
     def put(self, request, format=None):

--- a/api_v1/user/views.py
+++ b/api_v1/user/views.py
@@ -16,7 +16,6 @@ from user.models import User as AironeUser
 
 class AccessTokenAPI(APIView):
     authentication_classes = (AironeTokenAuth, BasicAuthentication, SessionAuthentication,)
-    permission_classes = (IsAuthenticated,)
 
     def get(self, request, format=None):
         user = AironeUser.objects.filter(id=request.user.id).first()


### PR DESCRIPTION
In the previous implementation sends query twice to the database for
authenticating users in the AccessTokenURI. But it's enough to send it
at once. And there was no test for authentication using HTTP basic
authentication.

This commit refactores custom authentication implementation to reduce
sending unnecessary db-query and adds test for HTTP basic
authentication.