### PR TITLE
change default database host setting

### DIFF
--- a/airone/settings.py
+++ b/airone/settings.py
@@ -101,7 +101,7 @@ DATABASES = {
         'NAME': 'airone',
         'USER': 'airone',
         'PASSWORD': 'password',
-        'HOST': 'localhost',
+        'HOST': '127.0.0.1',
         'OPTIONS': {
             'charset': 'utf8mb4',
         }


### PR DESCRIPTION
some tools are failed with mysqlclient
e.g. clear_and_init_db.sh

```
$ mysql -uairone -hlocalhost -ppassword -e 'select 1'

mysql: [Warning] Using a password on the command line interface can be insecure.
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/tmp/mysql.sock' (2)
```

```
$ mysql -uairone -h127.0.0.1 -ppassword -e 'select 1'

mysql: [Warning] Using a password on the command line interface can be insecure.
+---+
| 1 |
+---+
| 1 |
+---+
```