### PR TITLE
Catch ScannerError on importing entry

### DIFF
--- a/entry/tests/fixtures/invalid_import_data4.yaml
+++ b/entry/tests/fixtures/invalid_import_data4.yaml
@@ -1,0 +1,5 @@
+# NBSP, instead of whitespace
+hoge:
+  - name: entry
+    attrs:
+      test: fuga

--- a/entry/tests/fixtures/invalid_import_data5.yaml
+++ b/entry/tests/fixtures/invalid_import_data5.yaml
@@ -1,0 +1,4 @@
+# A not scannable data
+hoge:
+- attrs:
+fuga

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -2471,7 +2471,7 @@ class ViewTest(AironeViewTest):
             entity.attrs.add(attr)
 
         # try to import data which has invalid data structure
-        for index in range(4):
+        for index in range(6):
             fp = self.open_fixture_file('invalid_import_data%d.yaml' % index)
             resp = self.client.post(reverse('entry:do_import', args=[entity.id]), {'file': fp})
             self.assertEqual(resp.status_code, 400)

--- a/entry/views.py
+++ b/entry/views.py
@@ -469,6 +469,10 @@ def do_import_data(request, entity_id, context):
         return HttpResponse("Couldn't parse uploaded file", status=400)
     except ValueError as e:
         return HttpResponse("Invalid value is found: %s" % e, status=400)
+    except yaml.scanner.ScannerError:
+        return HttpResponse("Couldn't scan uploaded file", status=400)
+    except Exception as e:
+        return HttpResponse("Unknown exception: %s" % e, status=500)
 
     if not Entry.is_importable_data(data):
         return HttpResponse("Uploaded file has invalid data structure to import", status=400)


### PR DESCRIPTION
Some yaml files may occur uncaught `yaml.scanner.ScannerError` on importing entry.

![image](https://user-images.githubusercontent.com/191684/138546548-a92b2769-0c1f-4e6e-95d3-121babe0affe.png)

It's better to catch the error and show reason of the error.