### PR TITLE
Added job function that cannot be canceled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 * Update Django to version 3.2.4 LTS (#153)
+* Added job function that cannot be canceled (#199)
 
 ### Fixed
 * Fixed the result being different depending on the hint_attr_value of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## In development
+
+### Changed
+* Added job function that cannot be canceled (#199)
 ## v3.2.0
 
 ### Changed
 * Update Django to version 3.2.4 LTS (#153)
-* Added job function that cannot be canceled (#199)
 
 ### Fixed
 * Fixed the result being different depending on the hint_attr_value of

--- a/api_v1/job/views.py
+++ b/api_v1/job/views.py
@@ -82,6 +82,10 @@ class JobAPI(APIView):
         if job.status == Job.STATUS['DONE']:
             return Response('Target job has already been done')
 
+        if job.operation not in Job.CAN_CANCEL_OPERATIONS:
+            return Response('Target job cannot be canceled',
+                            status=status.HTTP_400_BAD_REQUEST)
+
         # update job.status to be canceled
         job.update(Job.STATUS['CANCELED'])
 

--- a/api_v1/job/views.py
+++ b/api_v1/job/views.py
@@ -82,7 +82,7 @@ class JobAPI(APIView):
         if job.status == Job.STATUS['DONE']:
             return Response('Target job has already been done')
 
-        if job.operation not in Job.CAN_CANCEL_OPERATIONS:
+        if job.operation not in Job.CANCELABLE_OPERATIONS:
             return Response('Target job cannot be canceled',
                             status=status.HTTP_400_BAD_REQUEST)
 

--- a/api_v1/tests/job/test_api.py
+++ b/api_v1/tests/job/test_api.py
@@ -209,7 +209,16 @@ class APITest(AironeViewTest):
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.content, b'"Failed to find Job(id=99999)"')
 
+        # target jobs that cannot be canceled
+        resp = self.client.delete('/api/v1/job/', json.dumps({'job_id': job.id}),
+                                  'application/json')
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.content, b'"Target job cannot be canceled"')
+
         # send request with proper parameter
+        job = Job.new_create(user, entry)
+        self.assertEqual(job.status, Job.STATUS['PREPARING'])
+
         resp = self.client.delete('/api/v1/job/', json.dumps({'job_id': job.id}),
                                   'application/json')
         self.assertEqual(resp.status_code, 200)

--- a/job/models.py
+++ b/job/models.py
@@ -90,6 +90,14 @@ class Job(models.Model):
         JobOperation.NOTIFY_DELETE_ENTRY.value,
     ]
 
+    CAN_CANCEL_OPERATIONS = [
+        JobOperation.CREATE_ENTRY.value,
+        JobOperation.IMPORT_ENTRY.value,
+        JobOperation.EXPORT_ENTRY.value,
+        JobOperation.REGISTER_REFERRALS.value,
+        JobOperation.EXPORT_SEARCH_RESULT.value,
+    ]
+
     user = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/job/models.py
+++ b/job/models.py
@@ -90,7 +90,7 @@ class Job(models.Model):
         JobOperation.NOTIFY_DELETE_ENTRY.value,
     ]
 
-    CAN_CANCEL_OPERATIONS = [
+    CANCELABLE_OPERATIONS = [
         JobOperation.CREATE_ENTRY.value,
         JobOperation.IMPORT_ENTRY.value,
         JobOperation.EXPORT_ENTRY.value,

--- a/job/tests/test_view.py
+++ b/job/tests/test_view.py
@@ -44,8 +44,20 @@ class ViewTest(AironeViewTest):
         # checks number of the returned objects are as expected
         resp = self.client.get('/job/')
         self.assertEqual(resp.status_code, 200)
-
+        self.assertTemplateUsed('list_jobs.html')
         self.assertEqual(len(resp.context['jobs']), _TEST_MAX_LIST_VIEW)
+
+        for i, job in enumerate(
+                Job.objects.filter(user=user).order_by('-created_at')[:_TEST_MAX_LIST_VIEW]):
+            self.assertEqual(resp.context['jobs'][i]['id'], job.id)
+            self.assertEqual(resp.context['jobs'][i]['target'], job.target)
+            self.assertEqual(resp.context['jobs'][i]['text'], job.text)
+            self.assertEqual(resp.context['jobs'][i]['status'], job.status)
+            self.assertEqual(resp.context['jobs'][i]['operation'], job.operation)
+            self.assertEqual(resp.context['jobs'][i]['can_cancel'], True)
+            self.assertEqual(resp.context['jobs'][i]['created_at'], job.created_at)
+            self.assertEqual(resp.context['jobs'][i]['operation'], job.operation)
+            self.assertGreaterEqual(resp.context['jobs'][i]['passed_time'], 0)
 
         # checks all job objects will be returned
         resp = self.client.get('/job/?nolimit=1')

--- a/job/views.py
+++ b/job/views.py
@@ -40,6 +40,7 @@ def index(request):
             'text': x.text,
             'status': x.status,
             'operation': x.operation,
+            'can_cancel': x.operation in Job.CAN_CANCEL_OPERATIONS,
             'created_at': x.created_at,
             'passed_time': (
                 x.updated_at - x.created_at

--- a/job/views.py
+++ b/job/views.py
@@ -40,7 +40,7 @@ def index(request):
             'text': x.text,
             'status': x.status,
             'operation': x.operation,
-            'can_cancel': x.operation in Job.CAN_CANCEL_OPERATIONS,
+            'can_cancel': x.operation in Job.CANCELABLE_OPERATIONS,
             'created_at': x.created_at,
             'passed_time': (
                 x.updated_at - x.created_at

--- a/templates/list_jobs.html
+++ b/templates/list_jobs.html
@@ -145,7 +145,7 @@
               {% endif %}
 
               {% if job.status != JOB.STATUS.DONE and job.status != JOB.STATUS.CANCELED %}
-              <p><button type='button' class='btn btn-danger btn-sm cancel-job' value='{{ job.id }}'>Cancel</button></p>
+              <p><button type='button' class='btn btn-danger btn-sm cancel-job' value='{{ job.id }}' {% if not job.can_cancel %}disabled=True{% endif %}>Cancel</button></p>
               {% endif %}
             </td>
 


### PR DESCRIPTION
close: https://github.com/dmm-com/airone/pull/169

Defined a job that can be canceled with CAN_CANCEL_OPERATIONS.
Jobs that cannot be canceled have their buttons disabled.

![image](https://user-images.githubusercontent.com/5561786/129651471-eef898af-1595-4e7f-99aa-19e0c2986045.png)
