### PR TITLE
Fixed the problem that the URL of Webhook API is different

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Changed the behavior of token refresh
 * Added job function that cannot be canceled (#199)
 
+### Fixed
+* Fixed the problem that the URL of Webhook API is different (#202)
+
 ## v3.2.0
 
 ### Changed

--- a/webhook/tests/test_api_v1.py
+++ b/webhook/tests/test_api_v1.py
@@ -19,14 +19,14 @@ class APITest(AironeViewTest):
         mock_resp.text = 'test-failure'
         mock_requests.post.return_value = mock_resp
 
-        resp = self.client.post('/webhook/api/v1/%s' % entity.id, json.dumps({
+        resp = self.client.post('/webhook/api/v1/set/%s' % entity.id, json.dumps({
             'webhook_url': 'https://example.com',
             'label': 'test endpoint',
             'request_headers': [{'key': 'content-type', 'value': 'application/json'}],
             'is_enabled': True,
         }), 'application/json')
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json()['msg'], 'Succeded in registering Webhook URL')
+        self.assertEqual(resp.json()['msg'], 'Succeded in registering Webhook')
 
         webhook = Webhook.objects.get(id=resp.json()['webhook_id'])
         self.assertEqual(webhook.url, 'https://example.com')
@@ -46,14 +46,14 @@ class APITest(AironeViewTest):
         mock_resp.text = 'test-failure'
         mock_requests.post.return_value = mock_resp
 
-        resp = self.client.post('/webhook/api/v1/%s' % entity.id, json.dumps({
+        resp = self.client.post('/webhook/api/v1/set/%s' % entity.id, json.dumps({
             'webhook_url': 'https://example.com',
             'label': 'test endpoint',
             'request_headers': [{'key': 'content-type', 'value': 'application/json'}],
             'is_enabled': True,
         }), 'application/json')
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json()['msg'], 'Succeded in registering Webhook URL')
+        self.assertEqual(resp.json()['msg'], 'Succeded in registering Webhook')
 
         webhook = Webhook.objects.get(id=resp.json()['webhook_id'])
         self.assertEqual(webhook.url, 'https://example.com')
@@ -73,7 +73,7 @@ class APITest(AironeViewTest):
         mock_resp.text = 'test-failure'
         mock_requests.post.return_value = mock_resp
 
-        resp = self.client.post('/webhook/api/v1/%s' % entity.id, json.dumps({
+        resp = self.client.post('/webhook/api/v1/set/%s' % entity.id, json.dumps({
             'id': 999999,  # invlaid webhook id
             'webhook_url': 'https://example.com',
             'label': 'test endpoint',
@@ -98,7 +98,7 @@ class APITest(AironeViewTest):
         mock_resp.text = 'test-failure'
         mock_requests.post.return_value = mock_resp
 
-        resp = self.client.post('/webhook/api/v1/%s' % entity.id, json.dumps({
+        resp = self.client.post('/webhook/api/v1/set/%s' % entity.id, json.dumps({
             'id': webhook.id,
             'webhook_url': 'https://changed-example.com',
             'label': 'changed-label',
@@ -114,3 +114,16 @@ class APITest(AironeViewTest):
         self.assertEqual(webhook.headers, json.dumps({'content-type': 'application/json'}))
         self.assertTrue(webhook.is_enabled)
         self.assertTrue(webhook.is_verified)
+
+    def test_delete_webhook_instance(self):
+        user = self.guest_login()
+        entity = Entity.objects.create(name='test-entity', created_user=user)
+        webhook = Webhook.objects.create(**{
+            'url': 'https://example.com'
+        })
+        entity.webhooks.add(webhook)
+
+        resp = self.client.delete('/webhook/api/v1/del/%s' % webhook.id)
+        self.assertEqual(resp.status_code, 200)
+
+        self.assertEqual(Webhook.objects.filter(id=webhook.id).first(), None)

--- a/webhook/urls.py
+++ b/webhook/urls.py
@@ -3,6 +3,6 @@ from django.conf.urls import url, include
 from . import views
 
 urlpatterns = [
-    url(r'^api/v1', include(('webhook.api_v1.urls', 'webhook.api_v1'))),
+    url(r'^api/v1/', include(('webhook.api_v1.urls', 'webhook.api_v1'))),
     url(r'^(\d+)$', views.list_webhook, name='list_webhook'),
 ]


### PR DESCRIPTION
close: https://github.com/dmm-com/airone/issues/202
Fixed webhook URL settings.
Fixed an issue where webhook tests were not running.

I confirmed that it can be set and deleted.
![image](https://user-images.githubusercontent.com/5561786/130169055-71ccb726-f851-4973-9746-4db4cffcf0ab.png)
![image](https://user-images.githubusercontent.com/5561786/130169082-d92a9db5-b22b-4f9e-ab0a-169e7c8ecf0d.png)
