### PR TITLE
Update CHANGELOG for change of #83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## In development
+
+### Changed
+
+* Changed implementation of Entity to create, edit and delete it at Celery.
+
 ## v2.6.0
 
 ### Added


### PR DESCRIPTION
At the #83, we overlooked that CHANGELOG wasn't updated at that PR. This
commit writes its change to the CHANGELOG.