### PR TITLE
Changed not to create tokens with GET user.access_token API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 * Update Django to version 3.2.4 LTS (#153)
+* Changed not to create tokens with GET user.access_token API (#166)
+* Changed the behavior of token refresh
 
 ### Fixed
 * Fixed the result being different depending on the hint_attr_value of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
+## In developmet
+
+### Changed
+* Changed not to create tokens with GET user.access_token API (#166)
+* Changed the behavior of token refresh
+
 ## v3.2.0
 
 ### Changed
 * Update Django to version 3.2.4 LTS (#153)
-* Changed not to create tokens with GET user.access_token API (#166)
-* Changed the behavior of token refresh
 
 ### Fixed
 * Fixed the result being different depending on the hint_attr_value of

--- a/api_v1/tests/test_api.py
+++ b/api_v1/tests/test_api.py
@@ -19,6 +19,7 @@ from entry.settings import CONFIG as ENTRY_CONFIG
 
 from unittest import mock
 from datetime import date, datetime, timedelta
+from rest_framework.authtoken.models import Token
 
 
 class APITest(AironeViewTest):
@@ -254,6 +255,7 @@ class APITest(AironeViewTest):
 
     def test_post_entry_with_token(self):
         admin = User.objects.create(username='admin', is_superuser='True')
+        Token.objects.create(user=admin)
 
         entity = Entity.objects.create(name='Entity', created_user=admin)
         params = {
@@ -780,6 +782,7 @@ class APITest(AironeViewTest):
     @mock.patch('api_v1.auth.datetime')
     def test_expiring_token_lifetime(self, dt_mock):
         user = User.objects.create(username='testuser')
+        Token.objects.create(user=user)
 
         entity = Entity.objects.create(name='E1', created_user=user)
         Entry.objects.create(name='e1', schema=entity, created_user=user,)
@@ -839,6 +842,7 @@ class APITest(AironeViewTest):
     @mock.patch('entry.tasks.notify_create_entry.delay')
     def test_create_entry_that_has_user_authorized_attribute(self, mock_notify_create_entry):
         users = {x: User.objects.create(username=x, is_superuser=False) for x in ['_u1', '_u2']}
+        [Token.objects.create(user=x) for x in users.values()]
 
         # declare notification mock
         self._test_data['notify_create_entry_is_called'] = False

--- a/templates/edit_user.html
+++ b/templates/edit_user.html
@@ -59,7 +59,7 @@
           </tr>
           {% endif %}
 
-          {% if token %}
+          {% if is_show_token %}
           <tr>
             <th>AccessToken</th>
             <td>
@@ -75,7 +75,12 @@
                 <input type="text" name="token_lifetime" value="{{ token_lifetime }}" />
                 (0 ~ 10^8 の範囲の整数を指定してください(0 を入力した場合は期限は無期限になります))
               </p>
-              有効期限：{{ token_expire }}
+              <div id='token_created'>作成日：{{ token_created }}</div>
+              {% if token_lifetime %}
+                <div id='token_expire'>有効期限：{{ token_expire }}</div>
+              {% else %}
+                <div id='token_expire'>有効期限：-</div>
+              {% endif %}
             </td>
           </tr>
         </table>
@@ -110,7 +115,7 @@ $("#refresh_token").on('click', function() {
       'X-CSRFToken': $('input[name=csrfmiddlewaretoken]').val(),
     },
   }).done(function(data){
-    $("#access_token").text(data['results']);
+    location.reload();
   });
 });
 

--- a/templates/edit_user.html
+++ b/templates/edit_user.html
@@ -63,7 +63,11 @@
           <tr>
             <th>AccessToken</th>
             <td>
-              <p id='access_token'>{{ token }}</p>
+              {% if token %}
+                <p id='access_token'>{{ token }}</p>
+              {% else %}
+                <p id='access_token'>トークンが発行されていません。Refreshボタンを押して発行してください。</p>
+              {% endif %}
               <button type='button' id='refresh_token' class='btn btn-primary btn-sm'>Refresh</button>
             </td>
           </tr>
@@ -75,8 +79,14 @@
                 <input type="text" name="token_lifetime" value="{{ token_lifetime }}" />
                 (0 ~ 10^8 の範囲の整数を指定してください(0 を入力した場合は期限は無期限になります))
               </p>
-              <div id='token_created'>作成日：{{ token_created }}</div>
-              {% if token_lifetime %}
+              {% if token_created %}
+                <div id='token_created'>作成日：{{ token_created }}</div>
+              {% else %}
+                <div id='token_created'>作成日：-</div>
+              {% endif %}
+              {% if token_expire and token_lifetime == 0 %}
+                <div id='token_expire'>有効期限：無期限</div>
+              {% elif token_expire and token_lifetime %}
                 <div id='token_expire'>有効期限：{{ token_expire }}</div>
               {% else %}
                 <div id='token_expire'>有効期限：-</div>

--- a/user/models.py
+++ b/user/models.py
@@ -30,7 +30,7 @@ class User(DjangoUser):
 
     @property
     def token(self):
-        return Token.objects.get_or_create(user=self)[0]
+        return Token.objects.filter(user=self).first()
 
     def _user_has_permission(self, target_obj, permission_level):
         slave_db = get_slave_db()

--- a/user/tests/test_model.py
+++ b/user/tests/test_model.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from django.contrib.auth.models import User as DjangoUser
+from rest_framework.authtoken.models import Token
 
 from airone.lib.acl import ACLType
 from entity.models import Entity, EntityAttr
@@ -10,8 +11,18 @@ from user.models import User, History
 
 class ModelTest(TestCase):
     def setUp(self):
-        self.user = User(username='ほげ', email='hoge@example.com', password='fuga')
+        self.user = User(username='ほげ', email='hoge@example.com')
+        self.user.set_password('fuga')
         self.user.save()
+
+    def test_get_token(self):
+        # if not have token
+        self.assertIsNone(self.user.token)
+
+        # create token
+        self.client.login(username='ほげ', password='fuga')
+        self.client.put('/api/v1/user/access_token')
+        self.assertEqual(self.user.token, Token.objects.get(user=self.user))
 
     def test_make_user(self):
         self.assertTrue(isinstance(self.user, DjangoUser))

--- a/user/tests/test_view.py
+++ b/user/tests/test_view.py
@@ -177,10 +177,10 @@ class ViewTest(TestCase):
             self.assertEqual(resp.context['user_email'], user.email)
             self.assertEqual(resp.context['user_is_superuser'], user.is_superuser)
             self.assertEqual(resp.context['is_show_token'], username == 'admin')
-            self.assertEqual(resp.context['token'], user.token if username == 'admin' else '')
+            self.assertEqual(resp.context['token'], user.token if username == 'admin' else None)
             self.assertEqual(resp.context['token_lifetime'], user.token_lifetime)
             self.assertEqual(resp.context['token_created'],
-                             user.token.created if username == 'admin' else '')
+                             user.token.created if username == 'admin' else None)
             self.assertEqual(resp.context['token_expire'],
                              user.token.created + timedelta(seconds=user.token_lifetime)
                              if username == 'admin' else None)

--- a/user/tests/test_view.py
+++ b/user/tests/test_view.py
@@ -1,4 +1,5 @@
 import json
+from datetime import timedelta
 
 from django.test import TestCase, Client
 from django.urls import reverse
@@ -151,19 +152,38 @@ class ViewTest(TestCase):
         resp = self.client.get(reverse('user:edit', args=[0]))
         self.assertEqual(resp.status_code, 303)
 
-    def test_edit_get_page(self):
+    def test_edit_get_with_guest_login(self):
+        self._guest_login()
+
+        user = User.objects.get(username='admin')
+        resp = self.client.get(reverse('user:edit', args=[user.id]))
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.content.decode('utf-8'),
+                         "You don't have permission to access")
+
+    def test_edit_get_with_admin_login(self):
         self._admin_login()
+        self.client.put('/api/v1/user/access_token')
 
         for username in ['guest', 'admin']:
-            user = User.objects.get(username='admin')
+            user = User.objects.get(username=username)
             resp = self.client.get(reverse('user:edit', args=[user.id]))
             self.assertEqual(resp.status_code, 200)
 
             # Check context of response
             self.assertTemplateUsed(template_name='edit_user.html')
+            self.assertEqual(resp.context['user_id'], user.id)
             self.assertEqual(resp.context['user_name'], user.username)
-            self.assertEqual(resp.context['token'], user.token)
+            self.assertEqual(resp.context['user_email'], user.email)
+            self.assertEqual(resp.context['user_is_superuser'], user.is_superuser)
+            self.assertEqual(resp.context['is_show_token'], username == 'admin')
+            self.assertEqual(resp.context['token'], user.token if username == 'admin' else '')
             self.assertEqual(resp.context['token_lifetime'], user.token_lifetime)
+            self.assertEqual(resp.context['token_created'],
+                             user.token.created if username == 'admin' else '')
+            self.assertEqual(resp.context['token_expire'],
+                             user.token.created + timedelta(seconds=user.token_lifetime)
+                             if username == 'admin' else None)
 
     def test_edit_post_without_login(self):
         user = User.objects.create(username='test', email='test@example.com')

--- a/user/views.py
+++ b/user/views.py
@@ -81,9 +81,9 @@ def edit(request, user_id):
         'user_email': user.email,
         'user_is_superuser': user.is_superuser,
         'is_show_token': current_user == user,
-        'token': user.token if current_user == user else '',
+        'token': user.token if current_user == user else None,
         'token_lifetime': user.token_lifetime,
-        'token_created': user.token.created if user.token else '',
+        'token_created': user.token.created if user.token else None,
         'token_expire': (user.token.created + timedelta(seconds=user.token_lifetime)
                          if user.token else None)
     }

