### PR TITLE
Support '^' and '$' on some search features

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -211,21 +211,9 @@ def _get_regex_pattern(keyword):
         str: Regular expression pattern of argument
 
     """
-    chars = prepend_escape_character(CONFIG.ESCAPE_CHARACTERS, keyword)
-
-    # Auto-fill '.*' if it doesn't have '^' and/or '$' explicitly
-    first = '.*'
-    last = '.*'
-    if len(chars) > 1:
-        if chars[0] == '^':
-            first = ''
-        if chars[-1] == '$':
-            last = ''
-
-    return '%s%s%s' % (
-        first,
-        ''.join(['[%s%s]' % (x.lower(), x.upper()) if x.isalpha() else x for x in chars]),
-        last)
+    return '.*%s.*' % ''.join(['[%s%s]' % (
+        x.lower(), x.upper()) if x.isalpha() else x for x in prepend_escape_character(
+        CONFIG.ESCAPE_CHARACTERS, keyword)])
 
 
 def prepend_escape_character(escape_character_list, keyword):

--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -211,9 +211,21 @@ def _get_regex_pattern(keyword):
         str: Regular expression pattern of argument
 
     """
-    return '.*%s.*' % ''.join(['[%s%s]' % (
-        x.lower(), x.upper()) if x.isalpha() else x for x in prepend_escape_character(
-        CONFIG.ESCAPE_CHARACTERS, keyword)])
+    chars = prepend_escape_character(CONFIG.ESCAPE_CHARACTERS, keyword)
+
+    # Auto-fill '.*' if it doesn't have '^' and/or '$' explicitly
+    first = '.*'
+    last = '.*'
+    if len(chars) > 1:
+        if chars[0] == '^':
+            first = ''
+        if chars[-1] == '$':
+            last = ''
+
+    return '%s%s%s' % (
+        first,
+        ''.join(['[%s%s]' % (x.lower(), x.upper()) if x.isalpha() else x for x in chars]),
+        last)
 
 
 def prepend_escape_character(escape_character_list, keyword):

--- a/airone/tests/test_elasticsearch.py
+++ b/airone/tests/test_elasticsearch.py
@@ -1,0 +1,26 @@
+import unittest
+
+from airone.lib import elasticsearch
+
+
+class ElasticSearchTest(unittest.TestCase):
+
+    def test_get_regex_pattern(self):
+        pattern = elasticsearch._get_regex_pattern('keyword')
+        self.assertEqual(pattern, '.*[kK][eE][yY][wW][oO][rR][dD].*')
+
+        # Empty
+        pattern = elasticsearch._get_regex_pattern('')
+        self.assertEqual(pattern, '.*.*')
+
+        # A keyword with meta characters should be escaped
+        pattern = elasticsearch._get_regex_pattern('key...word')
+        self.assertEqual(pattern, '.*[kK][eE][yY]\\.\\.\\.[wW][oO][rR][dD].*')
+
+        # A keyword with meta characters with '^' and/or '$'
+        pattern = elasticsearch._get_regex_pattern('^keyword')
+        self.assertEqual(pattern, '^[kK][eE][yY][wW][oO][rR][dD].*')
+        pattern = elasticsearch._get_regex_pattern('keyword$')
+        self.assertEqual(pattern, '.*[kK][eE][yY][wW][oO][rR][dD]$')
+        pattern = elasticsearch._get_regex_pattern('^keyword$')
+        self.assertEqual(pattern, '^[kK][eE][yY][wW][oO][rR][dD]$')

--- a/airone/tests/test_elasticsearch.py
+++ b/airone/tests/test_elasticsearch.py
@@ -16,11 +16,3 @@ class ElasticSearchTest(unittest.TestCase):
         # A keyword with meta characters should be escaped
         pattern = elasticsearch._get_regex_pattern('key...word')
         self.assertEqual(pattern, '.*[kK][eE][yY]\\.\\.\\.[wW][oO][rR][dD].*')
-
-        # A keyword with meta characters with '^' and/or '$'
-        pattern = elasticsearch._get_regex_pattern('^keyword')
-        self.assertEqual(pattern, '^[kK][eE][yY][wW][oO][rR][dD].*')
-        pattern = elasticsearch._get_regex_pattern('keyword$')
-        self.assertEqual(pattern, '.*[kK][eE][yY][wW][oO][rR][dD]$')
-        pattern = elasticsearch._get_regex_pattern('^keyword$')
-        self.assertEqual(pattern, '^[kK][eE][yY][wW][oO][rR][dD]$')

--- a/entry/settings.py
+++ b/entry/settings.py
@@ -14,6 +14,6 @@ CONFIG = Settings({
     'OR_SEARCH_CHARACTER': '|',
     'ESCAPE_CHARACTERS': ['(', ')', '<', '"', '{', '[', '#', '~', '@', '+', '*', '.', '?'],
     'ESCAPE_CHARACTERS_REFERRALS_ENTRY': ['$', '(', '^', '|', '[', '+', '*', '.', '?'],
-    'ESCAPE_CHARACTERS_ENTRY_LIST': ['$', '(', '^', '\\', '|', '[', '+', '*', '.', '?'],
+    'ESCAPE_CHARACTERS_ENTRY_LIST': ['(', '\\', '|', '[', '+', '*', '.', '?'],
     'TIME_FORMAT': '%Y-%m-%dT%H:%M:%S',
 })

--- a/entry/tests/test_api_v1.py
+++ b/entry/tests/test_api_v1.py
@@ -47,6 +47,15 @@ class ViewTest(AironeViewTest):
         self.assertTrue(
             all([x['name'] == 'e-10' or x['name'] == 'e-100' for x in resp.json()['results']]))
 
+        # send request with keyword parameter containing meta characters.
+        resp = self.client.get(reverse('entry:api_v1:get_entries', args=[entity.id]),
+                               {'keyword': '^e-10$'})
+        self.assertEqual(resp.status_code, 200)
+
+        self.assertTrue('results' in resp.json())
+        self.assertEqual(len(resp.json()['results']), 1)
+        self.assertEqual(resp.json()['results'][0]['name'], 'e-10')
+
         # send request with invalid keyword parameter
         resp = self.client.get(reverse('entry:api_v1:get_entries', args=[entity.id]),
                                {'keyword': 'invalid-keyword'})
@@ -65,9 +74,8 @@ class ViewTest(AironeViewTest):
         """
         Check for cases with special characters
         """
-        add_chars = ['!', '"', '#', '$', '%', '\'', '(', ')', '-', '=', '^', '~', '@', '`',
-                     '[', ']', '{', '}', ';', '+', ':', '*', ',', '<', '>', '.', '/', '?', '_', ' '
-                     '&', '|']
+        add_chars = ['!', '"', '#', '%', '\'', '(', ')', '-', '=', '~', '@', '`', '[', ']', '{',
+                     '}', ';', '+', ':', '*', ',', '<', '>', '.', '/', '?', '_', ' ', '&', '|']
         test_suites = []
         for i, add_char in enumerate(add_chars):
             entry_name = 'test%s%s' % (i, add_char)


### PR DESCRIPTION
Support `^`, `$` meta characters on some search features to filter a lot of entries with certain entry names. 