### PR TITLE
Fixed displaying old values on the show entry page

### DIFF
--- a/entry/models.py
+++ b/entry/models.py
@@ -1103,7 +1103,7 @@ class Entry(ACLBase):
             attrinfo['last_value'] = AttrDefaultValue[entity_attr.type]
 
             # check that attribute exists
-            attr = self.attrs.filter(schema=entity_attr).first()
+            attr = self.attrs.filter(is_active=True, schema=entity_attr).first()
             if not attr:
                 attrinfo['permission'] = user.has_permission(entity_attr, permission)
                 ret_attrs.append(attrinfo)

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -1012,6 +1012,25 @@ class ModelTest(AironeTestCase):
             self.assertEqual(result['permission'], True)
             self.assertEqual(result['last_value'], attrinfo[attr.name]['exp_val'])
 
+    def test_get_available_attrs_with_multi_attribute(self):
+        self._entity.attrs.add(self._attr.schema)
+        self._entry.attrs.add(self._attr)
+
+        # Add and register duplicate Attribute after registers
+        dup_attr = Attribute.objects.create(name=self._attr.schema.name,
+                                            schema=self._attr.schema,
+                                            created_user=self._user,
+                                            parent_entry=self._entry)
+        self._entry.attrs.add(dup_attr)
+
+        self._attr.delete()
+
+        attr = self._entry.attrs.filter(schema=self._attr.schema, is_active=True).first()
+        attr.add_value(self._user, 'hoge')
+
+        results = self._entry.get_available_attrs(self._user)
+        self.assertEqual(results[0]['last_value'], 'hoge')
+
     def test_set_attrvalue_to_entry_attr_without_availabe_value(self):
         user = User.objects.create(username='hoge')
 


### PR DESCRIPTION
In rare cases, multiple Attribute may be created.
Fixed displaying old values on the show entry page.