### PR TITLE
Fixed the value when AttributeValue with is_latest set to True is duplicated

### DIFF
--- a/entry/models.py
+++ b/entry/models.py
@@ -1120,7 +1120,7 @@ class Entry(ACLBase):
                 continue
 
             # set last-value of current attributes
-            last_value = attr.attrv_list[0] if attr.attrv_list else None
+            last_value = attr.attrv_list[-1] if attr.attrv_list else None
             if last_value is None:
                 ret_attrs.append(attrinfo)
                 continue
@@ -1644,4 +1644,4 @@ class Entry(ACLBase):
             parent_attr__name=attr_name,
             parent_attr__schema__is_active=True,
             parent_attr__parent_entry=self
-        ).first()
+        ).last()


### PR DESCRIPTION
Each attribute has multiple AttributeValue associated with it.
There is only one AttributeValue for is_latest=True.
However, there are cases where is_latest=True is duplicated.
(It may not be reproduced in the current version.)

In consideration of duplicate cases, changed so that id uses the last.