### PR TITLE
Fix entity breadcrumb on React UI

### DIFF
--- a/frontend/src/pages/EditEntity.js
+++ b/frontend/src/pages/EditEntity.js
@@ -34,6 +34,15 @@ export default function EditEntity({}) {
         <Typography component={Link} to={`/new-ui/entities`}>
           エンティティ一覧
         </Typography>
+        {/* TODO consider loading case */}
+        {!entity.loading && (
+          <Typography
+            component={Link}
+            to={`/new-ui/entities/${entityId}/entries`}
+          >
+            {entity.value.name}
+          </Typography>
+        )}
         <Typography color="textPrimary">エンティティ編集</Typography>
       </AironeBreadcrumbs>
 


### PR DESCRIPTION
Fix the breadcrumb to show entity name
![image](https://user-images.githubusercontent.com/191684/132302323-6b7d8ad4-5dcf-4ad7-902e-e8613b4d10a6.png)
