### PR TITLE
Advansed search permalink

### DIFF
--- a/dashboard/tests/test_view.py
+++ b/dashboard/tests/test_view.py
@@ -176,7 +176,12 @@ class ViewTest(AironeViewTest):
         # test to show advanced_search_result page
         resp = self.client.get(reverse('dashboard:advanced_search_result'), {
             'entity[]': [x.id for x in Entity.objects.filter(name__regex='^entity-')],
-            'attr[]': ['attr'],
+            'attr[]': ['attr'],  # an older param will be deprecated
+        })
+        self.assertEqual(resp.status_code, 200)
+        resp = self.client.get(reverse('dashboard:advanced_search_result'), {
+            'entity[]': [x.id for x in Entity.objects.filter(name__regex='^entity-')],
+            'attrinfo': json.dumps([{'name': 'attr'}]),  # A newer param
         })
         self.assertEqual(resp.status_code, 200)
 
@@ -226,8 +231,22 @@ class ViewTest(AironeViewTest):
                 job.get_cache()
 
         # test to show advanced_search_result page without mandatory params
+        resp = self.client.get(reverse('dashboard:advanced_search_result'), {})
+        self.assertEqual(resp.status_code, 400)
+        resp = self.client.get(reverse('dashboard:advanced_search_result'), {
+            'entity[]': [x.id for x in Entity.objects.filter(name__regex='^entity-')],
+        })
+        self.assertEqual(resp.status_code, 400)
+        resp = self.client.get(reverse('dashboard:advanced_search_result'), {
+            'is_all_entities': 'true',
+        })
+        self.assertEqual(resp.status_code, 400)
         resp = self.client.get(reverse('dashboard:advanced_search_result'), {
             'attr[]': ['attr'],
+        })
+        self.assertEqual(resp.status_code, 400)
+        resp = self.client.get(reverse('dashboard:advanced_search_result'), {
+            'attrinfo': json.dumps([{'name': 'attr'}]),
         })
         self.assertEqual(resp.status_code, 400)
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -149,6 +149,7 @@ def advanced_search_result(request):
     is_all_entities = request.GET.get('is_all_entities') == 'true'
     has_referral = request.GET.get('has_referral') == 'true'
     attrinfo = request.GET.get('attrinfo')
+    entry_name = request.GET.get('entry_name')
 
     # check entity params
     if not is_all_entities:
@@ -186,11 +187,13 @@ def advanced_search_result(request):
                                         entities,
                                         hint_attrs,
                                         CONFIG.MAXIMUM_SEARCH_RESULTS,
+                                        entry_name,
                                         hint_referral=has_referral),
         'max_num': CONFIG.MAXIMUM_SEARCH_RESULTS,
         'entities': ','.join([str(x) for x in entities]),
         'has_referral': has_referral,
         'is_all_entities': is_all_entities,
