### PR TITLE
Attach referring entries on yaml export

### DIFF
--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -137,6 +137,12 @@ def _yaml_export(job, values, recv_data, has_referral):
 
                 data['attrs'][attrinfo['name']] = _get_attr_value(_adata['type'], _adata['value'])
 
+        if has_referral is not False:
+            data["referrals"] = [{
+                "entity": x["schema"],
+                "entry": x["name"],
+            } for x in entry_info['referrals']]
+
         if entry_info['entity']['name'] in resp_data:
             resp_data[entry_info['entity']['name']].append(data)
         else:

--- a/dashboard/tests/test_view.py
+++ b/dashboard/tests/test_view.py
@@ -659,3 +659,41 @@ class ViewTest(AironeViewTest):
         resp_data = yaml.load(Job.objects.last().get_cache(), Loader=yaml.FullLoader)
         self.assertEqual(len(resp_data['Entity']), 2)
         self.assertEqual([x['name'] for x in resp_data['Entity']], ['bar', 'baz'])
+
+    @patch('dashboard.tasks.export_search_result.delay',
+           Mock(side_effect=dashboard_tasks.export_search_result))
+    def test_yaml_export_with_referral(self):
+        user = self.admin
+
+        # initialize Entities
+        ref_entity = Entity.objects.create(name='ReferredEntity', created_user=user)
+        entity = Entity.objects.create(name='entity', created_user=user)
+        entity_attr = EntityAttr.objects.create(name='attr_ref',
+                                                type=AttrTypeValue['object'],
+                                                created_user=user,
+                                                parent_entity=entity)
+        entity_attr.referral.add(ref_entity)
+        entity.attrs.add(entity_attr)
+
+        # initialize Entries
+        ref_entry = Entry.objects.create(name='ref', schema=ref_entity, created_user=user)
+        ref_entry.register_es()
+
+        entry = Entry.objects.create(name='entry', schema=entity, created_user=user)
+        entry.complement_attrs(user)
+        entry.attrs.first().add_value(user, ref_entry)
+
+        resp = self.client.post(reverse('dashboard:export_search_result'), json.dumps({
+            'entities': [ref_entity.id],
+            'attrinfo': [],
+            'export_style': 'yaml',
+            'has_referral': '',
+        }), 'application/json')
+        self.assertEqual(resp.status_code, 200)
+
+        resp_data = yaml.load(Job.objects.last().get_cache(), Loader=yaml.FullLoader)
+        self.assertEqual(len(resp_data['ReferredEntity']), 1)
+        referrals = resp_data['ReferredEntity'][0]['referrals']
+        self.assertEqual(len(referrals), 1)
+        self.assertEqual(referrals[0]['entity'], 'entity')
+        self.assertEqual(referrals[0]['entry'], 'entry')


### PR DESCRIPTION
It allows us to get list of referrals on advanced search page.

If we search entries with `has_referral`:
![image](https://user-images.githubusercontent.com/191684/138550901-4d05ca99-3cb1-490f-b9a6-0bf2a512feb6.png)
the yaml exporter provides referral info on `.<entity>[index].referrals` element:
```yaml
referred:
- attrs:
    a1: a1
  name: referred1
  referrals:
  - entitiy: referring
    entry: referring1
```