### PR TITLE
Fixed/advanced search/exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+* Fixed not being able to use regexp in entry names in the entry search API (#314)
 
 ## v3.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fixed an issue where advanced search narrow down was slow (#321)
 * Fixed not being able to use regexp in entry names in the entry search API (#314)
 * Fixed an exception error when specifying an invalid parameter in advanced search (#327)
+* Fixed the order of entities when is_all_entities is specified in advanced search (#330)
 
 ### Refactored
 * Refactored referral param in advanced search (#326)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Fixed not being able to use regexp in entry names in the entry search API (#314)
 * Fixed an exception error when specifying an invalid parameter in advanced search (#327)
 
+### Refactored
+* Refactored referral param in advanced search (#326)
+
 ## v3.4.1
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 * Fixed not being able to use regexp in entry names in the entry search API (#314)
+* Fixed an exception error when specifying an invalid parameter in advanced search (#327)
 
 ## v3.4.0
 

--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -220,6 +220,10 @@ def _is_valid(params, meta_info):
         return False
     # These are value checks of each parameters
     for _meta in meta_info:
+        # Skip no value
+        if 'omittable' in _meta and _meta['name'] not in params:
+            continue
+
         # The case specified value is str
         if (_meta['type'] == str and 'checker' in _meta and not _meta['checker'](params)):
             return False

--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -216,7 +216,7 @@ def _is_valid(params, meta_info):
         return False
     # These are type checks of each parameters
     if not all([isinstance(params[x['name']], x['type'])
-                for x in meta_info if 'omittable' not in x]):
+                for x in meta_info if x['name'] in params.keys()]):
         return False
     # These are value checks of each parameters
     for _meta in meta_info:

--- a/airone/tests/test_elasticsearch.py
+++ b/airone/tests/test_elasticsearch.py
@@ -34,38 +34,7 @@ class ElasticSearchTest(TestCase):
 
         # with anchor operators
         p2 = elasticsearch._get_regex_pattern('^keyword$')
-        self.assertEqual(p2, '.*^?[kK][eE][yY][wW][oO][rR][dD]$?.*')
-
-    def test_is_matched_keyword(self):
-        # if it has the same value with a hint
-        self.assertTrue(elasticsearch._is_matched_entry(
-            attrs=[{'name': 'attr', 'value': 'keyword', 'type': AttrTypeStr.TYPE}],
-            hint_attrs=[{'name': 'attr', 'keyword': 'keyword'}]
-        ))
-
-        # if a hint has ^ and/or $, it matches with the keyword as a regexp
-        self.assertTrue(elasticsearch._is_matched_entry(
-            attrs=[{'name': 'attr', 'value': 'keyword', 'type': AttrTypeStr.TYPE}],
-            hint_attrs=[{'name': 'attr', 'keyword': '^keyword'}]
-        ))
-        self.assertFalse(elasticsearch._is_matched_entry(
-            attrs=[{'name': 'attr', 'value': '111keyword', 'type': AttrTypeStr.TYPE}],
-            hint_attrs=[{'name': 'attr', 'keyword': '^keyword'}]
-        ))
-        self.assertTrue(elasticsearch._is_matched_entry(
-            attrs=[{'name': 'attr', 'value': 'keyword', 'type': AttrTypeStr.TYPE}],
-            hint_attrs=[{'name': 'attr', 'keyword': 'keyword$'}]
-        ))
-        self.assertFalse(elasticsearch._is_matched_entry(
-            attrs=[{'name': 'attr', 'value': 'keyword111', 'type': AttrTypeStr.TYPE}],
-            hint_attrs=[{'name': 'attr', 'keyword': 'keyword$'}]
-        ))
-
-        # if a hint is blank
-        self.assertTrue(elasticsearch._is_matched_entry(
-            attrs=[{'name': 'attr', 'value': 'keyword', 'type': AttrTypeStr.TYPE}],
-            hint_attrs=[{'name': 'attr', 'keyword': ''}]
-        ))
+        self.assertEqual(p2, '[kK][eE][yY][wW][oO][rR][dD]')
 
     def test_make_query(self):
         query = elasticsearch.make_query(

--- a/api_v1/entry/views.py
+++ b/api_v1/entry/views.py
@@ -30,16 +30,16 @@ class EntrySearchAPI(APIView):
     def post(self, request, format=None):
         user = User.objects.get(id=request.user.id)
 
-        hint_entity = request.data.get('entities')
+        hint_entities = request.data.get('entities')
         hint_entry_name = request.data.get('entry_name', '')
-        hint_attr = request.data.get('attrinfo')
+        hint_attrs = request.data.get('attrinfo')
         hint_referral = request.data.get('referral', False)
         is_output_all = request.data.get('is_output_all', True)
         entry_limit = request.data.get('entry_limit', CONFIG_ENTRY.MAX_LIST_ENTRIES)
 
-        if (not isinstance(hint_entity, list) or
+        if (not isinstance(hint_entities, list) or
                 not isinstance(hint_entry_name, str) or
-                not isinstance(hint_attr, list) or
+                not isinstance(hint_attrs, list) or
                 not isinstance(is_output_all, bool) or
                 not isinstance(hint_referral, (str, bool)) or
                 not isinstance(entry_limit, int)):
@@ -47,34 +47,43 @@ class EntrySearchAPI(APIView):
                             status=status.HTTP_400_BAD_REQUEST)
 
         # forbid to input large size request
-        if any([len(str(x)) > CONFIG_ENTRY.MAX_QUERY_SIZE * 2 for x in hint_attr]):
+        if len(hint_entry_name) > CONFIG_ENTRY.MAX_QUERY_SIZE:
             return Response("Sending parameter is too large", status=400)
 
+        # check attribute params
+        for hint_attr in hint_attrs:
+            if 'name' not in hint_attr:
+                return Response("The name key is required for attrinfo parameter", status=400)
+            if not isinstance(hint_attr['name'], str):
+                return Response("Invalid value for attrinfo parameter", status=400)
+            if hint_attr.get('keyword'):
+                if not isinstance(hint_attr['keyword'], str):
+                    return Response("Invalid value for attrinfo parameter", status=400)
+                # forbid to input large size request
+                if len(hint_attr['keyword']) > CONFIG_ENTRY.MAX_QUERY_SIZE:
+                    return Response("Sending parameter is too large", status=400)
+
         # check entities params
+        if not hint_entities:
+            return Response("The entities parameters are required", status=400)
         hint_entity_ids = []
-        for hint in hint_entity:
+        for hint_entity in hint_entities:
             entity = None
-            if isinstance(hint, int):
-                entity = Entity.objects.filter(Q(is_active=True),
-                                               Q(id=hint) | Q(name=hint)).first()
-            elif isinstance(hint, str):
-                if hint.isnumeric():
-                    entity = Entity.objects.filter(Q(is_active=True),
-                                                   Q(id=hint) | Q(name=hint)).first()
+            if isinstance(hint_entity, int):
+                entity = Entity.objects.filter(id=hint_entity, is_active=True).first()
+            elif isinstance(hint_entity, str):
+                if hint_entity.isnumeric():
+                    entity = Entity.objects.filter(Q(id=hint_entity) | Q(name=hint_entity),
+                                                   Q(is_active=True)).first()
                 else:
-                    # This may happen when a string value is specified in the entities parameter
-                    entity = Entity.objects.filter(name=hint, is_active=True).first()
+                    entity = Entity.objects.filter(name=hint_entity, is_active=True).first()
 
             if entity and user.has_permission(entity, ACLType.Readable):
                 hint_entity_ids.append(entity.id)
 
-        # check attrinfo params
-        if not all(['name' in x for x in hint_attr]):
-            return Response("The name key is required for attrinfo parameter", status=400)
-
         resp = Entry.search_entries(user,
                                     hint_entity_ids,
-                                    hint_attr,
+                                    hint_attrs,
                                     entry_limit,
                                     hint_entry_name,
                                     hint_referral,

--- a/api_v1/tests/entry/test_api.py
+++ b/api_v1/tests/entry/test_api.py
@@ -35,6 +35,20 @@ class APITest(AironeViewTest):
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.content, b'"The name key is required for attrinfo parameter"')
 
+        params = {**valid_params, **{
+            'attrinfo': [{'name': ['hoge']}]
+        }}
+        resp = self.client.post('/api/v1/entry/search', json.dumps(params), 'application/json')
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.content, b'"Invalid value for attrinfo parameter"')
+
+        params = {**valid_params, **{
+            'attrinfo': [{'name': 'value', 'keyword': ['hoge']}]
+        }}
+        resp = self.client.post('/api/v1/entry/search', json.dumps(params), 'application/json')
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.content, b'"Invalid value for attrinfo parameter"')
+
     def test_narrow_down_advanced_search_results(self):
         user = self.admin_login()
 
@@ -272,16 +286,39 @@ class APITest(AironeViewTest):
             }])
 
     def test_search_with_large_size_parameter(self):
-        LARGE_DATA = 'A' * 2048
         self.admin_login()
 
         params = {
             'entities': ['entity-1'],
-            'attrinfo': [{'name': 'attr', 'keyword': LARGE_DATA}]
+            'attrinfo': [{'name': 'attr', 'keyword': 'A' * 250}],
         }
         resp = self.client.post('/api/v1/entry/search', json.dumps(params), 'application/json')
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.content, b'"Sending parameter is too large"')
+
+        params = {
+            'entities': ['entity-1'],
+            'attrinfo': [{'name': 'attr'}],
+            'entry_name': 'A' * 250,
+        }
+        resp = self.client.post('/api/v1/entry/search', json.dumps(params), 'application/json')
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.content, b'"Sending parameter is too large"')
+
+        params = {
+            'entities': ['entity-1'],
+            'attrinfo': [{'name': 'attr', 'keyword': 'A' * 249}],
+        }
+        resp = self.client.post('/api/v1/entry/search', json.dumps(params), 'application/json')
+        self.assertEqual(resp.status_code, 200)
+
+        params = {
+            'entities': ['entity-1'],
+            'attrinfo': [{'name': 'attr'}],
+            'entry_name': 'A' * 249,
+        }
+        resp = self.client.post('/api/v1/entry/search', json.dumps(params), 'application/json')
+        self.assertEqual(resp.status_code, 200)
 
     def test_search_with_hint_entry_name(self):
         user = self.guest_login()
@@ -405,3 +442,14 @@ class APITest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
         result = resp.json()['result']
         self.assertEqual(list(result['ret_values'][0]['attrs'].keys()), ['attr1', 'attr2'])
+
+    def test_search_with_invalid_entity_param(self):
+        self.guest_login()
+
+        params = {
+            'entities': [],
+            'attrinfo': [{'name': 'attr'}],
+        }
+        resp = self.client.post('/api/v1/entry/search', json.dumps(params), 'application/json')
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.content, b'"The entities parameters are required"')

