### PR TITLE
Try to show/record entry history

### DIFF
--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -147,8 +147,10 @@ def render(request, template, context={}):
     context['OPERATION_HISTORY'] = {
         'ADD_ENTITY': History.ADD_ENTITY,
         'ADD_ATTR': History.ADD_ATTR,
+        'ADD_ENTRY': History.ADD_ENTRY,
         'MOD_ENTITY': History.MOD_ENTITY,
         'MOD_ATTR': History.MOD_ATTR,
+        'MOD_ENTRY': History.MOD_ENTRY,
         'DEL_ENTITY': History.DEL_ENTITY,
         'DEL_ATTR': History.DEL_ATTR,
         'DEL_ENTRY': History.DEL_ENTRY,

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -337,6 +337,11 @@ def restore_entry(self, job_id):
         # update entry information to Elasticsearch
         entry.register_es()
 
+        # register operation History for restoring entry
+        user = User.objects.filter(id=job.user.id).first()
+        entry_history = user.seth_entry_mod(entry)
+        entry_history.mod_entry(entry, 'restore deleted entry')
+
         # update job status and save it
         job.update(Job.STATUS['DONE'])
 

--- a/templates/show_entry/change_history.html
+++ b/templates/show_entry/change_history.html
@@ -1,3 +1,47 @@
+<h3>エントリの変更履歴</h3>
+<div>
+  <table class="table">
+    <thead>
+    <tr>
+      <th>Operator</th>
+      <th>Operation</th>
+      <th>Details</th>
+      <th>Time</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for column in entry_history %}
+      <tr>
+        <td>{{ column.user.username }}</td>
+        {% if column.operation == OPERATION_HISTORY.ADD_ENTRY %}
+          <td>作成</td>
+        {% elif column.operation == OPERATION_HISTORY.MOD_ENTRY %}
+          <td>変更</td>
+        {% elif column.operation == OPERATION_HISTORY.DEL_ENTRY %}
+          <td>削除</td>
+        {% else %}
+          <td>{{ column.operation }} ({{ OPERATION_HISTORY.ADD_ENTRY }})</td>
+        {% endif %}
+        <td>
+          <table class='table'>
+            <tbody>
+            {% for detail in column.details.all %}
+              <tr>
+                <td>{{ detail.target_obj.name }}</td>
+                <td>{{ detail.text }}</td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </td>
+        <td>{{ column.time }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<h3>属性の変更履歴</h3>
 <div class="row">
   <div class="col">
     <table class="table table-borderless airone-entry-table-history" id='attribute-history'>

--- a/user/models.py
+++ b/user/models.py
@@ -149,6 +149,12 @@ class User(DjangoUser):
     def seth_entity_del(self, target):
         return History.register(self, target, History.DEL_ENTITY)
 
+    def seth_entry_add(self, target):
+        return History.register(self, target, History.ADD_ENTRY)
+
+    def seth_entry_mod(self, target):
+        return History.register(self, target, History.MOD_ENTRY)
+
     def seth_entry_del(self, target):
         return History.register(self, target, History.DEL_ENTRY)
 
@@ -175,8 +181,10 @@ class History(models.Model):
 
     ADD_ENTITY = OP_ADD + TARGET_ENTITY
     ADD_ATTR = OP_ADD + TARGET_ATTR
+    ADD_ENTRY = OP_ADD + TARGET_ENTRY
     MOD_ENTITY = OP_MOD + TARGET_ENTITY
     MOD_ATTR = OP_MOD + TARGET_ATTR
+    MOD_ENTRY = OP_MOD + TARGET_ENTRY
     DEL_ENTITY = OP_DEL + TARGET_ENTITY
     DEL_ATTR = OP_DEL + TARGET_ATTR
     DEL_ENTRY = OP_DEL + TARGET_ENTRY
@@ -220,6 +228,14 @@ class History(models.Model):
     def mod_entity(self, target, text=''):
         detail = History.register(target=target,
                                   operation=History.MOD_ENTITY,
+                                  user=self.user,
+                                  text=text,
+                                  is_detail=True)
+        self.details.add(detail)
+
+    def mod_entry(self, target, text=''):
+        detail = History.register(target=target,
+                                  operation=History.MOD_ENTRY,
                                   user=self.user,
                                   text=text,
                                   is_detail=True)


### PR DESCRIPTION
Current entry-history page doesn't provide updates on the entry itself -- in other words, it actually supports only updated on their attributes. So I would like to support to record activities of entry(create/edit/delete/restore).

We can realize it with current data structure, like below:
![image](https://user-images.githubusercontent.com/191684/132090741-fda22bf1-5f22-482f-9033-bbed349b0b67.png)
