### PR TITLE
Reset default margin on the body

### DIFF
--- a/templates/frontend/index.html
+++ b/templates/frontend/index.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
   <title>Django DRF - React : Quickstart - Valentino G. - www.valentinog.com</title>
 </head>
-<body>
+<body style="margin: 0px">
   <div id="app" class="columns"><!-- React --></div>
 
   <script type="text/javascript">


### PR DESCRIPTION
Eliminate the default (from user agent stylesheet) margin.

# before

The `<body>` has `margin: 8px` automatically.

![image](https://user-images.githubusercontent.com/191684/130317549-9e6db1e7-5279-45f3-91b2-3c8564a0d65c.png)

# after

![image](https://user-images.githubusercontent.com/191684/130317570-ffe43ce3-dc87-43a2-820d-860379fe3561.png)