--- a/api_v1/tests/entry/test_api.py
+++ b/api_v1/tests/entry/test_api.py
@@ -8,6 +8,33 @@ from entry.models import Entry
 
 
 class APITest(AironeViewTest):
+    def test_search_invalid_param(self):
+        self.admin_login()
+        valid_params = {
+            'entities': [1],
+            'attrinfo': [],
+        }
+        invalid_params = [
+            {'entities': 'hoge'},
+            {'entry_name': ['hoge']},
+            {'attrinfo': 'hoge'},
+            {'is_output_all': 'hoge'},
+            {'referral': ['hoge']},
+            {'entry_limit': 'hoge'},
+        ]
+        for invalid_param in invalid_params:
+            params = {**valid_params, **invalid_param}
+            resp = self.client.post('/api/v1/entry/search', json.dumps(params), 'application/json')
+            self.assertEqual(resp.status_code, 400)
+            self.assertEqual(resp.content, b'"The type of parameter is incorrect"')
+
+        params = {**valid_params, **{
+            'attrinfo': [{'hoge': 'value'}]
+        }}
+        resp = self.client.post('/api/v1/entry/search', json.dumps(params), 'application/json')
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.content, b'"The name key is required for attrinfo parameter"')
+
     def test_narrow_down_advanced_search_results(self):
         user = self.admin_login()
 

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -165,20 +165,20 @@ def export_search_result(self, job_id):
     user = job.user
     recv_data = json.loads(job.params)
 
