### PR TITLE
Feature/multidb complement attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 * Update Django to version 3.2.4 LTS (#153)
 * Changed to complement_attrs when adding the attribute of the entity (#166)
+* Changed not to complement attribute values with GET method (#166)
 
 ### Fixed
 * Fixed the result being different depending on the hint_attr_value of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 * Update Django to version 3.2.4 LTS (#153)
+* Changed to complement_attrs when adding the attribute of the entity (#166)
 
 ### Fixed
 * Fixed the result being different depending on the hint_attr_value of

--- a/entity/tests/test_complex_view.py
+++ b/entity/tests/test_complex_view.py
@@ -109,10 +109,6 @@ class ComplexViewTest(AironeViewTest):
                                 'application/json')
         self.assertEqual(resp.status_code, 200)
 
-        # Checks that the Attributes associated to the added EntityAttrs are not created
-        self.assertEqual(entity.attrs.count(), 3)
-        self.assertEqual(entry.attrs.count(), 1)
-
         resp = self.client.get(reverse('entry:show', args=[entry.id]))
         self.assertEqual(resp.status_code, 200)
 

--- a/entity/tests/test_view.py
+++ b/entity/tests/test_view.py
@@ -314,7 +314,7 @@ class ViewTest(AironeViewTest):
 
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(entity.attrs.count(), 2)
-        self.assertEqual(entry.attrs.count(), 1)
+        self.assertEqual(entry.attrs.count(), 2)
 
     def test_post_edit_attribute_type(self):
         user = self.admin_login()

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -954,6 +954,19 @@ class ModelTest(AironeTestCase):
         self.assertEqual([int(x.value) for x in latest_value.data_array.all()],
                          [x.id for x in test_groups])
 
+    def test_get_missing_attrs(self):
+        user = User.objects.create(username='hoge')
+        entity = self.create_entity_with_all_type_attributes(user)
+        entry = Entry.objects.create(name='entry', schema=entity, created_user=user)
+
+        missing_attrs = entry.get_missing_attrs()
+        self.assertEqual(sorted(missing_attrs, key=lambda x: x.id),
+                         [x for x in entity.attrs.all()])
+
+        entry.complement_attrs(user)
+        missing_attrs = entry.get_missing_attrs()
+        self.assertEqual(missing_attrs, [])
+
     def test_get_available_attrs(self):
         user = User.objects.create(username='hoge')
         test_group = Group.objects.create(name='test-group')

--- a/entry/views.py
+++ b/entry/views.py
@@ -230,7 +230,7 @@ def edit(request, entry_id):
     if not entry.is_active:
         return _redirect_restore_entry(entry)
 
-    entry.complement_attrs(user)
+    missing_attrs = entry.get_missing_attrs()
 
     context = {
         'entry': entry,
@@ -239,6 +239,15 @@ def edit(request, entry_id):
         'form_url': '/entry/do_edit/%s' % entry.id,
         'redirect_url': '/entry/show/%s' % entry.id,
     }
+
+    context['attributes'].extend([{
+        'id': None,
+        'name': x.name,
+        'type': x.type,
+        'is_mandatory': x.is_mandatory,
+        'index': x.index,
+        'last_value': ''
+    } for x in missing_attrs])
 
     if custom_view.is_custom("edit_entry", entry.schema.name):
         # show custom view
@@ -329,13 +338,22 @@ def show(request, entry_id):
     if not entry.is_active:
         return _redirect_restore_entry(entry)
 
-    # create new attributes which are appended after creation of Entity
-    entry.complement_attrs(user)
+    # check for new attributes which are appended after creation of Entity
+    missing_attrs = entry.get_missing_attrs()
 
     context = {
         'entry': entry,
         'attributes': entry.get_available_attrs(user),
     }
+
+    context['attributes'].extend([{
+        'id': None,
+        'name': x.name,
+        'type': x.type,
+        'is_mandatory': x.is_mandatory,
+        'index': x.index,
+        'last_value': ''
+    } for x in missing_attrs])
 
     if custom_view.is_custom("show_entry", entry.schema.name):
         # show custom view

--- a/templates/edit_entry/attrs.html
+++ b/templates/edit_entry/attrs.html
@@ -4,6 +4,10 @@
   <td>
     {% if attr.is_mandatory %}<strong>(*)</strong>{% endif %}{{ attr.name }}
   </td>
+  {% if not attr.id %}
+  <td>
+    <span>Attribute not found.</span>
+  {% else %}
   <td id='{{ attr.name }}'>
     {% if attr.type|bitwise_and:attr_type_value.array %}
       <div>
@@ -144,10 +148,13 @@
       <input type="text" class="form-control attr_value" attr_id="{{ attr.id }}" enabled="True" value="{{ attr.last_value }}" {%if attr.is_mandatory%}mandatory="true"{%endif%}/>
 
     {% endif %}
+  {% endif %}
   </td>
   {% if is_edit %}
   <td>
-    <a href="/acl/{{ attr.id }}"><button type="button" class="btn btn-info btn-sm">ACL</button></a>
+    {% if attr.id %}
+      <a href="/acl/{{ attr.id }}"><button type="button" class="btn btn-info btn-sm">ACL</button></a>
+    {% endif %}
   </td>
   {% endif %}
 </tr>

--- a/templates/edit_entry/js.html
+++ b/templates/edit_entry/js.html
@@ -4,6 +4,7 @@ var get_register_attrs = function(base) {
   var attrs = []
 
   {% for attr in attributes %}
+  {% if attr.id %}
   attrs.push({
     'id': '{{ attr.id }}',
     'type': '{{ attr.type }}',
@@ -18,6 +19,7 @@ var get_register_attrs = function(base) {
       return {'data': $(e).val(), 'index': $(e).attr('index')};
     }).get(),
   });
+  {% endif %}
   {% endfor %}
 
   return attrs;

--- a/templates/show_entry/attributes.html
+++ b/templates/show_entry/attributes.html
@@ -5,7 +5,9 @@
       <tr>
         <td class='attr'>{{ attr.name }}</td>
         <td>
-        {% if attr.type == attr_type.string %}
+        {% if not attr.id %}
+          <span>Attribute not found.</span>
+        {% elif attr.type == attr_type.string %}
           <span class='url_conv'>{{ attr.last_value }}</span>
         {% elif attr.type == attr_type.textarea %}
           <span class='url_conv textarea'>{{ attr.last_value }}</span>


### PR DESCRIPTION
Multi-database support eliminates database updates due to GET requests.

Currently, when to view entry show page, attribute completion processing is executed.
This happens when you add Attribute for Entity after creating Entry.

Changed to add Attribute of Entry when adding the Attribute of Entity.
There is no Attribute of Entry while adding Attribute of Entity.
In that case, 'Attribute not found' is displayed.

![image](https://user-images.githubusercontent.com/5561786/128448705-b0951b89-034e-4478-a5c2-085759edd5a0.png)