### PR TITLE
Catch ValueError caused by yaml.load()

### DIFF
--- a/entry/tests/fixtures/invalid_import_data3.yaml
+++ b/entry/tests/fixtures/invalid_import_data3.yaml
@@ -1,0 +1,5 @@
+# out of range on date-type
+Entity:
+  - name: Entry
+    attrs:
+      date: 9999-99-99

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -2427,7 +2427,7 @@ class ViewTest(AironeViewTest):
             entity.attrs.add(attr)
 
         # try to import data which has invalid data structure
-        for index in range(3):
+        for index in range(4):
             fp = self.open_fixture_file('invalid_import_data%d.yaml' % index)
             resp = self.client.post(reverse('entry:do_import', args=[entity.id]), {'file': fp})
             self.assertEqual(resp.status_code, 400)

--- a/entry/views.py
+++ b/entry/views.py
@@ -461,6 +461,8 @@ def do_import_data(request, entity_id, context):
         data = yaml.load(context, Loader=yaml.FullLoader)
     except yaml.parser.ParserError:
         return HttpResponse("Couldn't parse uploaded file", status=400)
+    except ValueError as e:
+        return HttpResponse("Invalid value is found: %s" % e, status=400)
 
     if not Entry.is_importable_data(data):
         return HttpResponse("Uploaded file has invalid data structure to import", status=400)


### PR DESCRIPTION
If importing an invalid date value, current import feature failed by uncaught `ValueError`. For e.g.

![image](https://user-images.githubusercontent.com/191684/131210560-cb8c3545-4c2e-46f8-be21-078cc2603987.png)
![image](https://user-images.githubusercontent.com/191684/131210564-5766e55a-567f-4678-9813-94a8b99e8eba.png)

So I fix the importer to catch `ValueError` and return 400 error.