### PR TITLE
Changed to show unauthorized entity on the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 * Changed implementation of Entity to create, edit and delete it at Celery.
+* Changed to show unauthorized entity on the dashboard
 
 ## v2.6.0
 

--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -15,7 +15,7 @@ from user.models import User, History
 from job.models import Job, JobOperation
 
 from airone.lib.types import AttrTypes, AttrTypeValue
-from airone.lib.acl import ACLObjType, ACLType
+from airone.lib.acl import ACLObjType
 from django.conf import settings
 
 
@@ -156,20 +156,17 @@ def http_file_upload(func):
 
 
 def render(request, template, context={}):
-    if User.objects.filter(id=request.user.id).exists():
-        user = User.objects.get(id=request.user.id)
-
-        # added default parameters for navigate
-        entity_objects = entity_models.Entity.objects.order_by('name').filter(is_active=True)
-        context['navigator'] = {
-            'entities': [x for x in entity_objects if user.has_permission(x, ACLType.Readable)],
-            'acl_objtype': {
-                'entity': ACLObjType.Entity,
-                'entry': ACLObjType.Entry,
-                'attrbase': ACLObjType.EntityAttr,
-                'attr': ACLObjType.EntryAttr,
-            }
+    # added default parameters for navigate
+    entity_objects = entity_models.Entity.objects.order_by('name').filter(is_active=True)
+    context['navigator'] = {
+        'entities': [x for x in entity_objects],
+        'acl_objtype': {
+            'entity': ACLObjType.Entity,
+            'entry': ACLObjType.Entry,
+            'attrbase': ACLObjType.EntityAttr,
+            'attr': ACLObjType.EntryAttr,
         }
+    }
 
     # set constants for operation history
     context['OPERATION_HISTORY'] = {

--- a/dashboard/tests/test_view.py
+++ b/dashboard/tests/test_view.py
@@ -93,9 +93,18 @@ class ViewTest(AironeViewTest):
         self.assertEqual(len(resp.context['results']), 0)
 
     def test_show_dashboard_with_airone_user(self):
+        # prepare the data of the imported file
+        obj = yaml.safe_load(self.open_fixture_file('entry.yaml'))
+        obj_attrv_list = sorted(obj['AttributeValue'], key=lambda x: x['id'], reverse=True)
+        obj_entity_list = sorted(obj['Entity'], key=lambda x: x['id'])
+
         resp = self.client.get(reverse('dashboard:index'))
         self.assertEqual(resp.status_code, 200)
         self.assertIsNotNone(resp.context["version"])
+        for i, x in enumerate(resp.context["last_entries"]):
+            self.assertEqual(x['attr_value'].id, obj_attrv_list[i]['id'])
+        for i, x in enumerate(resp.context["navigator"]['entities']):
+            self.assertEqual(x.id, obj_entity_list[i]['id'])
 
     def test_show_dashboard_with_django_user(self):
         # create test user which is authenticated by Django, not AirOne

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -32,8 +32,9 @@ def index(request):
     context = {}
     if request.user.is_authenticated() and User.objects.filter(id=request.user.id).exists():
         history = []
+        # Sort by newest attribute update date (id is auto increment)
         for attr_value in AttributeValue.objects.order_by(
-                'created_time').reverse()[:CONFIG.LAST_ENTRY_HISTORY]:
+                'id').reverse()[:CONFIG.LAST_ENTRY_HISTORY]:
             parent_attr = attr_value.parent_attr
             parent_entry = parent_attr.parent_entry
 


### PR DESCRIPTION
It took a long time to browse the dashboard page.

The causes and changes are as follows.
- There was sorting by created_time to display the update history of AttributeValue.
Since the ID of AttributeValue is automatically incremented, the ID and created_time are equal.
Changed to search by ID, because that has an index.

- There was checking the permissions to display the entity in the navigator.
Changed to show unauthorized entity as well.
Even if you open unauthorized entity, error page will be displayed.