### PR TITLE
Fixed an issue where advanced search narrow down was slow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fixed an issue that caused redirects by incorrect URL links
 * Fixed no permission check in advanced search and simple search(#282)
 * Fixed a different number of entries displayed on the entity dashboard (#308)
+* Fixed an issue where advanced search narrow down was slow (#321)
 
 ## v3.3.1
 

--- a/api_v1/entry/views.py
+++ b/api_v1/entry/views.py
@@ -34,10 +34,12 @@ class EntrySearchAPI(APIView):
         hint_entry_name = request.data.get('entry_name', '')
         hint_attr = request.data.get('attrinfo')
         hint_referral = request.data.get('referral', False)
+        is_output_all = request.data.get('is_output_all', True)
         entry_limit = request.data.get('entry_limit', CONFIG_ENTRY.MAX_LIST_ENTRIES)
 
         if (not isinstance(hint_entity, list) or
                 not isinstance(hint_attr, list) or
+                not isinstance(is_output_all, bool) or
                 not isinstance(entry_limit, int)):
             return Response('The type of parameter is incorrect',
                             status=status.HTTP_400_BAD_REQUEST)
@@ -64,7 +66,7 @@ class EntrySearchAPI(APIView):
                                     entry_limit,
                                     hint_entry_name,
                                     hint_referral,
-                                    True)
+                                    is_output_all)
 
         return Response({'result': resp}, content_type='application/json; charset=UTF-8')
 

--- a/templates/advanced_search/result.js
+++ b/templates/advanced_search/result.js
@@ -162,6 +162,7 @@ $(document).ready(function() {
           entities: '{{ entities }}'.split(','),
           entry_name: $('.hint_entry_name').val(),
           attrinfo: get_attrinfo(),
+          is_output_all: false,
       };
 
       {% if has_referral is not False %}


### PR DESCRIPTION
close: https://github.com/dmm-com/airone/issues/321

Added is_output_all option to entry search API.
In the advanced search result narrowing down, is_output_all was set to False to solve the problem.
![image](https://user-images.githubusercontent.com/5561786/144773511-88b34e82-167c-4635-aee1-1393b1e66421.png)