### PR TITLE
Refactored the process of check permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Refactored
 * Refactored referral param in advanced search (#326)
+* Refactored the process of check permission
 
 ## v3.4.1
 

--- a/acl/api_v2/serializers.py
+++ b/acl/api_v2/serializers.py
@@ -56,7 +56,7 @@ class ACLSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs: Dict[str, Any]):
         user = User.objects.get(id=self.context['request'].user.id)
-        if not user.may_permitted(self.instance.id, ACLType.Full, **{
+        if not user.may_permitted(self.instance, ACLType.Full, **{
             'is_public': attrs['is_public'],
             'default_permission': attrs['default_permission'],
             'acl_settings': attrs['acl']


### PR DESCRIPTION
Entry and Attribute permission check was implemented without checking is_public and default_permission.

|  | time | query |
----|----|----
| now | 2,200msec | 120query |
| refactoring/get_available_attrs | 1,900msec | 67query |
| refactoring/check_permission | 400msec | 71query |
| refactoring/check_permission_another | 300msec | 68query |
| both refactoring | 100msec | 15query | 