-    has_referral = False
-    if 'has_referral' in recv_data:
-        has_referral = recv_data['has_referral']
+    has_referral = recv_data.get('has_referral', False)
+    referral_name = recv_data.get('referral_name')
+    entry_name = recv_data.get('entry_name')
 
-    hint_entry_name = ''
-    if 'entry_name' in recv_data and recv_data['entry_name']:
-        hint_entry_name = recv_data['entry_name']
+    hint_referral = '' if has_referral else False
+    if referral_name:
+        hint_referral = referral_name
 
     resp = Entry.search_entries(user,
                                 recv_data['entities'],
                                 recv_data['attrinfo'],
                                 settings.ES_CONFIG['MAXIMUM_RESULTS_NUM'],
-                                hint_referral=has_referral,
-                                entry_name=hint_entry_name)
+                                entry_name,
+                                hint_referral)
 
     io_stream = None
     if recv_data['export_style'] == 'yaml':

--- a/dashboard/tests/test_view.py
+++ b/dashboard/tests/test_view.py
@@ -189,7 +189,39 @@ class ViewTest(AironeViewTest):
             'entity[]': [x.id for x in Entity.objects.filter(name__regex='^entity-')],
             'attrinfo': json.dumps([{'name': 'attr'}]),  # A newer param
         })
