### PR TITLE
Added npm watch mode for React development

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,11 @@ Type 'yes' to continue, or 'no' to cancel: yes
 $ source .venv/bin/activate
 $ gunicorn airone.wsgi:application --bind=0.0.0.0:8080 --workers=3
 ```
+```
+(In development)
+$ source .venv/bin/activate
+$ python manage.py runserver
+```
 
 ## [Experimental] Build the new UI with React
 
@@ -331,6 +336,11 @@ $ gunicorn airone.wsgi:application --bind=0.0.0.0:8080 --workers=3
 ```
 $ npm install
 $ npm run build
+```
+```
+(In development)
+$ npm install
+$ npm run watch
 ```
 
 You can also auto-format .js files with [prettier](https://prettier.io/):

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "npm run build:development",
     "build:development": "webpack build --mode development",
     "build:production": "webpack build --mode production",
+    "watch": "webpack build --watch --mode development",
     "lint": "npx prettier --check frontend/",
     "fix": "npx prettier --write frontend/",
     "test": "npx jest frontend"


### PR DESCRIPTION
Added watch option to speed up build during development.
It is fast because only the change file is built.

```
(.venv) [root@PC-0001863-wsl airone]# npm run watch

> airone@1.0.0 watch /root/airone
> webpack build --watch --mode development

asset new-ui.js 2.43 MiB [compared for emit] (name: index)
orphan modules 784 KiB [orphan] 407 modules
runtime modules 1.13 KiB 5 modules
cacheable modules 1.86 MiB
  modules by path ./node_modules/ 1.76 MiB 176 modules
  modules by path ./frontend/src/ 100 KiB
    modules by path ./frontend/src/pages/*.js 53.8 KiB 16 modules
    modules by path ./frontend/src/components/ 37.2 KiB 12 modules
    modules by path ./frontend/src/utils/*.js 5.59 KiB
      ./frontend/src/utils/AironeAPIClient.js 4.46 KiB [built] [code generated]
      ./frontend/src/utils/Constants.js 951 bytes [built] [code generated]
      ./frontend/src/utils/DjangoUtils.js 202 bytes [built] [code generated]
    ./frontend/src/App.js 3.7 KiB [built] [code generated]
webpack 5.36.2 compiled successfully in 5945 ms
asset new-ui.js 2.43 MiB [emitted] (name: index)
cached modules 2.62 MiB [cached] 683 modules
runtime modules 1.13 KiB 5 modules
./frontend/src/pages/Dashboard.js 1.83 KiB [built] [code generated]
webpack 5.36.2 compiled successfully in 693 ms
```