### PR TITLE
Escape \ on ES query

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -261,12 +261,15 @@ def _get_hint_keyword_val(keyword: str) -> str:
     Returns:
         str: If a character corresponding to the empty string specified by CONFIG is entered,
             the empty character is returned.
+            Else if keyword contains '\\', a white space is returned specially.
             Otherwise, the input value is returned.
 
     """
     if (CONFIG.EMPTY_SEARCH_CHARACTER == keyword or
             CONFIG.EMPTY_SEARCH_CHARACTER_CODE == keyword):
         return ''
+    if '\\' in keyword:
+        return ' '
     return keyword
 
 

--- a/entry/settings.py
+++ b/entry/settings.py
@@ -12,8 +12,8 @@ CONFIG = Settings({
     'EMPTY_SEARCH_CHARACTER_CODE': chr(165),
     'AND_SEARCH_CHARACTER': '&',
     'OR_SEARCH_CHARACTER': '|',
-    'ESCAPE_CHARACTERS': ['(', ')', '<', '"', '{', '[', '#', '~', '@', '+', '*', '.', '?', '\\'],
-    'ESCAPE_CHARACTERS_REFERRALS_ENTRY': ['$', '(', '^', '|', '[', '+', '*', '.', '?', '\\'],
+    'ESCAPE_CHARACTERS': ['(', ')', '<', '"', '{', '[', '#', '~', '@', '+', '*', '.', '?'],
+    'ESCAPE_CHARACTERS_REFERRALS_ENTRY': ['$', '(', '^', '|', '[', '+', '*', '.', '?'],
     'ESCAPE_CHARACTERS_ENTRY_LIST': ['$', '(', '^', '\\', '|', '[', '+', '*', '.', '?'],
     'TIME_FORMAT': '%Y-%m-%dT%H:%M:%S',
 })

--- a/entry/settings.py
+++ b/entry/settings.py
@@ -12,8 +12,8 @@ CONFIG = Settings({
     'EMPTY_SEARCH_CHARACTER_CODE': chr(165),
     'AND_SEARCH_CHARACTER': '&',
     'OR_SEARCH_CHARACTER': '|',
-    'ESCAPE_CHARACTERS': ['(', ')', '<', '"', '{', '[', '#', '~', '@', '+', '*', '.', '?'],
-    'ESCAPE_CHARACTERS_REFERRALS_ENTRY': ['$', '(', '^', '|', '[', '+', '*', '.', '?'],
+    'ESCAPE_CHARACTERS': ['(', ')', '<', '"', '{', '[', '#', '~', '@', '+', '*', '.', '?', '\\'],
+    'ESCAPE_CHARACTERS_REFERRALS_ENTRY': ['$', '(', '^', '|', '[', '+', '*', '.', '?', '\\'],
     'ESCAPE_CHARACTERS_ENTRY_LIST': ['$', '(', '^', '\\', '|', '[', '+', '*', '.', '?'],
     'TIME_FORMAT': '%Y-%m-%dT%H:%M:%S',
 })

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -2860,17 +2860,14 @@ class ModelTest(AironeTestCase):
         for attr_name, info in attr_info.items():
             ret = Entry.search_entries(
                 user, [entity.id], [{'name': attr_name, 'keyword': double_empty_search_character}])
-            if attr_name not in ['bool', 'date']:
-                self.assertEqual(ret['ret_count'], 1)
-            else:
-                self.assertEqual(ret['ret_count'], 0)
+            self.assertEqual(ret['ret_count'], 0)
 
         # check functionallity of the 'entry_name' parameter
         ret = Entry.search_entries(user, [], entry_name=CONFIG.EMPTY_SEARCH_CHARACTER)
         self.assertEqual(ret['ret_count'], 1)
 
         ret = Entry.search_entries(user, [], entry_name=double_empty_search_character)
-        self.assertEqual(ret['ret_count'], 1)
+        self.assertEqual(ret['ret_count'], 0)
 
         # check combination of 'entry_name' and 'hint_attrs' parameter
         ret = Entry.search_entries(user, [entity.id],


### PR DESCRIPTION
If filter condition has `\`, ES sometimes returns 400 error with saying `elasticsearch.exceptions.RequestError: TransportError(400, 'search_phase_execution_exception', 'failed to create query:...`. So I think its better to escape `\` before sending the query.

before:
![image](https://user-images.githubusercontent.com/191684/133882963-0d7f0fdf-dfd9-48de-b138-8dc1fb40e41b.png)

after:
![image](https://user-images.githubusercontent.com/191684/133882997-c7b7e8ac-6b7e-4dee-a603-9f8e6c06b553.png)