+        entities = Entity.objects.filter(name__regex='^entity-')
+        entity = entities.first()
+        entry = Entry.objects.filter(schema=entity).first()
+        attr = entry.attrs.first()
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.context['hint_attrs'],
+                         [{'name': 'attr', 'is_readble': attr.is_public}])
+        self.assertEqual(resp.context['results']['ret_count'], 20)
+        self.assertEqual(len(resp.context['results']['ret_values']), 20)
+        self.assertEqual(resp.context['results']['ret_values'][0], {
+            'entity': {
+                'id': entity.id,
+                'name': entity.name,
+            },
+            'entry': {
+                'id': entry.id,
+                'name': entry.name,
+            },
+            'attrs': {
+                'attr': {
+                    'is_readble': attr.is_public,
+                    'type': attr.schema.type,
+                    'value': attr.get_latest_value().value,
+                }
+            },
+            'is_readble': entry.is_public,
+        })
+        self.assertEqual(resp.context['max_num'], 100)
+        self.assertEqual(resp.context['entities'], ','.join([str(x.id) for x in entities]))
+        self.assertEqual(resp.context['has_referral'], False)
+        self.assertEqual(resp.context['referral_name'], None)
+        self.assertEqual(resp.context['is_all_entities'], False)
+        self.assertEqual(resp.context['entry_name'], '')
 
         # test to export results of advanced_search
         export_params = {
@@ -239,15 +271,13 @@ class ViewTest(AironeViewTest):
         # test to show advanced_search_result page without mandatory params
         resp = self.client.get(reverse('dashboard:advanced_search_result'), {})
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.content.decode('utf-8'),
-                         'The attr[] or attrinfo parameters is required')
+        self.assertEqual(resp.content.decode('utf-8'), 'The entity[] parameters are required')
 
         resp = self.client.get(reverse('dashboard:advanced_search_result'), {
             'attrinfo': 'hoge',
         })
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.content.decode('utf-8'),
-                         'The attr[] or attrinfo parameters is required')
+        self.assertEqual(resp.content.decode('utf-8'), 'The attrinfo parameter is not JSON')
 
         resp = self.client.get(reverse('dashboard:advanced_search_result'), {
             'attrinfo': json.dumps([{'hoge': 'attr'}]),
@@ -260,8 +290,20 @@ class ViewTest(AironeViewTest):
             'attrinfo': json.dumps([{'name': []}]),
         })
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.content.decode('utf-8'),
-                         'Invalid name key value for attrinfo parameter')
+        self.assertEqual(resp.content.decode('utf-8'), 'Invalid value for attrinfo parameter')
+
+        resp = self.client.get(reverse('dashboard:advanced_search_result'), {
+            'attrinfo': json.dumps([{'name': 'hoge'}]),
+            'is_all_entities': 'true',
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.content.decode('utf-8'), 'Invalid value for attribute parameter')
+
+        resp = self.client.get(reverse('dashboard:advanced_search_result'), {
+            'attrinfo': json.dumps([{'name': 'attr', 'keyword': []}]),
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.content.decode('utf-8'), 'Invalid value for attrinfo parameter')
 
         resp = self.client.get(reverse('dashboard:advanced_search_result'), {
             'attrinfo': json.dumps([{'name': 'attr'}]),
@@ -329,6 +371,7 @@ class ViewTest(AironeViewTest):
         })
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.context['results']['ret_count'], 2)
+        self.assertEqual(resp.context['entry_name'], 'entry-0')
 
         # test to show advanced_search_result page with has_referal param
         ref_entry = Entry.objects.get(name='srv001', schema__name='Server')
@@ -344,6 +387,7 @@ class ViewTest(AironeViewTest):
             'name': ref_entry.name,
             'schema': ref_entry.schema.name,
         }])
