### PR TITLE
Build React app in dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,4 +172,4 @@ static_root
 
 # React
 node_modules
-templates/frontend/main.js*
+static/js/new-ui.js*

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "build": "webpack build --mode production"
+    "build": "webpack build --mode development"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "doc": "docs"
   },
   "scripts": {
-    "build": "webpack build --mode development",
+    "build": "npm run build:development",
+    "build:development": "webpack build --mode development",
+    "build:production": "webpack build --mode production",
     "lint": "npx prettier --check frontend/",
     "fmt": "npx prettier --write frontend/",
     "test": "npx jest frontend"

--- a/templates/frontend/index.html
+++ b/templates/frontend/index.html
@@ -8,8 +8,6 @@
 <body>
   <div id="app" class="columns"><!-- React --></div>
 
-  <script>
-    {% include 'frontend/main.js' %}
-  </script>
+  <script src="/static/js/new-ui.js"></script>
 </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,8 +5,8 @@ module.exports = {
     index: "./frontend/src/App.js"
   },
   output: {
-    filename: "main.js",
-    path: path.resolve('templates/frontend')
+    filename: "new-ui.js",
+    path: path.resolve('static/js')
   },
   module: {
     rules: [


### PR DESCRIPTION
`production` build mode generates a minified .js without debuggable information. It's still under development, so it's better to use dev-mode.

```
# it generates .js that's suitable for debug
$ npm run build
# or
$ npm run build:development

# it generates .js that's suitable for production environment (e.g. its minified)
$ npm run build:production
```