### PR TITLE
Fixed to keyword entries searched in attribute were not found

### DIFF
--- a/entry/api_v1/views.py
+++ b/entry/api_v1/views.py
@@ -174,7 +174,8 @@ def get_attr_referrals(request, attr_id):
             query_name = Q(name__icontains=keyword)
 
         return [{'id': x.id, 'name': x.name} for x in
-                model.objects.filter(Q(**query_params), query_name)[0:CONFIG.MAX_LIST_REFERRALS]]
+                model.objects.filter(Q(**query_params), query_name).order_by('name')
+                [0:CONFIG.MAX_LIST_REFERRALS]]
 
     def _get_referral_entries(attr):
         return _get_referral_objects(attr, Entry, {

--- a/entry/tests/test_api_v1.py
+++ b/entry/tests/test_api_v1.py
@@ -311,6 +311,15 @@ class ViewTest(AironeViewTest):
         for i, res in enumerate(resp.json()['results']):
             self.assertEqual(res['name'], 'e-%s' % targets[i])
 
+        # send request with keywords that hit more than MAX_LIST_REFERRALS
+        Entry.objects.create(name='e', schema=ref_entity, created_user=admin)
+
+        resp = self.client.get('/entry/api/v1/get_attr_referrals/%d/' % attr.id,
+                               {'keyword': 'e'})
+        self.assertEqual(resp.status_code, 200)
+
+        self.assertEqual(resp.json()['results'][0]['name'], 'e')
+
     def test_get_attr_referrals_with_entity_attr(self):
         """
         This test is needed because the get_attr_referrals API will receive an ID


### PR DESCRIPTION
close: https://github.com/dmm-com/airone/issues/123

When searching for entries, the results are sorted by name to include exact matches.
![image](https://user-images.githubusercontent.com/5561786/117595121-d6a20180-b17a-11eb-812e-43f263f906bb.png)
