### PR TITLE
Fixed implementation for ACL inheritance for Attribute

### DIFF
--- a/entry/models.py
+++ b/entry/models.py
@@ -993,19 +993,7 @@ class Entry(ACLBase):
         attr = Attribute.objects.create(name=base.name,
                                         schema=base,
                                         created_user=request_user,
-                                        parent_entry=self,
-                                        is_public=base.is_public,
-                                        default_permission=base.default_permission)
-
-        # inherits permissions of base object for user
-        [[user.permissions.add(getattr(attr, permission.name))
-            for permission in user.get_acls(base)]
-            for user in User.objects.filter(is_active=True)]
-
-        # inherits permissions of base object for each groups
-        [[group.permissions.add(getattr(attr, permission.name))
-            for permission in group.get_acls(base)]
-            for group in Group.objects.all()]
+                                        parent_entry=self)
 
         self.attrs.add(attr)
 

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -164,13 +164,10 @@ class ModelTest(AironeTestCase):
         entry = Entry.objects.create(name='entry', schema=entity, created_user=user)
         attr = entry.add_attribute_from_base(attrbase, user)
 
-        self.assertEqual(user.permissions.filter(name='writable').count(), 2)
-        self.assertEqual(user.permissions.filter(name='writable').first(), attrbase.writable)
-        self.assertEqual(user.permissions.filter(name='writable').last(), attr.writable)
-
-        # checks that acl metadata is inherited
-        self.assertFalse(attr.is_public)
-        self.assertEqual(attr.default_permission, attrbase.default_permission)
+        # checks that acl metadata is not inherited
+        self.assertTrue(attr.is_public)
+        self.assertEqual(attr.default_permission, ACLType.Nothing.id)
+        self.assertEqual(list(user.permissions.filter(name='writable').all()), [attrbase.writable])
 
     def test_inherite_attribute_permission_of_group(self):
         user = User.objects.create(username='hoge')
@@ -186,11 +183,9 @@ class ModelTest(AironeTestCase):
         group.permissions.add(attrbase.writable)
 
         entry = Entry.objects.create(name='entry', schema=entity, created_user=user)
-        attr = entry.add_attribute_from_base(attrbase, user)
+        entry.add_attribute_from_base(attrbase, user)
 
-        self.assertEqual(group.permissions.filter(name='writable').count(), 2)
-        self.assertEqual(group.permissions.filter(name='writable').first(), attrbase.writable)
-        self.assertEqual(group.permissions.filter(name='writable').last(), attr.writable)
+        self.assertEqual(list(group.permissions.filter(name='writable').all()), [attrbase.writable])
 
     def test_update_attribute_from_base(self):
         user = User.objects.create(username='hoge')
@@ -3284,6 +3279,7 @@ class ModelTest(AironeTestCase):
 
         # This checks both users have permissions for Attribute 'attr'
         attr = entry.attrs.first()
+        self.assertTrue(attr.is_public)
         self.assertTrue(all([g.has_permission(attr, ACLType.Full) for g in groups]))
         self.assertTrue(all([u.has_permission(attr, ACLType.Full) for u in [user1, user2]]))
 

--- a/group/models.py
+++ b/group/models.py
@@ -17,5 +17,10 @@ class Group(DjangoGroup):
         self.save()
 
     def has_permission(self, target_obj, permission_level):
+        # A bypass processing to rapidly return.
+        # This condition is effective when the public objects are majority.
+        if target_obj.is_public:
+            return True
+
         return any([permission_level.id <= x.get_aclid() for x
                     in self.permissions.all() if target_obj.id == x.get_objid()])


### PR DESCRIPTION
This commit fixed implementation not to inherit ACL settings of
EntityAttr when an Entry would be created because of changing
specification for it.