### PR TITLE
Fixed some attributes are not updated in advanced search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 * Fixed the problem that the URL of Webhook API is different (#202)
+* Fixed some attributes are not updated in advanced search results (#230)
 
 ## v3.2.0
 

--- a/entry/models.py
+++ b/entry/models.py
@@ -1333,7 +1333,7 @@ class Entry(ACLBase):
         for entity_attr in self.schema.attrs.filter(is_active=True):
             attrv = None
 
-            attr = self.attrs.filter(schema=entity_attr)
+            attr = self.attrs.filter(schema=entity_attr, is_active=True)
             if attr:
                 attrv = attr.first().get_latest_value()
 


### PR DESCRIPTION
close: https://github.com/dmm-com/airone/issues/230

Fixed some attributes are not updated in advanced search results.
Updating the entry after the fix will resolve it.

![image](https://user-images.githubusercontent.com/5561786/132481145-2d49beb7-8bcc-442b-9aad-66ee469e2e83.png)
![image](https://user-images.githubusercontent.com/5561786/132481066-782f9217-7dd4-4a45-87da-6f065019f4c8.png)
