### PR TITLE
Added the function to make a query request to the slave DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## In development
 
-### Changed
+### Added
+* Added the function to make a query request to the slave DB
 
+### Changed
+* Changed requesting DB to slave at Entry.get_referred_objects
+* Changed requesting DB to slave at User.has_permission
 * Changed implementation of Entity to create, edit and delete it at Celery.
 * Changed to show unauthorized entity on the dashboard
 

--- a/airone/lib/db.py
+++ b/airone/lib/db.py
@@ -1,0 +1,14 @@
+import random
+from django.conf import settings
+
+
+def get_slave_db():
+    '''Change the DB query request to Slave.
+    The slave DB has a replication delay compared to the master DB.
+    There is a problem if change all read query requests to slaves.
+    Use this function only for query requests that can afford replication delays.
+
+    Usage:
+    Entry.objects.using(get_slave_db()).filter(...)
+    '''
+    return random.choice(settings.AIRONE['DB_SLAVES'])

--- a/airone/tests/test_db.py
+++ b/airone/tests/test_db.py
@@ -1,0 +1,21 @@
+import unittest
+
+from airone.lib.db import get_slave_db
+from django.conf import settings
+
+
+class AirOneDBTest(unittest.TestCase):
+
+    def setUp(self):
+        # this saves original configurations to be able to retrieve them
+        self.orig_conf_db_slaves = settings.AIRONE['DB_SLAVES']
+
+        # this enables do profiling
+        settings.AIRONE['DB_SLAVES'] = ['slave1', 'slave2']
+
+    def tearDown(self):
+        # this retrieves original configurations
+        settings.AIRONE['ENABLE_PROFILE'] = self.orig_conf_db_slaves
+
+    def test_get_slave_db(self):
+        self.assertIn(get_slave_db(), settings.AIRONE['DB_SLAVES'])

--- a/api_v1/entry/views.py
+++ b/api_v1/entry/views.py
@@ -2,6 +2,7 @@ import pytz
 
 from api_v1.auth import AironeTokenAuth
 from airone.lib.profile import airone_profile
+from airone.lib.db import get_slave_db
 from django.conf import settings
 from django.db.models import Q
 
@@ -92,7 +93,7 @@ class EntryReferredAPI(APIView):
             query &= Q(schema__name=param_entity)
 
         ret_data = []
-        for entry in Entry.objects.filter(query):
+        for entry in Entry.objects.using(get_slave_db()).filter(query):
             ret_data.append({
                 'id': entry.id,
                 'entity': {'id': entry.schema.id, 'name': entry.schema.name},

--- a/entry/models.py
+++ b/entry/models.py
@@ -18,6 +18,7 @@ from airone.lib.types import AttrTypeValue
 from airone.lib.elasticsearch import (
     ESS, make_query, execute_query, make_search_results, is_date_check)
 from airone.lib import auto_complement
+from airone.lib.db import get_slave_db
 
 from .settings import CONFIG
 
@@ -996,7 +997,7 @@ class Entry(ACLBase):
         """
         This returns objects that refer current Entry in the AttributeValue
         """
-        ids = AttributeValue.objects.filter(
+        ids = AttributeValue.objects.using(get_slave_db()).filter(
                 Q(referral=self, is_latest=True) |
                 Q(referral=self, parent_attrv__is_latest=True)
                 ).values_list('parent_attr__parent_entry', flat=True)
@@ -1006,7 +1007,7 @@ class Entry(ACLBase):
         if entity_name:
             query &= Q(schema__name=entity_name)
 
-        return Entry.objects.filter(query)
+        return Entry.objects.using(get_slave_db()).filter(query)
 
     def may_append_attr(self, attr):
         """


### PR DESCRIPTION
Currently, AirOne is requesting queries from MasterDB for both writes and reads.
The load on MasterDB becomes a bottleneck when scaling.

The slave DB has a replication delay compared to the master DB.
There is a problem if change all read query requests to slaves.

To solve this, we added a function to change some DB requests to slaves.

- target
```
Entry.get_referred_objects
User.has_permission
```