### PR TITLE
Add missing null-checks on deleted-list-entry page

### DIFF
--- a/templates/list_entry/deleted_list.js
+++ b/templates/list_entry/deleted_list.js
@@ -178,7 +178,9 @@ function reconstruct_modal_body_for_entry(data) {
       let elem_ul = $("<ul class='list-group'>");
 
       for(var info of attr.value ) {
-        elem_ul.append($(`<li class='list-group-item'><a href='/entry/show/${ info.id }'>${ info.name }</li>`));
+        if (info) {
+          elem_ul.append($(`<li class='list-group-item'><a href='/entry/show/${ info.id }'>${ info.name }</li>`));
+        }
       }
       elem_td.append(elem_ul);
 
@@ -225,7 +227,9 @@ function reconstruct_modal_body_for_entry(data) {
       }
 
     } else if(attr.type == {{ attr_type.group }}) {
-      elem_td.append($(`<a href='/group/'>${ attr.value.name }</a>`));
+      if (attr.value) {
+        elem_td.append($(`<a href='/group/'>${ attr.value.name }</a>`));
+      }
 
     } else if(attr.type == {{ attr_type.array_group }}) {
       let elem_ul = $("<ul class='list-group'>");


### PR DESCRIPTION
The deleted-list-entry page misses some null-checks that occurs JavaScript errors. So I fix it to show available attributes on the page anyway.

![image](https://user-images.githubusercontent.com/191684/137576805-5442316a-df78-42a5-b690-3cf37c6fe3ef.png)