+        self.assertEqual(resp.context['has_referral'], True)
 
         # test to show advanced_search_result page with referral_name param
         resp = self.client.get(reverse('dashboard:advanced_search_result'), {
@@ -354,6 +398,7 @@ class ViewTest(AironeViewTest):
         })
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.context['results']['ret_count'], 1)
+        self.assertEqual(resp.context['referral_name'], 'srv001')
 
         # test to show advanced_search_result page with invalid has_referal param
         resp = self.client.get(reverse('dashboard:advanced_search_result'), {
@@ -364,6 +409,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.context['results']['ret_count'], 3)
         self.assertTrue(all(['referrals' not in x for x in resp.context['results']['ret_values']]))
+        self.assertEqual(resp.context['has_referral'], False)
 
     def test_show_advanced_search_results_with_no_permission(self):
         guest_user = self.guest_login()
@@ -593,7 +639,7 @@ class ViewTest(AironeViewTest):
             'export_style': 'hoge',
         }), 'application/json')
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.content.decode('utf-8'), 'Invalid "export_type" is specified')
+        self.assertEqual(resp.content.decode('utf-8'), 'Invalid parameters are specified')
 
         resp = self.client.post(reverse('dashboard:export_search_result'), json.dumps({
             'entities': [entity.id],
@@ -621,6 +667,39 @@ class ViewTest(AironeViewTest):
         }), 'application/json')
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.content.decode('utf-8'), 'Invalid parameters are specified')
+
+        # test to show advanced_search_result page with large param
+        resp = self.client.post(reverse('dashboard:export_search_result'), json.dumps({
+            'entities': [entity.id],
+            'attrinfo': [{'name': 'attr'}],
+            'export_style': 'csv',
+            'entry_name': 'a' * 250
+        }), 'application/json')
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.content.decode('utf-8'), 'Invalid parameters are specified')
+
+        resp = self.client.post(reverse('dashboard:export_search_result'), json.dumps({
+            'entities': [entity.id],
+            'attrinfo': [{'name': 'attr', 'keyword': 'a' * 250}],
+            'export_style': 'csv',
+        }), 'application/json')
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.content.decode('utf-8'), 'Invalid parameters are specified')
+
+        resp = self.client.post(reverse('dashboard:export_search_result'), json.dumps({
+            'entities': [entity.id],
+            'attrinfo': [{'name': 'attr'}],
+            'export_style': 'csv',
+            'entry_name': 'a' * 249
+        }), 'application/json')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.client.post(reverse('dashboard:export_search_result'), json.dumps({
+            'entities': [entity.id],
+            'attrinfo': [{'name': 'attr', 'keyword': 'a' * 249}],
+            'export_style': 'csv',
+        }), 'application/json')
+        self.assertEqual(resp.status_code, 200)
 
         # send request to export data
         resp = self.client.post(reverse('dashboard:export_search_result'), json.dumps({

--- a/dashboard/tests/test_view.py
+++ b/dashboard/tests/test_view.py
@@ -237,16 +237,24 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.content.decode('utf-8'), 'The attrinfo parameters is required')
 
         resp = self.client.get(reverse('dashboard:advanced_search_result'), {
-            'entity[]': [x.id for x in Entity.objects.filter(name__regex='^entity-')],
+            'attrinfo': 'hoge',
         })
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.content.decode('utf-8'), 'The attrinfo parameters is required')
+        self.assertEqual(resp.content.decode('utf-8'), 'The attrinfo parameter is not JSON')
 
         resp = self.client.get(reverse('dashboard:advanced_search_result'), {
-            'is_all_entities': 'true',
+            'attrinfo': json.dumps([{'hoge': 'attr'}]),
         })
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.content.decode('utf-8'), 'The attrinfo parameters is required')
+        self.assertEqual(resp.content.decode('utf-8'),
+                         'The name key is required for attrinfo parameter')
+
+        resp = self.client.get(reverse('dashboard:advanced_search_result'), {
+            'attrinfo': json.dumps([{'name': []}]),
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.content.decode('utf-8'),
+                         'Invalid name key value for attrinfo parameter')
 
         resp = self.client.get(reverse('dashboard:advanced_search_result'), {
             'attrinfo': json.dumps([{'name': 'attr'}]),
@@ -255,10 +263,11 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.content.decode('utf-8'), 'The entity[] parameters are required')
 
         resp = self.client.get(reverse('dashboard:advanced_search_result'), {
-            'attrinfo': 'hoge',
+            'attrinfo': json.dumps([{'name': 'attr'}]),
+            'entity[]': ['hoge']
         })
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.content.decode('utf-8'), 'The attrinfo parameter is not JSON')
+        self.assertEqual(resp.content.decode('utf-8'), 'Invalid entity ID is specified')
 
         resp = self.client.get(reverse('dashboard:advanced_search_result'), {
             'attrinfo': json.dumps([{'name': 'attr'}]),

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -202,14 +202,11 @@ def advanced_search_result(request):
             return HttpResponse("Invalid name key value for attrinfo parameter", status=400)
 
     # check entity params
-    hint_entity_ids = []
     if is_all_entities:
         attr_names = [x['name'] for x in hint_attrs]
-        attrs = sum(
-            [list(EntityAttr.objects.filter(name=x, is_active=True)) for x in attr_names], [])
-        hint_entity_ids = list(set([x.parent_entity.id for x in attrs if x and
-                                   user.has_permission(x.parent_entity, ACLType.Readable)]))
-    else:
+        recv_entity = list(EntityAttr.objects.filter(
+            name__in=attr_names, is_active=True, parent_entity__is_active=True
+        ).order_by('parent_entity__name').values_list('parent_entity__id', flat=True).distinct())
         if not recv_entity:
             return HttpResponse("The entity[] parameters are required", status=400)
 

--- a/entry/settings.py
+++ b/entry/settings.py
@@ -7,7 +7,7 @@ CONFIG = Settings({
         'MAX_LABEL_STRING': 45,
     },
     'MAX_HISTORY_COUNT': 10,
-    'MAX_QUERY_SIZE': 512,
+    'MAX_QUERY_SIZE': 249,  # '.*' + '[aA]'*249 + '.*' = 1000
     'EMPTY_SEARCH_CHARACTER': '\\',
     'EMPTY_SEARCH_CHARACTER_CODE': chr(165),
     'AND_SEARCH_CHARACTER': '&',

--- a/entry/settings.py
+++ b/entry/settings.py
@@ -13,7 +13,7 @@ CONFIG = Settings({
     'AND_SEARCH_CHARACTER': '&',
     'OR_SEARCH_CHARACTER': '|',
     'ESCAPE_CHARACTERS': ['(', ')', '<', '"', '{', '[', '#', '~', '@', '+', '*', '.', '?'],
-    'ESCAPE_CHARACTERS_REFERRALS_ENTRY': ['$', '(', '^', '|', '[', '+', '*', '.', '?'],
+    'ESCAPE_CHARACTERS_REFERRALS_ENTRY': ['$', '(', '^', '|', '[', '+', '*', '.', '?', '\\'],
     'ESCAPE_CHARACTERS_ENTRY_LIST': ['$', '(', '^', '\\', '|', '[', '+', '*', '.', '?'],
     'TIME_FORMAT': '%Y-%m-%dT%H:%M:%S',
 })

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -3114,7 +3114,7 @@ class ModelTest(AironeTestCase):
                      '[', ']', '{', '}', ';', '+', ':', '*', ',', '<', '>', '.', '/', '?', '_', ' ']
         test_suites = []
         for i, add_char in enumerate(add_chars):
-            entry_name = 'test%s%s' % (i, add_char)
+            entry_name = 'test%s%s' % (add_char, i)
             entry = Entry.objects.create(name=entry_name, schema=entity, created_user=user)
             entry.register_es()
 

--- a/templates/advanced_search/contents.js
+++ b/templates/advanced_search/contents.js
@@ -105,8 +105,11 @@ $('#do_search').on('click', function() {
   }).get();
   params.push('attrinfo=' + encodeURIComponent(JSON.stringify(attrinfo)))
 
-  var has_referral = $('#add_referral').is(':checked') ? 'has_referral' : ''
-  params.push(has_referral)
+  var has_referral = $('#add_referral').is(':checked')
+  if (has_referral){
+    params.push('has_referral=true');
+    params.push('referral_name=');
+  }
 
   location.href = `/dashboard/advanced_search_result?${ params.join('&') }`;
 });

--- a/templates/advanced_search/result.html
+++ b/templates/advanced_search/result.html
@@ -15,7 +15,7 @@
         <input type='hidden' name='entities' value='[{{ entities }}]' />
         <input type='hidden' name='attrinfo' value='[]' />
         <input type='hidden' name='export_style' value='' />
-        {% if has_referral is not False %}
+        {% if has_referral %}
           <input type='hidden' id='param_export_csv_referral' name='has_referral' value='' />
         {% endif %}
 
@@ -45,10 +45,10 @@
       </th>
       {% endfor %}
 
-      {% if has_referral is not False %}
+      {% if has_referral %}
       <th>
         参照エントリ<br/>
-        <input type='text' class='input-sm narrow_down_referral' value="{{ has_referral|default_if_none:'' }}"></input>
+        <input type='text' class='input-sm narrow_down_referral' value="{{ referral_name|default_if_none:'' }}"></input>
       </th>
       {% endif %}
     </tr>
@@ -152,7 +152,7 @@
         {% endif %}
       {% endfor %}
 
-      {% if has_referral is not False %}
+      {% if has_referral %}
       <td id='referral'>
         <ul class='list-group'>
           {% for referral in result.referrals %}
@@ -218,7 +218,7 @@
 
       <div class="modal-footer">
         <span class="mr-auto">
-          {% if has_referral is not False %}
+          {% if has_referral %}
             <input type='checkbox' id='modal_cond_add_referral' checked='True'> 参照エントリも含める</input>
           {% else %}
             <input type='checkbox' id='modal_cond_add_referral'> 参照エントリも含める</input>

--- a/templates/advanced_search/result.js
+++ b/templates/advanced_search/result.js
@@ -115,7 +115,7 @@ function reconstruct_tbody(results) {
       }
     {% endfor %}
 
-    {% if has_referral is not False %}
+    {% if has_referral%}
       let elem_ref_td = $('<td id=referral />');
       let elem_ref_ul = $("<ul class='list-group'/>");
 
@@ -165,7 +165,7 @@ $(document).ready(function() {
           is_output_all: false,
       };
 
-      {% if has_referral is not False %}
+      {% if has_referral%}
       request_params['referral'] = $('.narrow_down_referral').val();
       {% endif %}
 
@@ -193,13 +193,18 @@ $(document).ready(function() {
         // preserve a permalnk via pushState API to the advanced_search view (not entry-search API)
         // to filter search results with attribute keywords
         let params = [];
-        for (const entity of '{{ entities }}'.split(',')) {
-            params.push('entity[]=' +  entity);
-        }
+        {% if is_all_entities %}
+        params.push('is_all_entities=true');
+        {% else %}
+        '{{ entities }}'.split(',').forEach(function(val) {
+          params.push('entity[]=' + val);
+        });
+        {% endif %}
         params.push('entry_name=' + $('.hint_entry_name').val());
         params.push('attrinfo=' + encodeURIComponent(JSON.stringify(get_attrinfo())));
-        {% if has_referral is not False %}
-        params.push('has_referral=' + $('.narrow_down_referral').val());
+        {% if has_referral %}
+        params.push('has_referral=true');
+        params.push('referral_name=' + $('.narrow_down_referral').val());
         {% endif %}
         window.history.pushState('', '', 'advanced_search_result?' + params.join('&'));
 
@@ -248,7 +253,8 @@ $(document).ready(function() {
         'entities': '{{ entities }}'.split(','),
         'attrinfo': get_attrinfo(),
         'entry_name': $('.hint_entry_name').val(),
-        'has_referral': $('.narrow_down_referral').val(),
+        'has_referral': true,
+        'referral_name': $('.narrow_down_referral').val(),
         'export_style': style,
       }),
       dataType:      'json',
@@ -327,11 +333,8 @@ $(document).ready(function() {
     params.push('attrinfo=' + encodeURIComponent(JSON.stringify(attrinfo)));
 
     if ($('#modal_cond_add_referral').is(':checked')){
-      var has_referral = '';
-      if ($('.narrow_down_referral').val()){
-        has_referral = $('.narrow_down_referral').val()
-      }
-      params.push('has_referral=' + has_referral);
+      params.push('has_referral=true');
+      params.push(`referral_name=${$('.narrow_down_referral').val() ?? ''}`);
     }
 
     location.href = `/dashboard/advanced_search_result?${ params.join('&') }`;

--- a/templates/advanced_search/result.js
+++ b/templates/advanced_search/result.js
@@ -334,7 +334,7 @@ $(document).ready(function() {
 
     if ($('#modal_cond_add_referral').is(':checked')){
       params.push('has_referral=true');
-      params.push(`referral_name=${$('.narrow_down_referral').val() ?? ''}`);
+      params.push(`referral_name=${$('.narrow_down_referral').val() || ''}`);
     }
 
     location.href = `/dashboard/advanced_search_result?${ params.join('&') }`;


### PR DESCRIPTION
close: #314 #326 #327 #330

- Fixed the order of entities when is_all_entities is specified in advanced search
(#330)
![image](https://user-images.githubusercontent.com/5561786/145737534-e8262919-d5fb-4373-b91d-c5a027355f17.png)

- Fixed not being able to use regexp in entry names in the entry search AP
(#314)
![image](https://user-images.githubusercontent.com/5561786/145737592-9838d1c9-09a6-4226-bbb7-7644ed8874ff.png)

- Refactored referral param in advanced search
(#326)

- Fixed an exception error when specifying an invalid parameter in advanced search
(#327)
