### PR TITLE
fix urls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "python.pythonPath": ".venv/bin/python"
+    "python.defaultInterpreterPath": ".venv/bin/python"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixed the result being different depending on the hint_attr_value of
   search_entries (#158)
 * Fixed a problem in the processing of import entry (#159)
+* Fixed `urls` to avoid some warnings (#174)
 
 ## v3.1.0
 

--- a/airone/urls.py
+++ b/airone/urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
     url(r'^api/v1/', include(api_v1_urlpatterns)),
     url(r'^job/', include(('job.urls', 'job'))),
     url(r'^auth/', include(('django.contrib.auth.urls', 'auth'))),
-    url(r'^webhook/', include(('webhook.urls', 'entity'))),
+    url(r'^webhook/', include(('webhook.urls', 'webhook'))),
 ]
 
 for extension in settings.AIRONE['EXTENSIONS']:

--- a/webhook/api_v1/urls.py
+++ b/webhook/api_v1/urls.py
@@ -3,6 +3,6 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^/set/(\d+)$', views.set_webhook, name='set_webhook'),
-    url(r'^/del/(\d+)$', views.del_webhook, name='del_webhook'),
+    url(r'^set/(\d+)$', views.set_webhook, name='set_webhook'),
+    url(r'^del/(\d+)$', views.del_webhook, name='del_webhook'),
 ]


### PR DESCRIPTION
Fix `urls` to avoid some warnings.

```
System check identified some issues:

WARNINGS:
?: (urls.W002) Your URL pattern '^/del/(\d+)$' [name='del_webhook'] has a route beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
?: (urls.W002) Your URL pattern '^/set/(\d+)$' [name='set_webhook'] has a route beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
?: (urls.W005) URL namespace 'entity' isn't unique. You may not be able to reverse all URLs in this namespace
```