### PR TITLE
Fixed a bug at the background processing of creating Entry

### DIFF
--- a/airone/lib/test.py
+++ b/airone/lib/test.py
@@ -2,8 +2,10 @@ import inspect
 import sys
 import os
 
+from airone.lib.types import AttrTypeValue
 from django.test import TestCase, Client, override_settings
 from django.conf import settings
+from entity.models import Entity, EntityAttr
 from user.models import User
 from .elasticsearch import ESS
 
@@ -30,6 +32,36 @@ class AironeTestCase(TestCase):
         for fname in os.listdir(settings.AIRONE['FILE_STORE_PATH']):
             os.unlink(os.path.join(settings.AIRONE['FILE_STORE_PATH'], fname))
 
+    def create_entity(self, user, name, attrs=[], is_public=True):
+        """
+        This is a helper method to create Entity for test. This method has following parameters.
+        * user      : describes user instance which will be registered on creating Entity
+        * name      : describes name of Entity to be created
+        * is_public : same parameter of creating Entity [True by default]
+        * attrs     : describes EntityAttrs to attach creating Entity
+                      and expects to have following information
+          - name : indicates name of creating EntityAttr
+          - type : indicates type of creating EntityAttr [string by default]
+          - is_mandatory : same parameter of EntityAttr [False by default]
+        """
+        def _get_entity_attr_params(attr_info, attr_param, default_value):
+            if attr_param in attr_info and attr_info[attr_param]:
+                return attr_info[attr_param]
+            else:
+                return default_value
+
+        entity = Entity.objects.create(name=name, created_user=user, is_public=is_public)
+        for attr_info in attrs:
+            entity_attr = EntityAttr.objects.create(**{
+                'name': attr_info['name'],
+                'type': _get_entity_attr_params(attr_info, 'type', AttrTypeValue['string']),
+                'is_mandatory': _get_entity_attr_params(attr_info, 'is_mandatory', False),
+                'parent_entity': entity,
+                'created_user': user,
+            })
+            entity.attrs.add()
+
+        return entity
 
 class AironeViewTest(AironeTestCase):
     def setUp(self):

--- a/airone/lib/test.py
+++ b/airone/lib/test.py
@@ -52,7 +52,7 @@ class AironeTestCase(TestCase):
 
         entity = Entity.objects.create(name=name, created_user=user, is_public=is_public)
         for attr_info in attrs:
-            entity_attr = EntityAttr.objects.create(**{
+            EntityAttr.objects.create(**{
                 'name': attr_info['name'],
                 'type': _get_entity_attr_params(attr_info, 'type', AttrTypeValue['string']),
                 'is_mandatory': _get_entity_attr_params(attr_info, 'is_mandatory', False),
@@ -62,6 +62,7 @@ class AironeTestCase(TestCase):
             entity.attrs.add()
 
         return entity
+
 
 class AironeViewTest(AironeTestCase):
     def setUp(self):

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -114,10 +114,7 @@ def create_entry_attrs(self, job_id):
             # has already been created or is creating by other process. In that case, this job
             # do nothing about that Attribute instance.
             attr = entry.add_attribute_from_base(entity_attr, user)
-            if not attr:
-                continue
-
-            if not any([int(x['id']) == attr.schema.id for x in recv_data['attrs']]):
+            if not attr or not any([int(x['id']) == attr.schema.id for x in recv_data['attrs']]):
                 continue
 
             # When job is canceled during this processing, abort it after deleting the created entry

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -109,8 +109,14 @@ def create_entry_attrs(self, job_id):
             if not entity_attr.is_active or not user.has_permission(entity_attr, ACLType.Readable):
                 continue
 
-            # create Attibute object that contains AttributeValues
+            # This creates Attibute object that contains AttributeValues.
+            # But the add_attribute_from_base may return None when target Attribute instance
+            # has already been created or is creating by other process. In that case, this job
+            # do nothing about that Attribute instance.
             attr = entry.add_attribute_from_base(entity_attr, user)
+            if not attr:
+                continue
+
             if not any([int(x['id']) == attr.schema.id for x in recv_data['attrs']]):
                 continue
 


### PR DESCRIPTION
Close: https://github.com/dmm-com/airone/issues/95

The background processing of creating Entry was not idempotent. It
means once its action was run duplicately, an AttributeError exception
would be happened.

The previous its implementation didn't care about that
Entry.add_attribute_from_base might return None when the target entry
has already created or is under processing to be created.
By this commit, the background processing of creating entry will be
idempotent (Once multiple processes run its processing simultaneously or
duplicately, the processing will be done properly and result will be
same).