### PR TITLE
Refactored drf response format and default settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Refactored referral param in advanced search (#326)
 * Refactored the process of check permission
 * Refactored the process of get_available_attrs in Entry
+* Refactored drf response format and default settings
 
 ## v3.4.1
 

--- a/airone/settings.py
+++ b/airone/settings.py
@@ -296,4 +296,12 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 REST_FRAMEWORK = {
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        "rest_framework.authentication.BasicAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
+        "api_v1.auth.AironeTokenAuth",
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        "rest_framework.permissions.IsAuthenticated",
+    ]
 }

--- a/api_v1/entity/views.py
+++ b/api_v1/entity/views.py
@@ -3,18 +3,12 @@ from functools import reduce
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.authentication import BasicAuthentication
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.permissions import IsAuthenticated
 
 from airone.lib.profile import airone_profile
-from api_v1.auth import AironeTokenAuth
 from entity.models import Entity, EntityAttr
 
 
 class EntityAttrsAPI(APIView):
-    authentication_classes = (AironeTokenAuth, BasicAuthentication, SessionAuthentication,)
-    permission_classes = (IsAuthenticated,)
 
     @airone_profile
     def get(self, request, entity_ids, format=None):
@@ -38,4 +32,4 @@ class EntityAttrsAPI(APIView):
         else:
             attrs = get_attrs_of_all_entities()
 
-        return Response({'result': sorted(attrs)}, content_type='application/json; charset=UTF-8')
+        return Response({'result': sorted(attrs)})

--- a/api_v1/entry/views.py
+++ b/api_v1/entry/views.py
@@ -1,6 +1,5 @@
 import pytz
 
-from api_v1.auth import AironeTokenAuth
 from airone.lib.acl import ACLType
 from airone.lib.profile import airone_profile
 from django.conf import settings
@@ -9,9 +8,6 @@ from django.db.models import Q
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.authentication import BasicAuthentication
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.permissions import IsAuthenticated
 
 from entity.models import Entity
 from entry.models import Entry
@@ -23,8 +19,6 @@ from user.models import User
 
 
 class EntrySearchAPI(APIView):
-    authentication_classes = (AironeTokenAuth, BasicAuthentication, SessionAuthentication,)
-    permission_classes = (IsAuthenticated,)
 
     @airone_profile
     def post(self, request, format=None):
@@ -89,12 +83,10 @@ class EntrySearchAPI(APIView):
                                     hint_referral,
                                     is_output_all)
 
-        return Response({'result': resp}, content_type='application/json; charset=UTF-8')
+        return Response({'result': resp})
 
 
 class EntryReferredAPI(APIView):
-    authentication_classes = (AironeTokenAuth, BasicAuthentication, SessionAuthentication,)
-    permission_classes = (IsAuthenticated,)
 
     @airone_profile
     def get(self, request):
@@ -126,12 +118,10 @@ class EntryReferredAPI(APIView):
                 } for x in entry.get_referred_objects(entity_name=param_target_entity)]
             })
 
-        return Response({'result': ret_data}, content_type='application/json; charset=UTF-8')
+        return Response({'result': ret_data})
 
 
 class UpdateHistory(APIView):
-    authentication_classes = (AironeTokenAuth, BasicAuthentication, SessionAuthentication,)
-    permission_classes = (IsAuthenticated,)
 
     @airone_profile
     def get(self, request):

--- a/api_v1/job/views.py
+++ b/api_v1/job/views.py
@@ -4,21 +4,15 @@ from django.db.models import Q
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework.authentication import BasicAuthentication
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.permissions import IsAuthenticated
 
 from job.models import Job, JobOperation
 from job.settings import CONFIG as JOB_CONFIG
 from user.models import User
 
 from airone.lib.profile import airone_profile
-from api_v1.auth import AironeTokenAuth
 
 
 class JobAPI(APIView):
-    authentication_classes = (AironeTokenAuth, BasicAuthentication, SessionAuthentication,)
-    permission_classes = (IsAuthenticated,)
 
     @airone_profile
     def get(self, request, format=None):
@@ -63,7 +57,7 @@ class JobAPI(APIView):
         return Response({
             'result': jobs,
             'constant': constant,
-        }, content_type='application/json; charset=UTF-8')
+        })
 
     @airone_profile
     def delete(self, request, format=None):
