### PR TITLE
Added param of entry refferal API to reduce filter execution time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## in development
 
 * Refactored the API handler for authentication to optimize DB query
+* Added param of entry refferal API to reduce filter execution time
 
 ## v2.5.1
 

--- a/api_v1/tests/entry/test_api.py
+++ b/api_v1/tests/entry/test_api.py
@@ -188,8 +188,8 @@ class APITest(AironeViewTest):
 
         # check the case of entity param exists
         for index in range(0, 4):
-            resp = self.client.get('/api/v1/entry/referral?entry=%s&%s' %
-                                   (refs[index].name, entity.name))
+            resp = self.client.get('/api/v1/entry/referral?entry=%s&entity=%s' %
+                                   (refs[index].name, entity_ref.name))
             self.assertEqual(resp.status_code, 200)
 
             result = resp.json()['result']
@@ -220,6 +220,25 @@ class APITest(AironeViewTest):
                 'id': entry2.id,
                 'name': entry2.name,
                 'entity': {'id': entity2.id, 'name': entity2.name}
+            }])
+
+        # check the case of quiet param exists
+        for index in range(0, 4):
+            resp = self.client.get('/api/v1/entry/referral?entry=%s&quiet=1' % refs[index].name)
+            self.assertEqual(resp.status_code, 200)
+
+            result = resp.json()['result']
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0]['id'], refs[index].id)
+            self.assertEqual(result[0]['entity'], {'id': entity_ref.id, 'name': entity_ref.name})
+            self.assertEqual(result[0]['referral'], [{
+                'id': entry.id,
+                'name': entry.name,
+                'entity': {}
+            }, {
+                'id': entry2.id,
+                'name': entry2.name,
+                'entity': {}
             }])
 
     def test_search_with_large_size_parameter(self):

--- a/entry/models.py
+++ b/entry/models.py
@@ -1002,10 +1002,11 @@ class Entry(ACLBase):
                 ).values_list('parent_attr__parent_entry', flat=True)
 
         # if entity_name param exists, add schema name to reduce filter execution time
+        query = Q(pk__in=ids, is_active=True)
         if entity_name:
-            return Entry.objects.filter(pk__in=ids, schema__name=entity_name, is_active=True)
+            query &= Q(schema__name=entity_name)
 
-        return Entry.objects.filter(pk__in=ids, is_active=True)
+        return Entry.objects.filter(query)
 
     def may_append_attr(self, attr):
         """

--- a/entry/models.py
+++ b/entry/models.py
@@ -992,7 +992,7 @@ class Entry(ACLBase):
 
         return attr
 
-    def get_referred_objects(self):
+    def get_referred_objects(self, entity_name=None):
         """
         This returns objects that refer current Entry in the AttributeValue
         """
@@ -1000,6 +1000,10 @@ class Entry(ACLBase):
                 Q(referral=self, is_latest=True) |
                 Q(referral=self, parent_attrv__is_latest=True)
                 ).values_list('parent_attr__parent_entry', flat=True)
+
+        # if entity_name param exists, add schema name to reduce filter execution time
+        if entity_name:
+            return Entry.objects.filter(pk__in=ids, schema__name=entity_name, is_active=True)
 
         return Entry.objects.filter(pk__in=ids, is_active=True)
 


### PR DESCRIPTION
Adding the target entity to the search criteria when filtering entries will reduce processing time.

e.g.) specifying parameters
- before
```
curl -w "%{time_total}" 'http://${AirOneURL}/api/v1/entry/referral?entry=TestEntry' \
-H "Authorization: Token xxxx"
```
- entity param
```
curl -w "%{time_total}" 'http://${AirOneURL}/api/v1/entry/referral?entry=TestEntry&entity=TestEntity' \
-H "Authorization: Token xxxx"
```
- target entity param
```
curl -w "%{time_total}" 'http://${AirOneURL}/api/v1/entry/referral?entry=TestEntry&target_entity=RefEntity' \
-H "Authorization: Token xxxx"
```
- both
```
curl -w "%{time_total}" 'http://${AirOneURL}/api/v1/entry/referral?entry=TestEntry&entity=TestEntity&target_entity=RefEntity' \
-H "Authorization: Token xxxx"
```
