### PR TITLE
Fixed take a long time to create entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fixed the order of entities when is_all_entities is specified in advanced search (#330)
 * Fixed that cannot be retried after error when narrowing down in advanced search (#332)
 * Fixed an issue with array type attributes when copying entries (#342)
+* Fixed take a long time to create entry (#352)
 
 ### Refactored
 * Refactored referral param in advanced search (#326)

--- a/acl/__init__.py
+++ b/acl/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'acl.apps.AclConfig'

--- a/acl/apps.py
+++ b/acl/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class AclConfig(AppConfig):
     name = 'acl'
+
+    def ready(self):
+        from . import signals # noqa

--- a/acl/models.py
+++ b/acl/models.py
@@ -4,7 +4,6 @@ import re
 from datetime import datetime
 
 from django.db import models
-from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import Permission
 
 from user.models import User
@@ -53,16 +52,6 @@ class ACLBase(models.Model):
 
     def get_status(self, val):
         return self.status & val
-
-    def save(self, *args, **kwargs):
-        super(ACLBase, self).save(*args, **kwargs)
-
-        # create Permission sets for this object at once
-        content_type = ContentType.objects.get_for_model(self)
-        for acltype in ACLType.availables():
-            codename = '%s.%s' % (self.id, acltype.id)
-            if not Permission.objects.filter(codename=codename).exists():
-                Permission(name=acltype.name, codename=codename, content_type=content_type).save()
 
     def delete(self, *args, **kwargs):
         self.is_active = False

--- a/acl/signals.py
+++ b/acl/signals.py
@@ -1,0 +1,46 @@
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .models import ACLBase
+from entity.models import Entity, EntityAttr
+from entry.models import Entry, Attribute
+from airone.lib.acl import ACLType
+
+
+def create_permission(instance):
+    content_type = ContentType.objects.get_for_model(instance)
+    for acltype in ACLType.availables():
+        codename = '%s.%s' % (instance.id, acltype.id)
+        Permission(name=acltype.name, codename=codename, content_type=content_type).save()
+
+
+@receiver(post_save, sender=ACLBase)
+def aclbase_create_permission(sender, instance, created, **kwargs):
+    if created:
+        create_permission(instance)
+
+
+@receiver(post_save, sender=Entity)
+def entity_create_permission(sender, instance, created, **kwargs):
+    if created:
+        create_permission(instance)
+
+
+@receiver(post_save, sender=EntityAttr)
+def entity_attr_create_permission(sender, instance, created, **kwargs):
+    if created:
+        create_permission(instance)
+
+
+@receiver(post_save, sender=Entry)
+def entry_create_permission(sender, instance, created, **kwargs):
+    if created:
+        create_permission(instance)
+
+
+@receiver(post_save, sender=Attribute)
+def attribute_create_permission(sender, instance, created, **kwargs):
+    if created:
+        create_permission(instance)

--- a/acl/tests/test_signal.py
+++ b/acl/tests/test_signal.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+from django.contrib.auth.models import Permission
+
+from acl.models import ACLBase
+from entity.models import Entity, EntityAttr
+from entry.models import Entry, Attribute
+from user.models import User
+
+
+class SignalTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username='foo', email='hoge@example.com', password='fuga')
+
+    def test_create_aclbase_object(self):
+        for i, model in enumerate([ACLBase, Entity, EntityAttr, Entry, Attribute]):
+            obj = model.objects.create(name=i, created_user=self.user)
+
+            self.assertTrue(Permission.objects.filter(name='readable', codename='%s.2' % obj.id))
+            self.assertTrue(Permission.objects.filter(name='writable', codename='%s.4' % obj.id))
+            self.assertTrue(Permission.objects.filter(name='full', codename='%s.8' % obj.id))
+
+    def test_edit_aclebase_object(self):
+        for i, model in enumerate([ACLBase, Entity, EntityAttr, Entry, Attribute]):
+            obj = model.objects.create(name=i, created_user=self.user)
+
+            obj.name = str(i) + '_new'
+            obj.save(update_fields=['name'])
+
+            self.assertTrue(model.objects.filter(name=str(i) + '_new', is_active=True).exists())


### PR DESCRIPTION
Only when creating an ACLBase object Changed to create permissions.

Receive object change notifications with django signals.
https://docs.djangoproject.com/en/3.2/topics/signals/

For my development environment (about 2.5 million ACLBase objects)
Entry creation has been reduced from 5 seconds to less than 1 second.

Not only when creating entries, but also the time for changes has been reduced.