### PR TITLE
Fixed a warning log with an SSL connection to the extarnal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixed the result being different depending on the hint_attr_value of
   search_entries (#158)
 * Fixed a problem in the processing of import entry (#159)
+* Fixed a warning log with an SSL connection to the extarnal (#182)
 
 ## v3.1.0
 

--- a/airone/lib/event_notification.py
+++ b/airone/lib/event_notification.py
@@ -1,5 +1,9 @@
 import json
 import requests
+import urllib3
+from urllib3.exceptions import InsecureRequestWarning
+
+urllib3.disable_warnings(InsecureRequestWarning)
 
 
 def _send_request_to_webhook_endpoint(entry, user, event_type):

--- a/webhook/api_v1/views.py
+++ b/webhook/api_v1/views.py
@@ -1,5 +1,7 @@
 import json
 import requests
+import urllib3
+from urllib3.exceptions import InsecureRequestWarning
 
 from airone.lib.acl import ACLType
 from airone.lib.http import check_permission
@@ -13,6 +15,8 @@ from django.http.response import JsonResponse
 from entity.models import Entity
 
 from webhook.models import Webhook
+
+urllib3.disable_warnings(InsecureRequestWarning)
 
 
 @airone_profile


### PR DESCRIPTION
close: https://github.com/dmm-com/airone/issues/182

- before
```
[2021-07-27 10:08:21,007: INFO/MainProcess] Received task: entry.tasks.notify_update_entry[18a7ae97-60aa-4cc9-a9bc-03f7e338961b]
[2021-07-27 10:08:25,121: WARNING/ForkPoolWorker-8] /root/airone/.venv/lib64/python3.8/site-packages/urllib3/connectionpool.py:853: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  warnings.warn((
[2021-07-27 10:08:25,140: INFO/ForkPoolWorker-8] Task entry.tasks.notify_update_entry[18a7ae97-60aa-4cc9-a9bc-03f7e338961b] succeeded in 4.131522300000142s: None
```
- after
```
[2021-07-27 10:12:44,072: INFO/MainProcess] Received task: entry.tasks.notify_update_entry[c7ada59b-c8e3-43a1-8ba3-476232023b72]
[2021-07-27 10:12:48,659: INFO/ForkPoolWorker-8] Task entry.tasks.notify_update_entry[c7ada59b-c8e3-43a1-8ba3-476232023b72] succeeded in 4.581160299999965s: None
```