### PR TITLE
Fixed a search query timeout for long keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In development
 ### Added
 * Added `^` and `$` operators on filtering `text` and `string` typed attributes in advanced search result
+* Fixed a search query timeout for long keywords
 
 ## v3.0.0
 

--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -122,7 +122,7 @@ __all__ = [
 ]
 
 
-def make_query(hint_entity_ids, hint_attrs, entry_name, or_match):
+def make_query(hint_entity_ids, hint_attrs, hint_attr_value, entry_name, or_match):
     """Create a search query for Elasticsearch.
 
     Do the following:
@@ -180,6 +180,18 @@ def make_query(hint_entity_ids, hint_attrs, entry_name, or_match):
                         'should': [
                             {'term': {'attr.name': x['name']}} for x in hint_attrs if 'name' in x
                         ]
+                    }
+                }
+            }
+        })
+
+    if hint_attr_value:
+        query['query']['bool']['filter'].append({
+            'nested': {
+                'path': 'attr',
+                'query': {
+                    'wildcard': {
+                        'attr.value': "*" + str(hint_attr_value) + "*"
                     }
                 }
             }

--- a/airone/tests/test_elasticsearch.py
+++ b/airone/tests/test_elasticsearch.py
@@ -80,6 +80,7 @@ class ElasticSearchTest(TestCase):
         query = elasticsearch.make_query(
             hint_entity_ids=['1'],
             hint_attrs=[{'name': 'a1', 'keyword': 'a'}, {'name': 'a2', 'keyword': ''}],
+            hint_attr_value=None,
             entry_name='entry1',
             or_match=False,
         )

--- a/entry/models.py
+++ b/entry/models.py
@@ -1396,7 +1396,7 @@ class Entry(ACLBase):
 
     @classmethod
     def search_entries(kls, user, hint_entity_ids, hint_attrs=[], limit=CONFIG.MAX_LIST_ENTRIES,
-                       entry_name=None, or_match=False, hint_referral=False):
+                       entry_name=None, or_match=False, hint_referral=False, hint_attr_value=None):
         """Main method called from simple search and advanced search.
 
         Do the following:
@@ -1425,7 +1425,7 @@ class Entry(ACLBase):
 
         """
         # make query for elasticsearch to retrieve data user wants
-        query = make_query(hint_entity_ids, hint_attrs, entry_name, or_match)
+        query = make_query(hint_entity_ids, hint_attrs, hint_attr_value, entry_name, or_match)
 
         # sending request to elasticsearch with making query
         resp = execute_query(query)

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -1583,6 +1583,11 @@ class ModelTest(AironeTestCase):
         self.assertEqual(ret['ret_count'], 1)
         self.assertEqual(ret['ret_values'][0]['entry']['name'], 'e-10')
 
+        # check functionallity of the 'hint_attr_value' parameter
+        ret = Entry.search_entries(user, [entity.id], hint_attr_value='foo-0')
+        self.assertEqual(ret['ret_count'], 1)
+        self.assertEqual(ret['ret_values'][0]['entry']['name'], 'e-0')
+
     def test_search_entries_with_hint_referral(self):
         user = User.objects.create(username='hoge')
 


### PR DESCRIPTION
close: https://github.com/dmm-com/airone/issues/145

As a workaround, added an argument to search for all attributes.