### PR TITLE
Fix getting coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ commands =
   pip install -r requirements-dev.txt
   python manage.py makemigrations
   python manage.py migrate
-  coverage run manage.py test
   coverage run manage.py test tools.tests
+  coverage run manage.py test
   coverage report
 whitelist_externals = rm
 
@@ -28,8 +28,8 @@ commands =
   pip install -r requirements-dev.txt
   python manage.py makemigrations
   python manage.py migrate
-  python manage.py test
   python manage.py test tools.tests
+  python manage.py test
 whitelist_externals = rm
 
 [testenv:pep8]


### PR DESCRIPTION
We got a lower coverage than what we expect:
https://app.circleci.com/pipelines/github/dmm-com/airone/144/workflows/e4d10808-5f5a-4433-a092-4dcbe30f65d7/jobs/423

because the result is generated by `coverage run manage.py test tools.tests`, executed after `coverage run manage.py test`. So it fixes the test order to get correct coverage.
e.g. https://app.circleci.com/pipelines/github/dmm-com/airone/151/workflows/a15c87be-281a-4670-8e53-fa45637c70de/jobs/440