### PR TITLE
Put a link to edit-passwd on user page

### DIFF
--- a/templates/edit_user.html
+++ b/templates/edit_user.html
@@ -21,6 +21,11 @@
   </div>
   <div class="row">
     <div class="col">
+      <p>パスワードの変更は <a href="/user/edit_passwd/{{ user_id }}">こちら</a> から可能です</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
       <form id="edit-form" name="edit-form" url="/user/do_edit/{{ user_id }}" method='post'>
 
         <!-- Top navigation buttons-->


### PR DESCRIPTION
To improve usability, I put a link to edit-password page on edit-user page.

![image](https://user-images.githubusercontent.com/191684/131211494-c151bc6c-7298-43a6-beb8-6221e02c823a.png)
