### PR TITLE
Fixed that cannot be retried after error when narrowing down in advanced search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fixed not being able to use regexp in entry names in the entry search API (#314)
 * Fixed an exception error when specifying an invalid parameter in advanced search (#327)
 * Fixed the order of entities when is_all_entities is specified in advanced search (#330)
+* Fixed that cannot be retried after error when narrowing down in advanced search (#332)
 
 ### Refactored
 * Refactored referral param in advanced search (#326)

--- a/templates/advanced_search/result.js
+++ b/templates/advanced_search/result.js
@@ -155,7 +155,7 @@ $(document).ready(function() {
   function narrow_results_down(e) {
     if(! (e.keyCode != 13 || sending_request)) {
       sending_request = true;
-
+      MessageBox.clear();
       $('#entry_count').text('(...処理中...)');
 
       request_params = {
@@ -209,6 +209,7 @@ $(document).ready(function() {
         window.history.pushState('', '', 'advanced_search_result?' + params.join('&'));
 
       }).fail(function(data){
+        sending_request = false;
         MessageBox.error(data.responseText);
       });
     }


### PR DESCRIPTION
close: #332 
![image](https://user-images.githubusercontent.com/5561786/145930466-17ff48e9-35c8-4901-b0ff-a1b9e1199466.png)
![image](https://user-images.githubusercontent.com/5561786/145930476-da65581d-f010-4266-af5f-d0bca43ed51d.png)
