### PR TITLE
Fixed a bug that raises an exception at API handler of update entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixed the result being different depending on the hint_attr_value of
   search_entries (#158)
 * Fixed a problem in the processing of import entry (#159)
+* Fixed a bug that raises an exception at API handler of update entry (#186)
 
 ## v3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## In development
+
+### Changed
+* Update Django to version 3.2.4 LTS (#153)
+
+### Fixed
+* Fixed the result being different depending on the hint_attr_value of
+  search_entries (#158)
+* Fixed a problem in the processing of import entry (#159)
+
 ## v3.1.0
 
 ### Added

--- a/api_v1/views.py
+++ b/api_v1/views.py
@@ -95,7 +95,7 @@ class EntryAPI(APIView):
             if not entry.attrs.filter(name=name).exists():
                 continue
 
-            attr = entry.attrs.get(name=name)
+            attr = entry.attrs.get(schema__name=name, is_active=True)
             if user.has_permission(attr.schema, ACLType.Writable) and attr.is_updated(value):
                 attr.add_value(user, value)
 


### PR DESCRIPTION
Close: #186 

Previous implementation had a bug that raises an Exception of
`MultipleObjectsReturned` when a request that update entry, which has
deleted Attribute, was received. This commit fixed it.