### PR TITLE
Fixed a minor problem about version displaying

### DIFF
--- a/airone/settings.py
+++ b/airone/settings.py
@@ -177,8 +177,10 @@ try:
     outs, errs = proc.communicate(timeout=1)
     # if `git describe --tags` prints some string to stdout, use the result as version
     # else use 'unknown' as version (e.g. untagged git repository)
-    if outs != b'':
+    if isinstance(outs, str):
         AIRONE['VERSION'] = outs.strip()
+    elif isinstance(outs, bytes):
+        AIRONE['VERSION'] = outs.decode('utf-8').strip()
     else:
         logging.getLogger(__name__).warning('could not describe airone version from git')
 

--- a/dashboard/tests/test_view.py
+++ b/dashboard/tests/test_view.py
@@ -106,7 +106,7 @@ class ViewTest(AironeViewTest):
 
         resp = self.client.get(reverse('dashboard:index'))
         self.assertEqual(resp.status_code, 200)
-        self.assertIsNotNone(resp.context["version"])
+        self.assertIsInstance(resp.context["version"], str)
         for i, x in enumerate(resp.context["last_entries"]):
             self.assertEqual(x['attr_value'].id, obj_attrv_list[i]['id'])
         for i, x in enumerate(resp.context["navigator"]['entities']):


### PR DESCRIPTION
This commit fixed a problem of showing AirOne version as a bytes typed value.