### PR TITLE
Redirect authenticated users to the top page

### DIFF
--- a/airone/urls.py
+++ b/airone/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.conf.urls import url, include
 from django.contrib import admin
+from django.contrib.auth import views as auth_views
 from django.views.generic import RedirectView
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
@@ -18,7 +19,10 @@ urlpatterns = [
     url(r'^api-auth/', include(('rest_framework.urls', 'rest_framework'))),
     url(r'^api/v1/', include(api_v1_urlpatterns)),
     url(r'^job/', include(('job.urls', 'job'))),
-    url(r'^auth/', include(('django.contrib.auth.urls', 'auth'))),
+    url(r'^auth/login/', auth_views.LoginView.as_view(
+        redirect_authenticated_user=True,
+    ), name='login'),
+    url(r'^auth/logout/', auth_views.LogoutView.as_view(), name='logout'),
     url(r'^webhook/', include(('webhook.urls', 'webhook'))),
 ]
 

--- a/templates/nav_header.html
+++ b/templates/nav_header.html
@@ -9,7 +9,7 @@
       {% if user.is_authenticated %}
       <li class='navbar'>{% include 'nav_user.html' %}</li>
       {% else %}
-      <li class="navbar"><a href="{% url 'auth:login' %}" class="nav-link">ログイン</a></li>
+      <li class="navbar"><a href="{% url 'login' %}" class="nav-link">ログイン</a></li>
       {% endif %}
       <li class='navbar'>{% include 'nav_jobs.html' %}
       </li>

--- a/templates/nav_user.html
+++ b/templates/nav_user.html
@@ -3,6 +3,6 @@
   <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
     <a class="dropdown-item" href="/user/edit/{{ user.id }}">ユーザ設定</a>
     <div class="dropdown-divider"></div>
-    <a class="dropdown-item" href="{% url 'auth:logout' %}">ログアウト</a>
+    <a class="dropdown-item" href="{% url 'logout' %}">ログアウト</a>
   </div>
 </div>

--- a/templates/password_reset_complete.html
+++ b/templates/password_reset_complete.html
@@ -2,6 +2,6 @@
 <body>
 <h2>Password reset</h2>
 <p>Your password has been set. You may go ahead and log in now.</p>
-<p><a href="{% url 'auth:login' %}">Log in</a></p>
+<p><a href="{% url 'login' %}">Log in</a></p>
 </body>
 </html>

--- a/templates/registration/logged_out.html
+++ b/templates/registration/logged_out.html
@@ -2,6 +2,6 @@
   <body>
     <h2>Logged out</h2>
     <p>You have been successfully logged out.</p>
-    <p><a href="{% url 'auth:login' %}">Log in</a> again.</p>
+    <p><a href="{% url 'login' %}">Log in</a> again.</p>
   </body>
 </html>


### PR DESCRIPTION
When authenticated users access to the login page, it simply shows the login form without redirect. Its better to redirect them to the default page.