### PR TITLE
Use codecov to visualize coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install tox coverage
+            pip install tox coverage codecov
       - run:
           name: Wait for MySQL is available
           command: dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
@@ -50,6 +50,11 @@ jobs:
           paths:
             - venv
             - .tox/py36
+      - run:
+          name: Coverage
+          command: |
+            . venv/bin/activate
+            codecov
 
   python35:
     docker:
@@ -101,11 +106,6 @@ jobs:
           paths:
             - venv
             - .tox/py35
-      - run:
-          name: Coverage
-          command: |
-            . venv/bin/activate
-            ./coverage.sh
 
   pep8:
     docker:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,12 +1,5 @@
 [run]
 branch = True
-source =
-  acl
-  airone
-  dashboard
-  entity
-  entry
-  group
 omit =
   */migrations/*
   */tests/*

--- a/tox.ini
+++ b/tox.ini
@@ -15,21 +15,21 @@ commands =
   pip install -r requirements-dev.txt
   python manage.py makemigrations
   python manage.py migrate
-  python manage.py test
-  python manage.py test tools.tests
+  coverage run manage.py test
+  coverage run manage.py test tools.tests
+  coverage report
 whitelist_externals = rm
 
 [testenv:py35]
 # settings for selecting backend-db to use in test
-passenv = AIRONE_BACKEND_DB
+passenv = AIRONE_BACKEND_DB CODECOV_*
 commands =
   rm -f db.sqlite3
   pip install -r requirements-dev.txt
   python manage.py makemigrations
   python manage.py migrate
-  coverage run manage.py test
-  coverage run manage.py test tools.tests
-  coverage xml
+  python manage.py test
+  python manage.py test tools.tests
 whitelist_externals = rm
 
 [testenv:pep8]


### PR DESCRIPTION
`Coverage` CI step doesn't work fine now, for e.g.:
```
...
curl: no URL specified!
curl: try 'curl --help' or 'curl --manual' for more information
```
https://app.circleci.com/pipelines/github/dmm-com/airone/112/workflows/f1d03d20-9004-4985-9214-f4ed111bb386/jobs/317

And also [codecov](https://about.codecov.io/) should help us to show visualized coverage without charges(its free on OSS repos). So I would like to replace existing coverage reporting stuff with codecovm like below:

![image](https://user-images.githubusercontent.com/191684/109675776-70699300-7bbb-11eb-9304-ea4013e8cf3b.png)
https://codecov.io/gh/dmm-com/airone/tree/0540b9431f5323f9cd5bb0eda8b656d1940dd0ba

TODO

- [x] Investigate why some packages don't appear in coverage-xml result. => `source` directive on `.coveragerc`
- [x] Describe how to install it