### PR TITLE
Fixed some issues with simple search and advanced search

### DIFF
--- a/entry/models.py
+++ b/entry/models.py
@@ -1513,16 +1513,15 @@ class Entry(ACLBase):
                 continue
 
             # Check for has permission to EntityAttr, when is_output_all flag
-            output_attrs = []
+            output_attrs = hint_attrs
             if is_output_all:
                 for entity_attr in entity.attrs.filter(is_active=True):
-                    output_attrs.append({
-                        'name': entity_attr.name,
-                        'is_readble': True if (
-                            user.has_permission(entity_attr, ACLType.Readable)) else False
-                    })
-            else:
-                output_attrs = hint_attrs
+                    if entity_attr.name not in [x['name'] for x in hint_attrs if 'name' in x]:
+                        output_attrs.append({
+                            'name': entity_attr.name,
+                            'is_readble': True if (
+                                user.has_permission(entity_attr, ACLType.Readable)) else False
+                        })
 
             # retrieve data from database on the basis of the result of elasticsearch
             search_result = make_search_results(user, resp, output_attrs, limit, hint_referral)

--- a/entry/models.py
+++ b/entry/models.py
@@ -1439,7 +1439,7 @@ class Entry(ACLBase):
         return ret_values
 
     @classmethod
-    def search_entries(kls, user, hint_entity_ids, hint_attrs=[], limit=CONFIG.MAX_LIST_ENTRIES,
+    def search_entries(kls, user, hint_entity_ids, hint_attrs=None, limit=CONFIG.MAX_LIST_ENTRIES,
                        entry_name=None, hint_referral=False, is_output_all=False):
         """Main method called from advanced search.
 
@@ -1482,6 +1482,9 @@ class Entry(ACLBase):
                 ],
             }
         """
+        if not hint_attrs:
+            hint_attrs = []
+
         results = {
             'ret_count': 0,
             'ret_values': [],
@@ -1513,18 +1516,17 @@ class Entry(ACLBase):
                 continue
 
             # Check for has permission to EntityAttr, when is_output_all flag
-            output_attrs = hint_attrs
             if is_output_all:
                 for entity_attr in entity.attrs.filter(is_active=True):
                     if entity_attr.name not in [x['name'] for x in hint_attrs if 'name' in x]:
-                        output_attrs.append({
+                        hint_attrs.append({
                             'name': entity_attr.name,
                             'is_readble': True if (
                                 user.has_permission(entity_attr, ACLType.Readable)) else False
                         })
 
             # retrieve data from database on the basis of the result of elasticsearch
-            search_result = make_search_results(user, resp, output_attrs, limit, hint_referral)
+            search_result = make_search_results(user, resp, hint_attrs, limit, hint_referral)
             results['ret_count'] += search_result['ret_count']
             results['ret_values'].extend(search_result['ret_values'])
             limit -= results['ret_count']

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -3130,9 +3130,15 @@ class ModelTest(AironeTestCase):
     def test_search_entries_with_is_output_all(self):
         self._entity.attrs.add(self._attr.schema)
         self._entry.attrs.add(self._attr)
+        self._entry.attrs.first().add_value(self._user, 'hoge')
         self._entry.register_es()
         ret = Entry.search_entries(self._user, [self._entity.id], is_output_all=True)
-        self.assertEqual(ret['ret_values'][0]['attrs'], {'attr': {'is_readble': True, 'type': 2}})
+        self.assertEqual(ret['ret_values'][0]['attrs'],
+                         {'attr': {'value': 'hoge', 'is_readble': True, 'type': 2}})
+
+        ret = Entry.search_entries(self._user, [self._entity.id],
+                                   [{'name': 'attr', 'keyword': '^ge'}], is_output_all=True)
+        self.assertEqual(ret['ret_count'], 0)
 
     def test_search_entries_for_simple(self):
         self._entity.attrs.add(self._attr.schema)

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -3419,7 +3419,7 @@ class ViewTest(AironeViewTest):
             self.assertEqual(resp.status_code, 200)
             self.assertEqual(attrv1.get_value(), attr.get_latest_value().get_value())
 
-        resp = Entry.search_entries(user, [entity.id])
+        resp = Entry.search_entries(user, [entity.id], [], is_output_all=True)
         self.assertEqual(resp['ret_count'], 1)
         for attr_name, data in resp['ret_values'][0]['attrs'].items():
             self.assertEqual(data['type'], attr_info[attr_name]['type'])

--- a/templates/advanced_search/result.html
+++ b/templates/advanced_search/result.html
@@ -36,7 +36,7 @@
     <tr>
       <th>
         Name<br/>
-        <input type='text' class='input-sm narrow_down_entries hint_entry_name' attrname='{{ attrname }}' value="{{ entry_name|default_if_none:'' }}"></input>
+        <input type='text' class='input-sm narrow_down_entries hint_entry_name' value="{{ entry_name|default_if_none:'' }}"></input>
       </th>
       {% for hint_attr in hint_attrs %}
       <th>
@@ -55,7 +55,7 @@
   </thead>
   <tbody id='main_table'>
     {% for result in results.ret_values %}
-    <tr>
+    <tr id='entryinfo'>
       <th id='entry_name'><a href='/entry/show/{{ result.entry.id }}/'>{{ result.entry.name }} [{{ result.entity.name }}]</a></th>
 
       {% for hint_attr in hint_attrs %}

--- a/templates/advanced_search/result.js
+++ b/templates/advanced_search/result.js
@@ -103,7 +103,7 @@ function reconstruct_tbody(results) {
   elem_parent.children().remove();
 
   for(var result of results) {
-    var new_elem_entry = $('<tr/>');
+    var new_elem_entry = $('<tr id=entryinfo/>');
 
     new_elem_entry.append(`<th id=entry_name><a href='/entry/show/${ result.entry.id }/'>${ result.entry.name } [${ result.entity.name}]</a></th>`);
 

--- a/templates/nav_header.html
+++ b/templates/nav_header.html
@@ -17,7 +17,7 @@
   </div>
   <div>
     <form class="form-inline" action="/dashboard/search/" id="navbar-search-form">
-      <input name='query' class="form-control" type="text" placeholder="Search" value="{{ search_query|default:"" }}" />
+      <input name='query' class="form-control" type="text" placeholder="Search" value="{{ query|default:"" }}" />
       <button class="btn btn-outline-secondary" type="submit" form="navbar-search-form">検索</button>
     </form>
   </div>

--- a/templates/show_search_results.html
+++ b/templates/show_search_results.html
@@ -36,7 +36,7 @@
         <th>Atribute Name</th>
       </tr>
       {% for entry in entries %}
-      <tr id="entryinfo" {% if entry.name == search_query %} class="table-primary" {% endif %}>
+      <tr id="entryinfo" {% if entry.name == query %} class="table-primary" {% endif %}>
         <td id="name"><a href="/entry/show/{{ entry.id }}/">{{ entry.name }}</a></td>
         <td id="attrname">{{ entry.attr|default_if_none:'' }}</td>
       </tr>


### PR DESCRIPTION
- Fixed an issue where regular expressions would fail in advanced searches.
  - before
![image](https://user-images.githubusercontent.com/5561786/143156247-219b69c3-a7e7-45ed-9ad7-1361b010a3db.png)
  - after
![image](https://user-images.githubusercontent.com/5561786/143156169-6e9fe68c-07fd-4b7c-a925-0b7f88fe7322.png)

- Fixed couldn't AND and OR searches in simple search
  - before
![image](https://user-images.githubusercontent.com/5561786/143157112-9f491f75-a41b-44a1-b834-b733d679a935.png)
(search 『ho&ge』)
  - after
![image](https://user-images.githubusercontent.com/5561786/143157209-f7135ae4-f96c-465d-8648-ab37dc964699.png)

- Added CSS selector for ui-test in advanced search