### PR TITLE
Trim too-long breadcrumbs

### DIFF
--- a/frontend/src/components/common/AironeBreadcrumbs.tsx
+++ b/frontend/src/components/common/AironeBreadcrumbs.tsx
@@ -7,7 +7,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
   wrapper: {
     paddingLeft: "10%",
     paddingRight: "10%",
-    width: "100%",
+    width: "80%",
   },
 }));
 


### PR DESCRIPTION
The width of the breadcrumbs makes scrollbar, caused by too long width. 100% + 10% + 10% = 120% 😢 

<img width="453" alt="image" src="https://user-images.githubusercontent.com/191684/152632321-fe6d9187-2f4d-4b91-a471-1d187919ebc9.png">
