### PR TITLE
Added handler to report celery exception errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## In development
 
+### Added
+* Added handler to report celery exception errors
+
 ### Fixed
 * Fixed not being redirected to the original URL after login
 


### PR DESCRIPTION
Email settings are required.
If there is no mail setting, it will not be processed.