### PR TITLE
Fixed not being redirected to the original URL after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Changed implementation of Entity to create, edit and delete it at Celery.
 * Changed to show unauthorized entity on the dashboard
 
+### Fixed
+* Fixed not being redirected to the original URL after login
+
 ## v2.6.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Changelog
 
+## In development
+
+### Fixed
+* Fixed not being redirected to the original URL after login
+
 ## v2.7.0
 
 ### Changed
 * Changed implementation of Entity to create, edit and delete it at Celery.
 * Changed to show unauthorized entity on the dashboard
-
-### Fixed
-* Fixed not being redirected to the original URL after login
 
 ## v2.6.0
 

--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -1,6 +1,7 @@
 import json
 import importlib
 import urllib.parse
+from urllib.parse import quote
 import codecs
 
 from django.http import HttpResponseRedirect
@@ -30,7 +31,8 @@ def http_get(func):
             return HttpResponse('Invalid HTTP method is specified', status=400)
 
         if not request.user.is_authenticated():
-            return HttpResponseSeeOther('/dashboard/login?next=%s' % request.path)
+            return HttpResponseSeeOther('/dashboard/login?next=%s?%s' %
+                                        (request.path, quote(request.GET.urlencode())))
 
         return func(*args, **kwargs)
     return wrapper

--- a/airone/tests/test_http.py
+++ b/airone/tests/test_http.py
@@ -1,0 +1,33 @@
+import unittest
+
+from airone.lib.http import http_get
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+
+
+class AirOneHTTPTest(unittest.TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_airone_http_get_decorator(self):
+
+        @http_get
+        def mock_handler(request):
+            return 'mock_response'
+
+        test_suites = [
+            {'get_url': '/test', 'resp_url': '/dashboard/login?next=/test?'},
+            {'get_url': '/日本語', 'resp_url': '/dashboard/login?next=/%E6%97%A5%E6%9C%AC%E8%AA%9E?'},
+            {'get_url': '/test?query1=1&query2=test',
+             'resp_url': '/dashboard/login?next=/test?query1%3D1%26query2%3Dtest'},
+        ]
+
+        for i in test_suites:
+            request = self.factory.get(i['get_url'])
+            request.user = AnonymousUser()
+
+            resp = mock_handler(request)
+
+            self.assertEqual(resp.status_code, 303)
+            self.assertEqual(resp.url, i['resp_url'])


### PR DESCRIPTION
If you visit without authenticated, will be redirected to the login page.
At that time, put the path in 'next' field of query string.
However, there was a problem that the original query string was not included.

Changed to include the query string in 'next' field.

e.g.) `https://AirOneURL/dashboard/search/?query=vmXXXX`

- before
`https://AirOneURL/dashboard/login/?next=/dashboard/search/`

- after
`https://AirOneURL/dashboard/login/?next=/dashboard/search/?query%3DvmXXXX`