### PR TITLE
Added django debug toolbar

### DIFF
--- a/airone/settings.py
+++ b/airone/settings.py
@@ -29,6 +29,7 @@ CELERY_BROKER_HEARTBEAT = 0
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
+# INTERNAL_IPS = ['127.0.0.1']
 
 ALLOWED_HOSTS = ['*']
 
@@ -57,6 +58,7 @@ INSTALLED_APPS = [
     'rest_framework.authtoken',
     'custom_view.background',
     'drf_spectacular',
+    # "debug_toolbar",
 ]
 
 MIDDLEWARE = [
@@ -69,6 +71,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'airone.lib.db.AirOneReplicationMiddleware',
+    # "debug_toolbar.middleware.DebugToolbarMiddleware",
 ]
 
 ROOT_URLCONF = 'airone.urls'

--- a/airone/urls.py
+++ b/airone/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     ), name='login'),
     url(r'^auth/logout/', auth_view.logout, name='logout'),
     url(r'^webhook/', include(('webhook.urls', 'webhook'))),
+    # url(r'^__debug__/', include('debug_toolbar.urls')),
 ]
 
 for extension in settings.AIRONE['EXTENSIONS']:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,3 +24,4 @@ types-requests
 requests-html==0.10.0
 drf_spectacular==0.17.3
 django-replicated==2.7
+django-debug-toolbar==3.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ requests==2.20.0
 uritemplate==3.0.1
 drf_spectacular==0.17.3
 django-replicated==2.7
+django-debug-toolbar==3.2.4


### PR DESCRIPTION
It has been commented out. Please enable it only when you use it.

- SQL
![image](https://user-images.githubusercontent.com/5561786/149046141-1d413f1e-f8d4-4536-a63f-6f292692ddd6.png)
- Profiling
![image](https://user-images.githubusercontent.com/5561786/149046167-c8e81bf6-a4b4-45c4-a838-071539dfaecf.png)
- debugsqlshell
```
(.venv) dooga@hinagawa-dev:~/airone$ python manage.py debugsqlshell
Python 3.8.0 (default, Dec  9 2021, 17:53:27) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> from entry.models import Entry
>>> Entry.objects.first()

SELECT VERSION(), @@sql_mode, @@default_storage_engine, @@sql_auto_is_null, @@lower_case_table_names,
                                                                              CONVERT_TZ('2001-01-01 01:00:00', 'UTC', 'UTC') IS NOT NULL [0.40ms]

SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED [0.19ms]
SELECT `acl_aclbase`.`id`,
       `acl_aclbase`.`name`,
       `acl_aclbase`.`is_public`,
       `acl_aclbase`.`created_user_id`,
       `acl_aclbase`.`is_active`,
       `acl_aclbase`.`status`,
       `acl_aclbase`.`default_permission`,
       `acl_aclbase`.`updated_time`,
       `acl_aclbase`.`objtype`,
       `entry_entry`.`aclbase_ptr_id`,
       `entry_entry`.`schema_id`
FROM `entry_entry`
INNER JOIN `acl_aclbase` ON (`entry_entry`.`aclbase_ptr_id` = `acl_aclbase`.`id`)
ORDER BY `entry_entry`.`aclbase_ptr_id` ASC
LIMIT 1 [0.42ms]
<Entry: Entry object (26)>
>>> 
```