### PR TITLE
Changed the HTTP method on the entry.export page from GET to POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
+## In development
+
+### Changed
+* Changed the HTTP method on the entry.export page from GET to POST (#166)
+
 ## v3.2.0
 
 ### Changed
 * Update Django to version 3.2.4 LTS (#153)
-* Changed the HTTP method on the entry.export page from GET to POST (#166)
 
 ### Fixed
 * Fixed the result being different depending on the hint_attr_value of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 * Update Django to version 3.2.4 LTS (#153)
+* Changed the HTTP method on the entry.export page from GET to POST (#166)
 
 ### Fixed
 * Fixed the result being different depending on the hint_attr_value of

--- a/entry/views.py
+++ b/entry/views.py
@@ -401,8 +401,8 @@ def refer(request, entry_id):
 
 
 @airone_profile
-@http_get
-def export(request, entity_id):
+@http_post([])
+def export(request, entity_id, recv_data):
     user = User.objects.get(id=request.user.id)
 
     job_params = {
@@ -413,7 +413,7 @@ def export(request, entity_id):
     if not Entity.objects.filter(id=entity_id).exists():
         return HttpResponse('Failed to get entity of specified id', status=400)
 
-    if 'format' in request.GET and request.GET.get('format') == 'CSV':
+    if 'format' in recv_data and recv_data['format'] == 'CSV':
         job_params['export_format'] = 'csv'
 
     # check whether same job is sent

--- a/templates/list_entry/common.js
+++ b/templates/list_entry/common.js
@@ -2,8 +2,9 @@ var send_export_request = function(format) {
   MessageBox.clear();
 
   $.ajax({
-    url: `/entry/export/{{ entity.id }}?format=${ format }`,
-    type: 'GET',
+    url: `/entry/export/{{ entity.id }}/`,
+    type: 'POST',
+    data: JSON.stringify({format: format}),
     dataType: 'json',
     contentType: 'application/x-www-form-urlencoded;charset=utf-8',
     scriptCharset: 'utf-8',


### PR DESCRIPTION
Eliminating database updates with GET requests due to multi-database support.

Currently, the entry export task is running in the background job.
Creating a job updates the database.
I changed from the GET method to the POST method.

![image](https://user-images.githubusercontent.com/5561786/125242559-d1526600-e327-11eb-9152-ad1d9c03321a.png)
