### PR TITLE
Fixed the across different databases error of multidb settings

### DIFF
--- a/api_v1/entry/views.py
+++ b/api_v1/entry/views.py
@@ -93,7 +93,8 @@ class EntryReferredAPI(APIView):
             query &= Q(schema__name=param_entity)
 
         ret_data = []
-        for entry in Entry.objects.using(get_slave_db()).filter(query):
+        slave_db = get_slave_db()
+        for entry in Entry.objects.using(slave_db).filter(query):
             ret_data.append({
                 'id': entry.id,
                 'entity': {'id': entry.schema.id, 'name': entry.schema.name},

--- a/entry/models.py
+++ b/entry/models.py
@@ -999,7 +999,8 @@ class Entry(ACLBase):
         """
         This returns objects that refer current Entry in the AttributeValue
         """
-        ids = AttributeValue.objects.using(get_slave_db()).filter(
+        slave_db = get_slave_db()
+        ids = AttributeValue.objects.using(slave_db).filter(
                 Q(referral=self, is_latest=True) |
                 Q(referral=self, parent_attrv__is_latest=True)
                 ).values_list('parent_attr__parent_entry', flat=True)
@@ -1009,7 +1010,7 @@ class Entry(ACLBase):
         if entity_name:
             query &= Q(schema__name=entity_name)
 
-        return Entry.objects.using(get_slave_db()).filter(query)
+        return Entry.objects.using(slave_db).filter(query)
 
     def may_append_attr(self, attr):
         """


### PR DESCRIPTION
In a configuration with multiple slave DBs, the following error occurred in ORM using get_slave_db() such as get_referred_objects().

```
>>> from django.conf import settings
>>> settings.AIRONE['DB_SLAVES']
['slave1', 'slave2']
>>> Entry.objects.get(name='Gibbs').get_referred_objects()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/virtualenv/lib/python3.6/site-packages/django/db/models/query.py", line 250, in __repr__
    data = list(self[:REPR_OUTPUT_SIZE + 1])
  File "/virtualenv/lib/python3.6/site-packages/django/db/models/query.py", line 274, in __iter__
    self._fetch_all()
  File "/virtualenv/lib/python3.6/site-packages/django/db/models/query.py", line 1242, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/virtualenv/lib/python3.6/site-packages/django/db/models/query.py", line 55, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
  File "/virtualenv/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 1129, in execute_sql
    sql, params = self.as_sql()
  File "/virtualenv/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 489, in as_sql
    where, w_params = self.compile(self.where) if self.where is not None else ("", [])
  File "/virtualenv/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 405, in compile
    sql, params = node.as_sql(self, self.connection)
  File "/virtualenv/lib/python3.6/site-packages/django/db/models/sql/where.py", line 81, in as_sql
    sql, params = compiler.compile(child)
  File "/virtualenv/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 405, in compile
    sql, params = node.as_sql(self, self.connection)
  File "/virtualenv/lib/python3.6/site-packages/django/db/models/fields/related_lookups.py", line 99, in as_sql
    return super().as_sql(compiler, connection)
  File "/virtualenv/lib/python3.6/site-packages/django/db/models/lookups.py", line 355, in as_sql
    return super().as_sql(compiler, connection)
  File "/virtualenv/lib/python3.6/site-packages/django/db/models/lookups.py", line 163, in as_sql
    rhs_sql, rhs_params = self.process_rhs(compiler, connection)
  File "/virtualenv/lib/python3.6/site-packages/django/db/models/lookups.py", line 324, in process_rhs
    "Subqueries aren't allowed across different databases. Force "
ValueError: Subqueries aren't allowed across different databases. Force the inner query to be evaluated using `list(inner_query)`.
>>>
```

The cause was that get_slave_db() was executed every time in Subqueries and a different DB was used.
Before executing the query, I ran get_slave_db() to temporarily fix the reference DB.

using() can only specify a single DB.
https://docs.djangoproject.com/en/2.2/topics/db/multi-db/#manually-selecting-a-database


After fixing it, I confirmed that no error occurred.
```
>>> from django.conf import settings
>>> settings.AIRONE['DB_SLAVES']
['slave1', 'slave2']
>>> Entry.objects.get(name='Gibbs').get_referred_objects()
<QuerySet [<Entry: Entry object (2069871)>, <Entry: Entry object (2069881)>, <Entry: Entry object (2062506)>, <Entry: Entry object (2133663)>, <Entry: Entry object (2218525)>]>
>>>
```