### PR TITLE
Fixed processing to send request data to a Entry that have Attributes, which have not been created yet.

### DIFF
--- a/templates/edit_entry/attrs.html
+++ b/templates/edit_entry/attrs.html
@@ -1,5 +1,5 @@
-{% for attr in attributes %}
 {% load bitwise_tags %}
+{% for attr in attributes %}
 <tr id='{{ attr.name|cut:" " }}'>
   <td>
     {% if attr.is_mandatory %}<strong>(*)</strong>{% endif %}{{ attr.name }}
@@ -8,7 +8,15 @@
   {% if not attr.is_readble %}
     <span>Permission denied.</span>  
   {% else %}
-    {% if attr.type|bitwise_and:attr_type_value.array %}
+    {% if not attr.id and attr.entity_attr_id %}
+    <!--
+      In this case, target attribute is middle of processing for making in the background.
+      It would not be better to display this attribute normally, but it also not be better
+      to hide. So, this emphasize "The current attribute is under processing to make".
+    -->
+    <div class="p-3 mb-2 bg-light text-dark">Current Attribute is under processing to make (plz, wait for a while)</div>
+
+    {% elif attr.type|bitwise_and:attr_type_value.array %}
       <div>
         <button type="button" class="btn btn-primary btn-sm" name='add_attr' attr_id="{{ attr.id }}" entity_attr_id="{{ attr.entity_attr_id }}">add row</button>
         <div class='array_element' attr_id="{{ attr.id }}" entity_attr_id="{{ attr.entity_attr_id }}" {%if attr.is_mandatory%}mandatory="true"{%endif%}>

--- a/templates/edit_entry/js.html
+++ b/templates/edit_entry/js.html
@@ -4,6 +4,16 @@ var get_register_attrs = function(base) {
   var attrs = []
 
   {% for attr in attributes %}
+    /*
+      This condition is necessary because attr.id might be None
+    when a new EntityAttr is added on an Entity until Attribute
+    instance is created on this Entry.
+
+      This prevents to sending AttributeValue data before
+    corresponding Attribute instance is created.
+    */
+    {% if attr.id %}
+
   attrs.push({
     'entity_attr_id': '{{ attr.entity_attr_id}}',
     'id': '{{ attr.id }}',
@@ -19,6 +29,8 @@ var get_register_attrs = function(base) {
       return {'data': $(e).val(), 'index': $(e).attr('index')};
     }).get(),
   });
+
+    {% endif %}
   {% endfor %}
 
   return attrs;


### PR DESCRIPTION
 After the multiple database measure (c.f. #166), specification of
creating Attribute instance was changed from creating it on-demand to
creating all Attributes at once when EntityAttr was added. By this
change, an attribute value data might be sent when a corresponding
Attribute instance has not been created yet. At that time, some problems
would be occurred.
 This commit fixes this problem at editing Entry for adding processing to
exempt to send request data for those Attributes that have not been
created on database yet.