### PR TITLE
Process editing/deleting entity on a Celery worker.

### DIFF
--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -214,6 +214,7 @@ def render(request, template, context={}):
     # set Construct for Entity status
     context['STATUS_ENTITY'] = {}
     context['STATUS_ENTITY']['TOP_LEVEL'] = entity_models.Entity.STATUS_TOP_LEVEL
+    context['STATUS_ENTITY']['CREATING'] = entry_models.Entity.STATUS_CREATING
     context['STATUS_ENTITY']['EDITING'] = entry_models.Entity.STATUS_EDITING
 
     # set Construct for Entry status

--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -194,6 +194,7 @@ def render(request, template, context={}):
             'EXPORT': JobOperation.EXPORT_ENTRY.value,
             'RESTORE': JobOperation.RESTORE_ENTRY.value,
             'EXPORT_SEARCH_RESULT': JobOperation.EXPORT_SEARCH_RESULT.value,
+            'CREATE_ENTITY': JobOperation.CREATE_ENTITY.value,
             'EDIT_ENTITY': JobOperation.EDIT_ENTITY.value,
             'DELETE_ENTITY': JobOperation.DELETE_ENTITY.value,
         }

--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -194,6 +194,8 @@ def render(request, template, context={}):
             'EXPORT': JobOperation.EXPORT_ENTRY.value,
             'RESTORE': JobOperation.RESTORE_ENTRY.value,
             'EXPORT_SEARCH_RESULT': JobOperation.EXPORT_SEARCH_RESULT.value,
+            'EDIT_ENTITY': JobOperation.EDIT_ENTITY.value,
+            'DELETE_ENTITY': JobOperation.DELETE_ENTITY.value,
         }
     }
 
@@ -211,6 +213,7 @@ def render(request, template, context={}):
     # set Construct for Entity status
     context['STATUS_ENTITY'] = {}
     context['STATUS_ENTITY']['TOP_LEVEL'] = entity_models.Entity.STATUS_TOP_LEVEL
+    context['STATUS_ENTITY']['EDITING'] = entry_models.Entity.STATUS_EDITING
 
     # set Construct for Entry status
     context['STATUS_ENTRY'] = {}

--- a/api_v1/job/views.py
+++ b/api_v1/job/views.py
@@ -46,6 +46,7 @@ class JobAPI(APIView):
                 'export': JobOperation.EXPORT_ENTRY.value,
                 'export_search_result': JobOperation.EXPORT_SEARCH_RESULT.value,
                 'restore': JobOperation.RESTORE_ENTRY.value,
+                'create_entity': JobOperation.CREATE_ENTITY.value,
                 'edit_entity': JobOperation.EDIT_ENTITY.value,
                 'delete_entity': JobOperation.DELETE_ENTITY.value,
             }

--- a/api_v1/job/views.py
+++ b/api_v1/job/views.py
@@ -46,6 +46,8 @@ class JobAPI(APIView):
                 'export': JobOperation.EXPORT_ENTRY.value,
                 'export_search_result': JobOperation.EXPORT_SEARCH_RESULT.value,
                 'restore': JobOperation.RESTORE_ENTRY.value,
+                'edit_entity': JobOperation.EDIT_ENTITY.value,
+                'delete_entity': JobOperation.DELETE_ENTITY.value,
             }
         }
 

--- a/api_v1/tests/job/test_api.py
+++ b/api_v1/tests/job/test_api.py
@@ -52,6 +52,7 @@ class APITest(AironeViewTest):
             'export': JobOperation.EXPORT_ENTRY.value,
             'export_search_result': JobOperation.EXPORT_SEARCH_RESULT.value,
             'restore': JobOperation.RESTORE_ENTRY.value,
+            'create_entity': JobOperation.CREATE_ENTITY.value,
             'edit_entity': JobOperation.EDIT_ENTITY.value,
             'delete_entity': JobOperation.DELETE_ENTITY.value,
         })

--- a/api_v1/tests/job/test_api.py
+++ b/api_v1/tests/job/test_api.py
@@ -52,6 +52,8 @@ class APITest(AironeViewTest):
             'export': JobOperation.EXPORT_ENTRY.value,
             'export_search_result': JobOperation.EXPORT_SEARCH_RESULT.value,
             'restore': JobOperation.RESTORE_ENTRY.value,
