### PR TITLE
Fix #110 show error messages on create-user

### DIFF
--- a/static/js/messagebox.js
+++ b/static/js/messagebox.js
@@ -69,7 +69,7 @@ MessageBox._showMessage = function(text, style) {
     '<button type="button" class="close" data-dismiss="alert" aria-label="close">' +
       '<span aria-hidden="true">&times;</span>' +
     '</button>' + text + '</div>';
-  $(".airone-messagebox").append(content);
+  $(".airone-messagebox").html(content);
   $(".alert").alert();
 };
 

--- a/templates/create_user.html
+++ b/templates/create_user.html
@@ -57,6 +57,8 @@ $('#create-form').submit(function(){
     MessageBox.setNextOnLoadMessage(MessageBox.SUCCESS, `Success to create User "${username}"`);
 
     location.href = '/user/';
+  }).fail(function(resp){
+      MessageBox.error(resp.responseText);
   });
 
   return false;


### PR DESCRIPTION
https://github.com/dmm-com/airone/issues/110

Show error messages on the form when a user failed to create a new user, like this:
![image](https://user-images.githubusercontent.com/191684/114271759-095abc00-9a4e-11eb-948c-aa08f1be51cf.png)
