### PR TITLE
Fixed the result being different depending on the hint_attr_value of search_entries

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -190,8 +190,8 @@ def make_query(hint_entity_ids, hint_attrs, hint_attr_value, entry_name, or_matc
             'nested': {
                 'path': 'attr',
                 'query': {
-                    'wildcard': {
-                        'attr.value': "*" + str(hint_attr_value) + "*"
+                    'regexp': {
+                        'attr.value': ".*" + _get_regex_pattern(str(hint_attr_value)) + ".*"
                     }
                 }
             }

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -1598,6 +1598,11 @@ class ModelTest(AironeTestCase):
         self.assertEqual(ret['ret_count'], 1)
         self.assertEqual(ret['ret_values'][0]['entry']['name'], 'e-0')
 
+        # check whether keyword would be insensitive case
+        ret = Entry.search_entries(user, [entity.id], hint_attr_value='FOO-0')
+        self.assertEqual(ret['ret_count'], 1)
+        self.assertEqual(ret['ret_values'][0]['entry']['name'], 'e-0')
+
     def test_search_entries_with_hint_referral(self):
         user = User.objects.create(username='hoge')
 


### PR DESCRIPTION
The following PR added the hint_attr_value option to the search_entries function.
https://github.com/dmm-com/airone/pull/146

The search results were different because hint_attr_value is case sensitive.
Changed Elasticsearch query to regular expression format.

```
>>> Entry.search_entries(user, [entity.id], hint_attr_value='hoge')['ret_count']
3
>>> Entry.search_entries(user, [entity.id], hint_attr_value='Hoge')['ret_count']
3
```