+            'edit_entity': JobOperation.EDIT_ENTITY.value,
+            'delete_entity': JobOperation.DELETE_ENTITY.value,
         })
         self.assertEqual(results['constant']['status'], {
             'processing': Job.STATUS['PROCESSING'],

--- a/entity/models.py
+++ b/entity/models.py
@@ -45,7 +45,8 @@ class EntityAttr(ACLBase):
 
 class Entity(ACLBase):
     STATUS_TOP_LEVEL = 1 << 0
-    STATUS_EDITING = 1 << 1
+    STATUS_CREATING = 1 << 1
+    STATUS_EDITING = 1 << 2
 
     note = models.CharField(max_length=200)
     attrs = models.ManyToManyField(EntityAttr)

--- a/entity/models.py
+++ b/entity/models.py
@@ -45,6 +45,7 @@ class EntityAttr(ACLBase):
 
 class Entity(ACLBase):
     STATUS_TOP_LEVEL = 1 << 0
+    STATUS_EDITING = 1 << 1
 
     note = models.CharField(max_length=200)
     attrs = models.ManyToManyField(EntityAttr)

--- a/entity/tasks.py
+++ b/entity/tasks.py
@@ -1,0 +1,106 @@
+import json
+import logging
+
+from airone.lib.types import AttrTypeValue
+from airone.celery import app
+from entity.models import Entity, EntityAttr
+from user.models import User
+from job.models import Job
+
+Logger = logging.getLogger(__name__)
+
+
+@app.task(bind=True)
+def edit_entity(self, job_id):
+    job = Job.objects.get(id=job_id)
+
+    if job.proceed_if_ready():
+        # At the first time, update job status to prevent executing this job duplicately
+        job.update(Job.STATUS['PROCESSING'])
+
+        user = User.objects.filter(id=job.user.id).first()
+        entity = Entity.objects.filter(id=job.target.id, is_active=True).first()
+        if not entity or not user:
+            # Abort when specified entry doesn't exist
+            job.update(Job.STATUS['CANCELED'])
+            return
+
+        recv_data = json.loads(job.params)
+
+        # register history to modify Entity
+        history = user.seth_entity_mod(entity)
+        if entity.name != recv_data['name']:
+            history.mod_entity(entity, 'old name: "%s"' % (entity.name))
+
+        entity.name = recv_data['name']
+        entity.note = recv_data['note']
+
+        # update processing for each attrs
+        for attr in recv_data['attrs']:
+            if 'deleted' in attr:
+                # In case of deleting attribute which has been already existed
+                attr_obj = EntityAttr.objects.get(id=attr['id'])
+                attr_obj.delete()
+
+                # register History to register deleting EntityAttr
+                history.del_attr(attr_obj)
+
+            elif 'id' in attr and EntityAttr.objects.filter(id=attr['id']).exists():
+                # In case of updating attribute which has been already existed
+                attr_obj = EntityAttr.objects.get(id=attr['id'])
+
+                # register operaion history if the parameters are changed
+                if attr_obj.name != attr['name']:
+                    history.mod_attr(attr_obj, 'old name: "%s"' % (attr_obj.name))
+
+                if attr_obj.is_mandatory != attr['is_mandatory']:
+                    if attr['is_mandatory']:
+                        history.mod_attr(attr_obj, 'set mandatory flag')
+                    else:
+                        history.mod_attr(attr_obj, 'unset mandatory flag')
+
+                params = {
+                    'name': attr['name'],
+                    'refs': [int(x) for x in attr['ref_ids']],
+                    'index': attr['row_index'],
+                    'is_mandatory': attr['is_mandatory'],
+                    'is_delete_in_chain': attr['is_delete_in_chain'],
+                }
+                if attr_obj.is_updated(**params):
+                    attr_obj.name = attr['name']
+                    attr_obj.is_mandatory = attr['is_mandatory']
+                    attr_obj.is_delete_in_chain = attr['is_delete_in_chain']
+                    attr_obj.index = int(attr['row_index'])
+
+                    # the case of an attribute that has referral entry
+                    attr_obj.referral.clear()
+                    if attr_obj.type & AttrTypeValue['object']:
+                        [attr_obj.referral.add(Entity.objects.get(id=x)) for x in attr['ref_ids']]
+
+                    attr_obj.save()
+
+            else:
+                # In case of creating new attribute
+                attr_obj = EntityAttr.objects.create(name=attr['name'],
+                                                     type=int(attr['type']),
+                                                     is_mandatory=attr['is_mandatory'],
+                                                     is_delete_in_chain=attr['is_delete_in_chain'],
+                                                     index=int(attr['row_index']),
+                                                     created_user=user,
+                                                     parent_entity=entity)
+
+                # append referral objects
+                if int(attr['type']) & AttrTypeValue['object']:
+                    [attr_obj.referral.add(Entity.objects.get(id=x)) for x in attr['ref_ids']]
+
+                # add a new attribute on the existed Entries
+                entity.attrs.add(attr_obj)
+
+                # register History to register adding EntityAttr
+                history.add_attr(attr_obj)
+
+        # clear flag to specify this entry has been completed to edit
+        entity.del_status(Entity.STATUS_EDITING)
+
+        # update job status and save it
+        job.update(Job.STATUS['DONE'])

--- a/entity/tasks.py
+++ b/entity/tasks.py
@@ -47,6 +47,9 @@ def create_entity(self, job_id):
             # register history to modify Entity
             history.add_attr(attr_base)
 
+        # clear flag to specify this entity has been completed to create
+        entity.del_status(Entity.STATUS_CREATING)
+
         # update job status and save it
         job.update(Job.STATUS['DONE'])
 

--- a/entity/tests/test_complex_view.py
+++ b/entity/tests/test_complex_view.py
@@ -24,6 +24,7 @@ class ComplexViewTest(AironeViewTest):
 
     @patch('entry.tasks.create_entry_attrs.delay', Mock(side_effect=entry_tasks.create_entry_attrs))
     @patch('entry.tasks.edit_entry_attrs.delay', Mock(side_effect=entry_tasks.edit_entry_attrs))
+    @patch('entity.tasks.create_entity.delay', Mock(side_effect=entity_tasks.create_entity))
     @patch('entity.tasks.edit_entity.delay', Mock(side_effect=entity_tasks.edit_entity))
     def test_add_attr_after_creating_entry(self):
         """
@@ -174,6 +175,7 @@ class ComplexViewTest(AironeViewTest):
         value_arr_obj = attr_arr_obj.values.last()
         self.assertEqual(value_arr_obj.data_array.count(), 1)
 
+    @patch('entity.tasks.create_entity.delay', Mock(side_effect=entity_tasks.create_entity))
     @patch('entry.tasks.create_entry_attrs.delay', Mock(side_effect=entry_tasks.create_entry_attrs))
     def test_inherite_attribute_acl(self):
         """

--- a/entity/tests/test_complex_view.py
+++ b/entity/tests/test_complex_view.py
@@ -10,7 +10,8 @@ from django.urls import reverse
 
 from entity.models import Entity, EntityAttr
 from entry.models import Entry, AttributeValue
-from entry import tasks
+from entry import tasks as entry_tasks
+from entity import tasks as entity_tasks
 
 from unittest.mock import patch
 from unittest.mock import Mock
@@ -21,8 +22,9 @@ class ComplexViewTest(AironeViewTest):
     This has complex tests that combine multiple requests across the inter-applicational
     """
 
-    @patch('entry.tasks.create_entry_attrs.delay', Mock(side_effect=tasks.create_entry_attrs))
-    @patch('entry.tasks.edit_entry_attrs.delay', Mock(side_effect=tasks.edit_entry_attrs))
+    @patch('entry.tasks.create_entry_attrs.delay', Mock(side_effect=entry_tasks.create_entry_attrs))
+    @patch('entry.tasks.edit_entry_attrs.delay', Mock(side_effect=entry_tasks.edit_entry_attrs))
+    @patch('entity.tasks.edit_entity.delay', Mock(side_effect=entity_tasks.edit_entity))
     def test_add_attr_after_creating_entry(self):
         """
         This test executes followings
@@ -172,7 +174,7 @@ class ComplexViewTest(AironeViewTest):
         value_arr_obj = attr_arr_obj.values.last()
         self.assertEqual(value_arr_obj.data_array.count(), 1)
 
-    @patch('entry.tasks.create_entry_attrs.delay', Mock(side_effect=tasks.create_entry_attrs))
+    @patch('entry.tasks.create_entry_attrs.delay', Mock(side_effect=entry_tasks.create_entry_attrs))
     def test_inherite_attribute_acl(self):
         """
         This test executes followings
@@ -258,6 +260,7 @@ class ComplexViewTest(AironeViewTest):
         self.assertEqual(Entry.objects.count(), 2)
         self.assertEqual(Entry.objects.get(name='entry2').attrs.count(), 0)
 
+    @patch('entity.tasks.edit_entity.delay', Mock(side_effect=entity_tasks.edit_entity))
     def test_cache_referred_entry_at_deleting_attr(self):
         user = self.admin_login()
 

--- a/entity/tests/test_view.py
+++ b/entity/tests/test_view.py
@@ -90,10 +90,12 @@ class ViewTest(AironeViewTest):
         self.assertEqual(len(resp.context['entities']), 1)
         self.assertEqual(resp.context['entities'][0].id, entity_public.id)
 
+    @mock.patch('entity.tasks.create_entity.delay', mock.Mock(side_effect=tasks.create_entity))
     def test_create_post_without_login(self):
         resp = self.client.post(reverse('entity:do_create'), json.dumps({}), 'application/json')
         self.assertEqual(resp.status_code, 401)
 
+    @mock.patch('entity.tasks.create_entity.delay', mock.Mock(side_effect=tasks.create_entity))
     def test_create_post(self):
         self.admin_login()
 
@@ -487,6 +489,7 @@ class ViewTest(AironeViewTest):
 
         self.assertEqual(resp.status_code, 400)
 
+    @mock.patch('entity.tasks.create_entity.delay', mock.Mock(side_effect=tasks.create_entity))
     def test_post_create_with_valid_referral_attr(self):
         user = self.admin_login()
 
@@ -784,6 +787,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(Entity.objects.filter(name='hoge'))
 
+    @mock.patch('entity.tasks.create_entity.delay', mock.Mock(side_effect=tasks.create_entity))
     def test_create_entity_attr_with_multiple_referral(self):
         user = self.admin_login()
 

--- a/entity/tests/test_view.py
+++ b/entity/tests/test_view.py
@@ -14,6 +14,7 @@ from entity.settings import CONFIG
 from entry.models import Entry, Attribute
 from user.models import User, History
 from unittest import mock
+from entity import tasks
 from xml.etree import ElementTree
 
 
@@ -245,6 +246,7 @@ class ViewTest(AironeViewTest):
                                 'application/json')
         self.assertEqual(resp.status_code, 400)
 
+    @mock.patch('entity.tasks.edit_entity.delay', mock.Mock(side_effect=tasks.edit_entity))
     def test_post_edit_with_valid_params(self):
         user = self.admin_login()
 
@@ -284,6 +286,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(History.objects.filter(operation=History.ADD_ATTR).count(), 1)
         self.assertEqual(History.objects.filter(operation=History.MOD_ATTR).count(), 2)
 
+    @mock.patch('entity.tasks.edit_entity.delay', mock.Mock(side_effect=tasks.edit_entity))
     def test_post_edit_after_creating_entry(self):
         user = self.admin_login()
 
@@ -349,6 +352,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(EntityAttr.objects.get(id=attr.id).type, AttrTypeStr)
         self.assertEqual(EntityAttr.objects.get(id=attr.id).referral.count(), 0)
 
+    @mock.patch('entity.tasks.edit_entity.delay', mock.Mock(side_effect=tasks.edit_entity))
     def test_post_edit_attribute_referral(self):
         user = self.admin_login()
 
@@ -429,6 +433,42 @@ class ViewTest(AironeViewTest):
         self.assertEqual(EntityAttr.objects.get(id=attr.id).type, AttrTypeStr)
         self.assertEqual(EntityAttr.objects.get(id=attr.id).referral.count(), 0)
 
+    @mock.patch('entity.tasks.edit_entity.delay', mock.Mock())
+    def test_post_edit_still_under_processing(self):
+        user = self.admin_login()
+
+        entity = Entity.objects.create(name='hoge', note='fuga', created_user=user)
+        attr = EntityAttr.objects.create(name='puyo',
+                                         created_user=user,
+                                         is_mandatory=True,
+                                         type=AttrTypeStr,
+                                         parent_entity=entity)
+        entity.attrs.add(attr)
+
+        params = {
+            'name': 'foo',
+            'note': 'bar',
+            'is_toplevel': True,
+            'attrs': [
+                {'name': 'foo', 'type': str(AttrTypeStr), 'is_delete_in_chain': False,
+                 'is_mandatory': False, 'id': attr.id, 'row_index': '1'},
+                {'name': 'bar', 'type': str(AttrTypeStr), 'is_delete_in_chain': False,
+                 'is_mandatory': True, 'row_index': '2'},
+            ],
+        }
+
+        # Call a new editing entity
+        resp = self.client.post(reverse('entity:do_edit', args=[entity.id]),
+                                json.dumps(params),
+                                'application/json')
+        self.assertEqual(resp.status_code, 200)
+
+        # Call the entity still processing again
+        resp = self.client.post(reverse('entity:do_edit', args=[entity.id]),
+                                json.dumps(params),
+                                'application/json')
+        self.assertEqual(resp.status_code, 400)
+
     def test_post_create_with_invalid_referral_attr(self):
         self.admin_login()
 
@@ -476,6 +516,7 @@ class ViewTest(AironeViewTest):
         self.assertFalse(any([x.is_mandatory for x in created_entity.attrs.all()]))
         self.assertTrue(all([x.is_delete_in_chain for x in created_entity.attrs.all()]))
 
+    @mock.patch('entity.tasks.edit_entity.delay', mock.Mock(side_effect=tasks.edit_entity))
     def test_post_delete_attribute(self):
         user = self.admin_login()
 

--- a/entity/views.py
+++ b/entity/views.py
@@ -213,7 +213,8 @@ def do_create(request, recv_data):
     # create EntityAttr objects
     entity = Entity(name=recv_data['name'],
                     note=recv_data['note'],
-                    created_user=user)
+                    created_user=user,
+                    status=Entity.STATUS_CREATING)
 
     # set status parameters
     if recv_data['is_toplevel']:

--- a/entity/views.py
+++ b/entity/views.py
@@ -221,25 +221,9 @@ def do_create(request, recv_data):
 
     entity.save()
 
-    # register history to modify Entity
-    history = user.seth_entity_add(entity)
-
-    for attr in recv_data['attrs']:
-        attr_base = EntityAttr.objects.create(name=attr['name'],
-                                              type=int(attr['type']),
-                                              is_mandatory=attr['is_mandatory'],
-                                              is_delete_in_chain=attr['is_delete_in_chain'],
-                                              created_user=user,
-                                              parent_entity=entity,
-                                              index=int(attr['row_index']))
-
-        if int(attr['type']) & AttrTypeValue['object']:
-            [attr_base.referral.add(Entity.objects.get(id=x)) for x in attr['ref_ids']]
-
-        entity.attrs.add(attr_base)
-
-        # register history to modify Entity
-        history.add_attr(attr_base)
+    # Create a new job to edit entity and run it
+    job = Job.new_create_entity(user, entity, params=recv_data)
+    job.run()
 
     return JsonResponse({
         'entity_id': entity.id,

--- a/entity/views.py
+++ b/entity/views.py
@@ -11,6 +11,7 @@ from .models import Entity
 from .models import EntityAttr
 from user.models import User, History
 from entry.models import Entry, AttributeValue
+from job.models import Job
 
 from airone.lib.types import AttrTypes, AttrTypeValue
 from airone.lib.http import http_get, http_post
@@ -147,12 +148,9 @@ def do_edit(request, entity_id, recv_data):
 
     entity = Entity.objects.get(id=entity_id)
 
-    # register history to modify Entity
-    history = user.seth_entity_mod(entity)
-
-    # check operation history detail
-    if entity.name != recv_data['name']:
-        history.mod_entity(entity, 'old name: "%s"' % (entity.name))
+    # prevent to show edit page under the processing
+    if entity.get_status(Entity.STATUS_EDITING):
+        return HttpResponse('Target entity is now under processing', status=400)
 
     # update status parameters
     if recv_data['is_toplevel']:
@@ -161,78 +159,18 @@ def do_edit(request, entity_id, recv_data):
         entity.del_status(Entity.STATUS_TOP_LEVEL)
 
     # update entity metatada informations to new ones
-    entity.name = recv_data['name']
-    entity.note = recv_data['note']
+    entity.set_status(Entity.STATUS_EDITING)
     entity.save()
 
-    # update processing for each attrs
-    for attr in recv_data['attrs']:
-        if 'deleted' in attr:
-            # In case of deleting attribute which has been already existed
-            attr_obj = EntityAttr.objects.get(id=attr['id'])
-            attr_obj.delete()
+    # Create a new job to edit entity and run it
+    job = Job.new_edit_entity(user, entity, params=recv_data)
+    job.run()
 
-            # register History to register deleting EntityAttr
-            history.del_attr(attr_obj)
-
-        elif 'id' in attr and EntityAttr.objects.filter(id=attr['id']).exists():
-            # In case of updating attribute which has been already existed
-            attr_obj = EntityAttr.objects.get(id=attr['id'])
-
-            # register operaion history if the parameters are changed
-            if attr_obj.name != attr['name']:
-                history.mod_attr(attr_obj, 'old name: "%s"' % (attr_obj.name))
-
-            if attr_obj.is_mandatory != attr['is_mandatory']:
-                if attr['is_mandatory']:
-                    history.mod_attr(attr_obj, 'set mandatory flag')
-                else:
-                    history.mod_attr(attr_obj, 'unset mandatory flag')
-
-            params = {
-                'name': attr['name'],
-                'refs': [int(x) for x in attr['ref_ids']],
-                'index': attr['row_index'],
-                'is_mandatory': attr['is_mandatory'],
-                'is_delete_in_chain': attr['is_delete_in_chain'],
-            }
-            if attr_obj.is_updated(**params):
-                attr_obj.name = attr['name']
-                attr_obj.is_mandatory = attr['is_mandatory']
-                attr_obj.is_delete_in_chain = attr['is_delete_in_chain']
-                attr_obj.index = int(attr['row_index'])
-
-                # the case of an attribute that has referral entry
-                attr_obj.referral.clear()
-                if attr_obj.type & AttrTypeValue['object']:
-                    [attr_obj.referral.add(Entity.objects.get(id=x)) for x in attr['ref_ids']]
-
-                attr_obj.save()
-
-        else:
-            # In case of creating new attribute
-            attr_obj = EntityAttr.objects.create(name=attr['name'],
-                                                 type=int(attr['type']),
-                                                 is_mandatory=attr['is_mandatory'],
-                                                 is_delete_in_chain=attr['is_delete_in_chain'],
-                                                 index=int(attr['row_index']),
-                                                 created_user=user,
-                                                 parent_entity=entity)
-
-            # append referral objects
-            if int(attr['type']) & AttrTypeValue['object']:
-                [attr_obj.referral.add(Entity.objects.get(id=x)) for x in attr['ref_ids']]
-
-            # add a new attribute on the existed Entries
-            entity.attrs.add(attr_obj)
-
-            # register History to register adding EntityAttr
-            history.add_attr(attr_obj)
-
+    new_name = recv_data['name']
     return JsonResponse({
         'entity_id': entity.id,
-        'entity_name': entity.name,
-        'msg': 'Success to update Entity "%s"' % entity.name,
+        'entity_name': new_name,
+        'msg': 'Success to schedule to update Entity "%s"' % new_name,
     })
 
 

--- a/job/models.py
+++ b/job/models.py
@@ -36,6 +36,8 @@ class JobOperation(Enum):
     RESTORE_ENTRY = 7
     EXPORT_SEARCH_RESULT = 8
     REGISTER_REFERRALS = 9
+    EDIT_ENTITY = 10
+    DELETE_ENTITY = 11
 
 
 class Job(models.Model):
@@ -246,6 +248,7 @@ class Job(models.Model):
         if not kls._METHOD_TABLE:
             entry_task = kls.get_task_module('entry.tasks')
             dashboard_task = kls.get_task_module('dashboard.tasks')
+            entity_task = kls.get_task_module('entity.tasks')
 
             kls._METHOD_TABLE = {
                 JobOperation.CREATE_ENTRY.value: entry_task.create_entry_attrs,
@@ -257,6 +260,8 @@ class Job(models.Model):
                 JobOperation.RESTORE_ENTRY.value: entry_task.restore_entry,
                 JobOperation.EXPORT_SEARCH_RESULT.value: dashboard_task.export_search_result,
                 JobOperation.REGISTER_REFERRALS.value: entry_task.register_referrals,
+                JobOperation.EDIT_ENTITY.value: entity_task.edit_entity,
+                # JobOperation.DELETE_ENTITY.value: entity_task.delete_entity,
             }
 
         return kls._METHOD_TABLE
@@ -318,6 +323,16 @@ class Job(models.Model):
     def new_register_referrals(kls, user, target):
         return kls._create_new_job(user, target, JobOperation.REGISTER_REFERRALS.value, '',
                                    json.dumps({}, default=_support_time_default, sort_keys=True))
+
+    @classmethod
+    def new_edit_entity(kls, user, target, text='', params={}):
+        return kls._create_new_job(user, target, JobOperation.EDIT_ENTITY.value, text,
+                                   json.dumps(params, default=_support_time_default,
+                                              sort_keys=True))
+
+    @classmethod
+    def new_delete_entity(kls, user, target, text='', params={}):
+        return kls._create_new_job(user, target, JobOperation.DELETE_ENTITY.value, text, params)
 
     def set_cache(self, value):
         with open('%s/job_%d' % (settings.AIRONE['FILE_STORE_PATH'], self.id), 'wb') as fp:

--- a/job/models.py
+++ b/job/models.py
@@ -261,7 +261,7 @@ class Job(models.Model):
                 JobOperation.EXPORT_SEARCH_RESULT.value: dashboard_task.export_search_result,
                 JobOperation.REGISTER_REFERRALS.value: entry_task.register_referrals,
                 JobOperation.EDIT_ENTITY.value: entity_task.edit_entity,
-                # JobOperation.DELETE_ENTITY.value: entity_task.delete_entity,
+                JobOperation.DELETE_ENTITY.value: entity_task.delete_entity,
             }
 
         return kls._METHOD_TABLE

--- a/job/models.py
+++ b/job/models.py
@@ -36,8 +36,9 @@ class JobOperation(Enum):
     RESTORE_ENTRY = 7
     EXPORT_SEARCH_RESULT = 8
     REGISTER_REFERRALS = 9
-    EDIT_ENTITY = 10
-    DELETE_ENTITY = 11
+    CREATE_ENTITY = 10
+    EDIT_ENTITY = 11
+    DELETE_ENTITY = 12
 
 
 class Job(models.Model):
@@ -220,7 +221,7 @@ class Job(models.Model):
                          timedelta(seconds=kls._get_job_timeout()))
             dependent_job = (
                 Job.objects.filter(target=target, operation=operation, updated_at__gt=threshold)
-                .order_by('updated_at').last()
+                    .order_by('updated_at').last()
             )
 
         params = {
@@ -260,6 +261,7 @@ class Job(models.Model):
                 JobOperation.RESTORE_ENTRY.value: entry_task.restore_entry,
                 JobOperation.EXPORT_SEARCH_RESULT.value: dashboard_task.export_search_result,
                 JobOperation.REGISTER_REFERRALS.value: entry_task.register_referrals,
+                JobOperation.CREATE_ENTITY.value: entity_task.create_entity,
                 JobOperation.EDIT_ENTITY.value: entity_task.edit_entity,
                 JobOperation.DELETE_ENTITY.value: entity_task.delete_entity,
             }
@@ -323,6 +325,12 @@ class Job(models.Model):
     def new_register_referrals(kls, user, target):
         return kls._create_new_job(user, target, JobOperation.REGISTER_REFERRALS.value, '',
                                    json.dumps({}, default=_support_time_default, sort_keys=True))
+
+    @classmethod
+    def new_create_entity(kls, user, target, text='', params={}):
+        return kls._create_new_job(user, target, JobOperation.CREATE_ENTITY.value, text,
+                                   json.dumps(params, default=_support_time_default,
+                                              sort_keys=True))
 
     @classmethod
     def new_edit_entity(kls, user, target, text='', params={}):

--- a/job/models.py
+++ b/job/models.py
@@ -222,7 +222,7 @@ class Job(models.Model):
                          timedelta(seconds=kls._get_job_timeout()))
             dependent_job = (
                 Job.objects.filter(target=target, operation=operation, updated_at__gt=threshold)
-                    .order_by('updated_at').last()
+                .order_by('updated_at').last()
             )
 
         params = {

--- a/job/models.py
+++ b/job/models.py
@@ -185,6 +185,7 @@ class Job(models.Model):
             'target': {
                 'id': self.target.id,
                 'name': self.target.name,
+                'is_active': self.target.is_active,
             } if self.target else {},
             'text': self.text,
             'status': self.status,

--- a/job/views.py
+++ b/job/views.py
@@ -45,6 +45,7 @@ def index(request):
         } for x in Job.objects.filter(query).order_by('-created_at')[:limitation]
             if (x.operation in export_operations or
                 (x.operation not in export_operations and x.target and x.target.is_active) or
+                (x.operation is JobOperation.DELETE_ENTITY.value and x.target) or
                 (x.operation is JobOperation.DELETE_ENTRY.value and x.target))]
     }
 

--- a/static/js/airone_jobs_nav.js
+++ b/static/js/airone_jobs_nav.js
@@ -33,6 +33,7 @@ $(document).ready(function() {
           let target_name = '';
           switch(operation_type) {
             case data['constant']['operation']['create']:
+            case data['constant']['operation']['create_entity']:
               target_name = jobinfo['target']['name'];
               operation = '作成';
               break;
@@ -79,6 +80,7 @@ $(document).ready(function() {
                   // The case of export job, it has no target
                   link_url = `/job/download/${ jobinfo['id'] }`;
                   break;
+                case data['constant']['operation']['create_entity']:
                 case data['constant']['operation']['edit_entity']:
                 case data['constant']['operation']['delete_entity']:
                   // This indicates Entity-ID

--- a/static/js/airone_jobs_nav.js
+++ b/static/js/airone_jobs_nav.js
@@ -70,6 +70,7 @@ $(document).ready(function() {
               container.append(`<li class='dropdown-item job-status-processing' href='#'>[処理中/${operation}] ${ target_name }</li>`);
               break;
             case data['constant']['status']['done']:
+              var link_url = null;
               switch(operation_type) {
                 case data['constant']['operation']['import']:
                   // The case of import job, target-id indicates Entity-ID
@@ -83,15 +84,24 @@ $(document).ready(function() {
                 case data['constant']['operation']['create_entity']:
                 case data['constant']['operation']['edit_entity']:
                 case data['constant']['operation']['delete_entity']:
-                  // This indicates Entity-ID
-                  link_url = `/entry/${ jobinfo['target']['id'] }`;
+                  if (jobinfo['target']['is_active']){
+                    // This indicates Entity-ID
+                    link_url = `/entry/${ jobinfo['target']['id'] }`;
+                  } else {
+                    // Prevent to enter a deleted entity
+                    link_url = null;
+                  }
                   break;
                 default:
                   // This indicates Entry-ID by default
                   link_url = `/entry/show/${ jobinfo['target']['id'] }`;
               }
 
-              container.append(`<a class='dropdown-item job-status-done' href="${ link_url }">[完了/${operation}] ${ target_name }</a>`);
+              if (link_url !== null) {
+                container.append(`<a class='dropdown-item job-status-done' href="${ link_url }">[完了/${operation}] ${ target_name }</a>`);
+              } else {
+                container.append(`<li class='dropdown-item' href='#'>[完了/${operation}] ${ target_name }</li>`);
+              }
 
               break;
             case data['constant']['status']['error']:

--- a/static/js/airone_jobs_nav.js
+++ b/static/js/airone_jobs_nav.js
@@ -37,10 +37,12 @@ $(document).ready(function() {
               operation = '作成';
               break;
             case data['constant']['operation']['edit']:
+            case data['constant']['operation']['edit_entity']:
               target_name = jobinfo['target']['name'];
               operation = '編集';
               break;
             case data['constant']['operation']['delete']:
+            case data['constant']['operation']['delete_entity']:
               target_name = jobinfo['target']['name'];
               operation = '削除';
               break;
@@ -67,16 +69,24 @@ $(document).ready(function() {
               container.append(`<li class='dropdown-item job-status-processing' href='#'>[処理中/${operation}] ${ target_name }</li>`);
               break;
             case data['constant']['status']['done']:
-              if (operation_type == data['constant']['operation']['import']) {
-                // The case of import job, target-id indicates Entity-ID
-                link_url = `/entry/${ jobinfo['target']['id'] }`;
-              } else if (operation_type == data['constant']['operation']['export'] ||
-                         operation_type == data['constant']['operation']['export_search_result']) {
-                // The case of export job, it has no target
-                link_url = `/job/download/${ jobinfo['id'] }`;
-              } else {
-                // This indicates Entry-ID by default
-                link_url = `/entry/show/${ jobinfo['target']['id'] }`;
+              switch(operation_type) {
+                case data['constant']['operation']['import']:
+                  // The case of import job, target-id indicates Entity-ID
+                  link_url = `/entry/${ jobinfo['target']['id'] }`;
+                  break;
+                case data['constant']['operation']['export']:
+                case data['constant']['operation']['export_search_result']:
+                  // The case of export job, it has no target
+                  link_url = `/job/download/${ jobinfo['id'] }`;
+                  break;
+                case data['constant']['operation']['edit_entity']:
+                case data['constant']['operation']['delete_entity']:
+                  // This indicates Entity-ID
+                  link_url = `/entry/${ jobinfo['target']['id'] }`;
+                  break;
+                default:
+                  // This indicates Entry-ID by default
+                  link_url = `/entry/show/${ jobinfo['target']['id'] }`;
               }
 
               container.append(`<a class='dropdown-item job-status-done' href="${ link_url }">[完了/${operation}] ${ target_name }</a>`);

--- a/templates/list_entities.html
+++ b/templates/list_entities.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load bitwise_tags %}
 
 {% block title %}List Entities{% endblock %}
 
@@ -68,7 +69,13 @@
           {% for entity in entities %}
           <tr>
             <td>
+              {% if entity.status|bitwise_and:STATUS_ENTITY.CREATING %}
+                {{ entity.name }} [作成中]
+              {% elif entity.status|bitwise_and:STATUS_ENTITY.EDITING %}
+                <a href='/entry/{{ entity.id }}'>{{ entity.name }} [編集中]</a>
+              {% else %}
                 <a href='/entry/{{ entity.id }}'>{{ entity.name }}</a>
+              {% endif %}
             </td>
             <td>{{ entity.note }}</td>
             <td>

--- a/templates/list_jobs.html
+++ b/templates/list_jobs.html
@@ -52,6 +52,12 @@
               {% endif %}
             {% elif job.operation|divmod:100 == JOB.OPERATION.IMPORT %}
               <td><a href='/entry/{{ job.target.id }}/'>{{ job.target.name }}</a></td>
+            {% elif job.operation|divmod:100 == JOB.OPERATION.CREATE_ENTITY %}
+              <td><a href='/entry/{{ job.target.id }}/'>{{ job.target.name }}</a></td>
+            {% elif job.operation|divmod:100 == JOB.OPERATION.EDIT_ENTITY %}
+              <td><a href='/entry/{{ job.target.id }}/'>{{ job.target.name }}</a></td>
+            {% elif job.operation|divmod:100 == JOB.OPERATION.DELETE_ENTITY %}
+              <td>{{ job.target.name }}</td>
             {% else %}
               <td><a href='/entry/show/{{ job.target.id }}/'>{{ job.target.name }}</a></td>
             {% endif %}

--- a/templates/list_jobs.html
+++ b/templates/list_jobs.html
@@ -85,6 +85,10 @@
               エクスポート
             {% elif job.operation|divmod:100 == JOB.OPERATION.RESTORE %}
               復旧
+            {% elif job.operation|divmod:100 == JOB.OPERATION.EDIT_ENTITY %}
+              編集
+            {% elif job.operation|divmod:100 == JOB.OPERATION.DELETE_ENTITY %}
+              削除
             {% endif %}
             </td>
 

--- a/templates/list_jobs.html
+++ b/templates/list_jobs.html
@@ -85,6 +85,8 @@
               エクスポート
             {% elif job.operation|divmod:100 == JOB.OPERATION.RESTORE %}
               復旧
+            {% elif job.operation|divmod:100 == JOB.OPERATION.CREATE_ENTITY %}
+              作成
             {% elif job.operation|divmod:100 == JOB.OPERATION.EDIT_ENTITY %}
               編集
             {% elif job.operation|divmod:100 == JOB.OPERATION.DELETE_ENTITY %}

--- a/templates/navigation.html
+++ b/templates/navigation.html
@@ -17,16 +17,28 @@
 
     {% elif object.objtype == navigator.acl_objtype.entity %}
       <li class="breadcrumb-item"><a href="/entity/">エンティティ一覧</a></li>
-      <li class="breadcrumb-item">{{ entity.name }}</li>
+      {% if entity.status|bitwise_and:STATUS_ENTITY.EDITING %}
+        <li class="breadcrumb-item">{{ entity.name }} [編集中]</li>
+      {% else %}
+        <li class="breadcrumb-item">{{ entity.name }}</li>
+      {% endif %}
 
     {% elif path == 'create_entry' %}
       <li class="breadcrumb-item"><a href="/entity/">エンティティ一覧</a></li>
-      <li class="breadcrumb-item"><a href='/entry/{{ entity.id }}'>{{ entity.name }}</a></li>
+      {% if entity.status|bitwise_and:STATUS_ENTITY.EDITING %}
+        <li class="breadcrumb-item"><a href='/entry/{{ entity.id }}'>{{ entity.name }} [編集中]</a></li>
+      {% else %}
+        <li class="breadcrumb-item"><a href='/entry/{{ entity.id }}'>{{ entity.name }}</a></li>
+      {% endif %}
       <li class="breadcrumb-item">新規エントリ作成</li>
 
     {% elif path == 'index_entry' %}
       <li class="breadcrumb-item"><a href="/entity/">エンティティ一覧</a></li>
-      <li class="breadcrumb-item">{{ entity.name }}</li>
+      {% if entity.status|bitwise_and:STATUS_ENTITY.EDITING %}
+        <li class="breadcrumb-item">{{ entity.name }} [編集中]</li>
+      {% else %}
+        <li class="breadcrumb-item">{{ entity.name }}</li>
+      {% endif %}
 
     {% elif path == 'import_entity' %}
       <li class="breadcrumb-item"><a href="/entity/">エンティティ一覧</a></li>
@@ -34,11 +46,19 @@
 
     {% elif path == 'history_entity' %}
       <li class="breadcrumb-item"><a href="/entity/">エンティティ一覧</a></li>
-      <li class="breadcrumb-item">{{ entity.name }}の変更履歴</li>
+      {% if entity.status|bitwise_and:STATUS_ENTITY.EDITING %}
+        <li class="breadcrumb-item">{{ entity.name }} [編集中]の変更履歴</li>
+      {% else %}
+        <li class="breadcrumb-item">{{ entity.name }}の変更履歴</li>
+      {% endif %}
 
     {% elif path == 'import_entry' %}
       <li class="breadcrumb-item"><a href="/entity/">エンティティ一覧</a></li>
-      <li class="breadcrumb-item"><a href="/entry/{{ entity.id }}">{{ entity.name }}</a></li>
+      {% if entity.status|bitwise_and:STATUS_ENTITY.EDITING %}
+        <li class="breadcrumb-item"><a href="/entry/{{ entity.id }}">{{ entity.name }} [編集中]</a></li>
+      {% else %}
+        <li class="breadcrumb-item"><a href="/entry/{{ entity.id }}">{{ entity.name }}</a></li>
+      {% endif %}
       <li class="breadcrumb-item">インポート</li>
 
     {% elif path == 'create_entity' %}
@@ -47,7 +67,11 @@
 
     {% elif path == 'edit_entity' %}
       <li class="breadcrumb-item"><a href="/entity/">エンティティ一覧</a></li>
-      <li class="breadcrumb-item"><a href='/entry/{{ entity.id }}'>{{ entity.name }}</a></li>
+      {% if entity.status|bitwise_and:STATUS_ENTITY.EDITING %}
+        <li class="breadcrumb-item"><a href='/entry/{{ entity.id }}'>{{ entity.name }} [編集中]</a></li>
+      {% else %}
+        <li class="breadcrumb-item"><a href='/entry/{{ entity.id }}'>{{ entity.name }}</a></li>
+      {% endif %}
       <li class="breadcrumb-item">エンティティの編集</li>
 
     {% elif path == 'acl' %}


### PR DESCRIPTION
Editing or deleting entity sometimes takes long time so the process makes UX worse. I would like to let it a background processing with Celery not to block a client, such as following:

![image](https://user-images.githubusercontent.com/191684/107789756-58a9a680-6d95-11eb-86aa-a672cce4b9c2.png)
