### PR TITLE
Fixed the session being cut off after logging in with multi-DB

### DIFF
--- a/airone/lib/db.py
+++ b/airone/lib/db.py
@@ -1,0 +1,27 @@
+import logging
+
+from django_replicated.middleware import ReplicationMiddleware
+from django_replicated.utils import routers
+
+log = logging.getLogger('django_replicated.middleware')
+
+
+class AirOneReplicationMiddleware(ReplicationMiddleware):
+    def handle_redirect_after_write(self, request, response):
+        '''
+        Sets a flag using cookies to redirect requests happening after
+        successful write operations to ensure that corresponding read
+        request will use master database. This avoids situation when
+        replicas lagging behind on updates a little.
+
+        (AirOne)
+        The original deletes the cookie on the second GET request.
+        Changed to retain cookies as replication may be delayed.
+        Also, I changed to set a cookie after connecting to MasterDB
+        even if it is not a redirect. After the number of seconds specified
+        by MAX_AGE has elapsed, it will be deleted on the browser side.
+        '''
+
+        if routers.state() == 'master':
+            log.debug('set force master cookie for %s', request.path)
+            self.set_force_master_cookie(response)

--- a/airone/settings.py
+++ b/airone/settings.py
@@ -67,7 +67,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
-    'django_replicated.middleware.ReplicationMiddleware',
+    'airone.lib.db.AirOneReplicationMiddleware',
 ]
 
 ROOT_URLCONF = 'airone.urls'

--- a/airone/tests/test_db.py
+++ b/airone/tests/test_db.py
@@ -1,0 +1,46 @@
+import time
+from django.utils.http import parse_http_date
+
+from airone.lib.test import AironeViewTest
+from airone import settings
+
+COOKIE_NAME = settings.REPLICATED_FORCE_MASTER_COOKIE_NAME
+
+
+class ViewTest(AironeViewTest):
+    def setUp(self):
+        super(ViewTest, self).setUp()
+
+        self.admin = self.admin_login()
+
+    def test_replicated_middleware(self):
+        # Post: use master, set cookie
+        with self.assertLogs('django_replicated.router', level='DEBUG') as log:
+            self.assertNotIn(COOKIE_NAME, self.client.cookies)
+            response = self.client.post('/dashboard/')
+            self.assertEqual(response.cookies[COOKIE_NAME].value, 'true')
+            self.assertIn('DEBUG:django_replicated.router:db_for_write: default', log.output)
+
+        # First GET after POST: use master, set cookie
+        with self.assertLogs('django_replicated.router', level='DEBUG') as log:
+            self.assertEqual(self.client.cookies[COOKIE_NAME].value, 'true')
+            response = self.client.get('/dashboard/')
+            self.assertEqual(response.cookies[COOKIE_NAME].value, 'true')
+            self.assertIn('DEBUG:django_replicated.router:db_for_write: default', log.output)
+
+        # Second GET after POST: use master, set cookie
+        with self.assertLogs('django_replicated.router', level='DEBUG') as log:
+            self.assertEqual(response.cookies[COOKIE_NAME].value, 'true')
+            response = self.client.get('/dashboard/')
+            self.assertEqual(response.cookies[COOKIE_NAME].value, 'true')
+            self.assertIn('DEBUG:django_replicated.router:db_for_write: default', log.output)
+
+        # GET after expired cookies: use slave
+        with self.assertLogs('django_replicated.router', level='DEBUG') as log:
+            self.assertTrue(parse_http_date(self.client.cookies[COOKIE_NAME]['expires']) <
+                            (time.time() + settings.REPLICATED_FORCE_MASTER_COOKIE_MAX_AGE))
+            # Delete expired cookies
+            del self.client.cookies[COOKIE_NAME]
+            response = self.client.get('/dashboard/')
+            self.assertNotIn(COOKIE_NAME, self.client.cookies)
+            self.assertIn('DEBUG:django_replicated.router:db_for_read: default', log.output)


### PR DESCRIPTION
The django_replicated library selects SlaveDB for GET requests, and MaserDB otherwise.
Also, for the redirect after POST, select MasterDB even for GET.
This is only once. Subsequent GET requests will select SlaveDB.

If SlaveDB has replication delays, referencing non-existent data can be a problem.
e.g.) there is no session data in SlaveDB immediately after logging in.

After selecting MasterDB, I changed it so that MasterDB is selected until cokkie expires.

The original code is below.
https://github.com/yandex/django_replicated/blob/125ec732162091411811cf77c8061e4ed6fcd7de/django_replicated/middleware.py#L142-L155