@@ -93,8 +87,6 @@ class JobAPI(APIView):
 
 
 class SpecificJobAPI(APIView):
-    authentication_classes = (AironeTokenAuth, BasicAuthentication, SessionAuthentication,)
-    permission_classes = (IsAuthenticated,)
 
     @airone_profile
     def post(self, request, job_id, format=None):
@@ -121,8 +113,6 @@ class SpecificJobAPI(APIView):
 
 
 class SearchJob(APIView):
-    authentication_classes = (AironeTokenAuth, BasicAuthentication, SessionAuthentication,)
-    permission_classes = (IsAuthenticated,)
 
     @airone_profile
     def get(self, request):
@@ -148,5 +138,4 @@ class SearchJob(APIView):
             return Response('There is no job that is matched specified condition',
                             status=status.HTTP_404_NOT_FOUND)
 
-        return Response({'result': [x.to_json() for x in jobs]},
-                        content_type='application/json; charset=UTF-8')
+        return Response({'result': [x.to_json() for x in jobs]})

--- a/api_v1/user/views.py
+++ b/api_v1/user/views.py
@@ -4,19 +4,13 @@ from django.contrib.auth.models import User as DjangoUser
 
 from rest_framework.response import Response
 from rest_framework.authtoken.models import Token
-from rest_framework.authentication import BasicAuthentication
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 
 from airone.lib.profile import airone_profile
-from api_v1.auth import AironeTokenAuth
 from user.models import User as AironeUser
 
 
 class AccessTokenAPI(APIView):
-    authentication_classes = (AironeTokenAuth, BasicAuthentication, SessionAuthentication,)
-    permission_classes = (IsAuthenticated,)
 
     @airone_profile
     def get(self, request, format=None):

--- a/api_v1/views.py
+++ b/api_v1/views.py
@@ -5,11 +5,7 @@ from copy import deepcopy
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.authentication import BasicAuthentication
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.permissions import IsAuthenticated
 
-from api_v1.auth import AironeTokenAuth
 from airone.lib.acl import ACLType
 from airone.lib.profile import airone_profile
 from entity.models import Entity
@@ -23,8 +19,6 @@ from django.db.models import Q
 
 
 class EntryAPI(APIView):
-    authentication_classes = (AironeTokenAuth, BasicAuthentication, SessionAuthentication,)
-    permission_classes = (IsAuthenticated,)
 
     @airone_profile
     def post(self, request, format=None):

--- a/webhook/api_v2/views.py
+++ b/webhook/api_v2/views.py
@@ -1,25 +1,16 @@
-from api_v1.auth import AironeTokenAuth
-
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.authentication import BasicAuthentication
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.permissions import IsAuthenticated
 
 from airone.lib.profile import airone_profile
 from entity.models import Entity
 
 
 class WebhookAPI(APIView):
-    authentication_classes = (AironeTokenAuth, BasicAuthentication, SessionAuthentication,)
-    permission_classes = (IsAuthenticated,)
 
     @airone_profile
     def get(self, request, entity_id):
         entity = Entity.objects.filter(id=entity_id, is_active=True).first()
         if entity is None:
-            return Response({'msg': 'There is no entity for setting'},
-                            content_type='application/json; charset=UTF-8', status=400)
+            return Response({'msg': 'There is no entity for setting'}, status=400)
 
-        return Response([x.to_dict() for x in entity.webhooks.all()],
-                        content_type='application/json; charset=UTF-8')
+        return Response([x.to_dict() for x in entity.webhooks.all()])


### PR DESCRIPTION
The default DRF settings were redundant, so I refactored them.

With the DRF function, you can see the API results from the WEB UI as well.
![image](https://user-images.githubusercontent.com/5561786/150088761-d9e7ecc3-c312-4c91-906b-00f9de9181b2.png)

```
http://localhost:8080/api/v1/entity/attrs/1
(entityId)
```

```
http://localhost:8080/api/v1/entry/search
{
  "entities": ["1"],
  "attrinfo": []
}
```

```
http://localhost:8080/api/v1/entry/referral
entry=test (entityName)
```

```
http://localhost:8080/api/v1/job/search
target_id=1 ()
```