+        'entry_name': entry_name,
     })
 
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -181,7 +181,7 @@ def advanced_search_result(request):
         entities = recv_entity
 
     return render(request, 'advanced_search_result.html', {
-        'attrs': attr_names,
+        'hint_attrs': hint_attrs,
         'results': Entry.search_entries(user,
                                         entities,
                                         hint_attrs,

--- a/templates/advanced_search/contents.js
+++ b/templates/advanced_search/contents.js
@@ -82,9 +82,11 @@ $('.narrow_down_option').keyup(function() {
 });
 
 $('#do_search').on('click', function() {
-  var attrs = $('#selected_attr').children().map(function() {
-    return 'attr[]=' + encodeURIComponent(this.value);
-  }).get().join('&');
+  // Build URL encoded JSON stringified attrinfo
+  const attrinfo = $('#selected_attr').children().map(function() {
+    return {'name': this.value};
+  }).get();
+  const encoded_attrinfo = encodeURIComponent(JSON.stringify(attrinfo));
 
   var entities = $('#selected_entity').children().map(function() {
     return 'entity[]=' + encodeURIComponent(this.value);
@@ -92,7 +94,7 @@ $('#do_search').on('click', function() {
 
   var is_all_entities = $('#select_all_entity').is(':checked');
 
-  location.href = `/dashboard/advanced_search_result?has_referral=${ $('#add_referral').is(':checked') }&is_all_entities=${ is_all_entities }&${ attrs }&${ entities }`;
+  location.href = `/dashboard/advanced_search_result?has_referral=${ $('#add_referral').is(':checked') }&is_all_entities=${ is_all_entities }&attrinfo=${ encoded_attrinfo }&${ entities }`;
 });
 
 $('#select_all_entity').on('click', function() {

--- a/templates/advanced_search/result.html
+++ b/templates/advanced_search/result.html
@@ -36,7 +36,7 @@
     <tr>
       <th>
         Name<br/>
-        <input type='text' class='input-sm narrow_down_entries hint_entry_name' attrname='{{ attrname }}'></input>
+        <input type='text' class='input-sm narrow_down_entries hint_entry_name' attrname='{{ attrname }}' value="{{ entry_name|default_if_none:'' }}"></input>
       </th>
       {% for hint_attr in hint_attrs %}
       <th>

--- a/templates/advanced_search/result.html
+++ b/templates/advanced_search/result.html
@@ -38,10 +38,10 @@
         Name<br/>
         <input type='text' class='input-sm narrow_down_entries hint_entry_name' attrname='{{ attrname }}'></input>
       </th>
-      {% for attrname in attrs %}
+      {% for hint_attr in hint_attrs %}
       <th>
-        {{ attrname }}<br/>
-        <input type='text' class='input-sm narrow_down_entries hint_attr_value' attrname='{{ attrname }}'></input>
+        {{ hint_attr.name }}<br/>
+        <input type='text' class='input-sm narrow_down_entries hint_attr_value' attrname='{{ hint_attr.name }}' value="{{ hint_attr.keyword|default_if_none:'' }}"></input>
       </th>
       {% endfor %}
 
@@ -58,8 +58,8 @@
     <tr>
       <th><a href='/entry/show/{{ result.entry.id }}'>{{ result.entry.name }} [{{ result.entity.name }}]</a></th>
 
-      {% for attrname in attrs %}
-        {% with result.attrs|get_item:attrname as attr %}
+      {% for hint_attr in hint_attrs %}
+        {% with result.attrs|get_item:hint_attr.name as attr %}
           {% if attr.type == attr_type.string %}
             <td>{{ attr.value }}</td>
 
@@ -200,8 +200,8 @@
       <div class="col-md-5">
         <label class="col-label">検索対象の属性</label>
         <select multiple="on" id="modal_condition_selected_attr" class="form-control" size='9'>
-          {% for attrname in attrs %}
-          <option value='{{ attrname }}'>{{ attrname }}</option>
+          {% for hint_attr in hint_attrs %}
+          <option value='{{ hint_attr.name }}'>{{ hint_attr.name }}</option>
           {% endfor %}
         </select>
       </div>

--- a/templates/advanced_search/result.js
+++ b/templates/advanced_search/result.js
@@ -170,6 +170,22 @@ $(document).ready(function() {
         $('#entry_count').text(`(${ data.result.ret_count } 件)`);
 
         reconstruct_tbody(data.result.ret_values);
+
+        // XXX preserve permalnk to the advanced_search view (not entry-search API)
+        // to filter search results with attribute keywords experimentally
+        const attrinfo = get_attrinfo();
+        let params = ['attrinfo=' + encodeURIComponent(JSON.stringify(attrinfo))];
+        for (const entity of '{{ entities }}'.split(',')) {
+            params.push('entity[]=' +  entity);
+        }
+        for (const attr of attrinfo) {
+          params.push('attr[]=' +  attr.name);
+        }
+        {% if has_referral %}
+        params.push('has_referral=' + $('.narrow_down_referral').val());
+        {% endif %}
+        window.history.pushState('', '', 'advanced_search_result?' + params.join('&'));
+
       }).fail(function(data){
         MessageBox.error(data.responseText);
       });

--- a/templates/advanced_search/result.js
+++ b/templates/advanced_search/result.js
@@ -177,6 +177,7 @@ $(document).ready(function() {
         for (const entity of '{{ entities }}'.split(',')) {
             params.push('entity[]=' +  entity);
         }
+        params.push('entry_name=' + $('.hint_entry_name').val());
         params.push('attrinfo=' + encodeURIComponent(JSON.stringify(get_attrinfo())));
         {% if has_referral %}
         params.push('has_referral=' + $('.narrow_down_referral').val());

--- a/templates/advanced_search/result.js
+++ b/templates/advanced_search/result.js
@@ -171,16 +171,13 @@ $(document).ready(function() {
 
         reconstruct_tbody(data.result.ret_values);
 
-        // XXX preserve permalnk to the advanced_search view (not entry-search API)
-        // to filter search results with attribute keywords experimentally
-        const attrinfo = get_attrinfo();
-        let params = ['attrinfo=' + encodeURIComponent(JSON.stringify(attrinfo))];
+        // preserve a permalnk via pushState API to the advanced_search view (not entry-search API)
+        // to filter search results with attribute keywords
+        let params = [];
         for (const entity of '{{ entities }}'.split(',')) {
             params.push('entity[]=' +  entity);
         }
-        for (const attr of attrinfo) {
-          params.push('attr[]=' +  attr.name);
-        }
+        params.push('attrinfo=' + encodeURIComponent(JSON.stringify(get_attrinfo())));
         {% if has_referral %}
         params.push('has_referral=' + $('.narrow_down_referral').val());
         {% endif %}

--- a/templates/advanced_search/result.js
+++ b/templates/advanced_search/result.js
@@ -99,8 +99,8 @@ function reconstruct_tbody(results) {
 
     new_elem_entry.append(`<th><a href='/entry/show/${ result.entry.id }/'>${ result.entry.name } [${ result.entity.name}]</a></th>`);
 
-    {% for attrname in attrs %}
-      new_elem_entry.append(make_attr_elem(result.attrs['{{ attrname }}']));
+    {% for hint_attr in hint_attrs %}
+      new_elem_entry.append(make_attr_elem(result.attrs['{{ hint_attr.name }}']));
     {% endfor %}
 
     {% if has_referral %}


### PR DESCRIPTION
# Overview

The current `/dashboard/advanced_search_result` doesn't accept attr hint parameters so users cannot share filtered search result with something like a permalink.

This PR accepts the parameters, for more details it accepts the parameter, like this:
![image](https://user-images.githubusercontent.com/191684/113478848-642c6a80-94c6-11eb-982e-a0b35cf25298.png)

And also it rewrite URL when users filter their search result (currently using `pushState()`

## What I did

- Introduce `attrinfo` a new param on `/dashboard/advanced_search_result`
  - It has the same structure with `hint_attrs` on `Entry.search_entries()`
  - Its encoded in JSON to represent such a complicated structure on GET request parameter
  - It should be replacement for `attr[]`
- Preserve a permalink with `attrinfo` when a user filters a search result with an attr hint
  - Its performed via HTML5 `pushState()`
- Generate a URL with `attrinfo`, not `attr[]` on `/dashboard/advanced_search`

# Discussion points

It minimizes differences to implement it with adding a new GET parameter `attrinfo` in URL-encoded JSON on the search result view, and use HTML5 `pushState()` API to change users address bar to the permalink. In my opinion, it performs a dirty hack on JS code, we need to discuss how to do it more.

- Do we keep to render the search result via Ajax? Is it really needed in JS? In other words, does it require an async process?
- Do we keep to have 2 similar views on `/dashboard/advanced_search_result` and `/api/v1/entry/search`?
- How do we accept attr-hints parameter on `/dashboard/advanced_search_result`? Its a GET method endpoint, and the parameter should be complicated type `[{"name": "xxx", "keyword": "yyy"}, ...]`