### PR TITLE
Updated Django version that fixed security bug (CVE-2021-44420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+* Updated Django version that fixed security bug (CVE-2021-44420)
 
 ### Fixed
 * Fixed an issue where advanced search narrow down was slow (#321)

--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -709,11 +709,12 @@ def execute_query(query: Dict[str, str], size: int = 0) -> Dict[str, str]:
 
     """
     kwargs = {
+        'size': settings.ES_CONFIG['MAXIMUM_RESULTS_NUM'],
         'body': query,
         'ignore': [404],
         'sort': ['name.keyword:asc']
     }
-    if size:
+    if size and isinstance(size, int):
         kwargs['size'] = size
 
     try:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 six==1.10.0
 django-import-export==2.5.0
-django==3.2.5
+django==3.2.10
 mock==2.0.0
 coverage>=4.4.1
 celery==4.4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 six==1.10.0
 django-import-export==2.5.0
-django==3.2.5
+django==3.2.10
 mock==2.0.0
 coverage>=4.4.1
 celery==4.4.7


### PR DESCRIPTION
This commit change dependent Django version from v3.2.5 to v3.2.10 that
applied a patch of CVE-2021-44420.
(c.f. https://www.djangoproject.com/weblog/2021/dec/07/security-releases/)