--- a/user/views.py
+++ b/user/views.py
@@ -14,8 +14,6 @@ from airone.lib.http import check_superuser
 from airone.lib.profile import airone_profile
 from user.forms import UsernameBasedPasswordResetForm
 
-from rest_framework.authtoken.models import Token
-
 from .models import User
 
 
@@ -77,16 +75,17 @@ def edit(request, user_id):
     if not current_user.is_superuser and current_user != user:
         return HttpResponse("You don't have permission to access", status=400)
 
-    (token, _) = Token.objects.get_or_create(user=user)
     context = {
         'user_id': int(user_id),
         'user_name': user.username,
         'user_email': user.email,
-        'user_password': user.password,
         'user_is_superuser': user.is_superuser,
-        'token': token if current_user == user else '',
+        'is_show_token': current_user == user,
+        'token': user.token if current_user == user else '',
         'token_lifetime': user.token_lifetime,
-        'token_expire': token.created + timedelta(seconds=user.token_lifetime),
+        'token_created': user.token.created if user.token else '',
+        'token_expire': (user.token.created + timedelta(seconds=user.token_lifetime)
+                         if user.token else None)
     }
 
     return render(request, 'edit_user.html', context)


### PR DESCRIPTION
Eliminating database updates with GET requests due to multi-database support.

Currently, when you open the user edit page with GET, an access token is created.
Removed the process of creating an access token.
If there is no access token, nothing will be displayed.

![image](https://user-images.githubusercontent.com/5561786/125239762-1aa0b680-e324-11eb-8617-5883d39382f5.png)
