### PR TITLE
Fixed some problems related with entry's changing history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Set entry-id for each entry columns in the list entry page
 
 ### Fixed
+* Fixed problems that changing values for group won't be shown correctly
+  in the changing entry's attribute page
 
 ## v3.5.0
 

--- a/frontend/src/components/entry/AttributeValue.tsx
+++ b/frontend/src/components/entry/AttributeValue.tsx
@@ -20,9 +20,6 @@ const ElemObject: FC<{ attrValue: { id: number; name: string } }> = ({
 };
 
 const ElemNamedObject: FC<{ attrValue: any }> = ({ attrValue }) => {
-  console.log(`[onix/ElemNamedObject(00)]`);
-  console.log(attrValue);
-
   const key = Object.keys(attrValue)[0];
   return (
     <Box>

--- a/templates/list_webhooks.html
+++ b/templates/list_webhooks.html
@@ -245,9 +245,6 @@ var save_settings = function(e){
     request_params.id = webhooks[target_webhook_index].id;
   }
 
-  console.log('[onix/save_settings(10)] ### request_params');
-  console.log(request_params);
-
   $.ajax({
     type: 'POST',
     url: "/webhook/api/v1/set/{{ entity.id }}",
@@ -292,10 +289,6 @@ var delete_header_info = function(e) {
   $(e.target).closest('.header-info').remove();
 }
 
-var show_webhook_modal = function(e) {
-  console.log('[onix/show_webhook_modal(00)]');
-}
-
 var hide_webhook_modal = function(e) {
   // remove all input elements
   $('#webhook_url').val('');
@@ -319,8 +312,6 @@ var create_webhook = function(e) {
 
 var show_edit_webhook = function(e) {
   var index = $(e.target).attr("webhook_index")
-  console.log(`[onix/edit_webhook(00)] index: ${ index }`);
-  console.log(webhooks[index]);
 
   // set editing webhook_id;
   target_webhook_index = index;
@@ -334,7 +325,6 @@ var show_edit_webhook = function(e) {
   for (const [key, value] of Object.entries(webhooks[index].headers)) {
     var header_elem = create_header_input_element();
 
-    console.log(`[onix/edit_webhook(10)] (key, value) = (${ key }, ${ value })`);
     header_elem.find('.header-key').val(key);
     header_elem.find('.header-value').val(value);
 
@@ -346,8 +336,6 @@ var show_edit_webhook = function(e) {
 
 var show_delete_webhook = function(e) {
   var index = $(e.target).attr("webhook_index");
-
-  console.log(`[onix/delete_webhook(00)] ${ index }`);
 
 	// update target_webhook_index
 	target_webhook_index = index;
@@ -376,7 +364,6 @@ $(document).ready(function() {
   $('#save_settings').on('click', save_settings);
   $('#add-header-info').on('click', add_header_info);
   $('.delete-header-info').on('click', delete_header_info);
-  $('#WebhookModal').on('shown.bs.modal', show_webhook_modal);
   $('#WebhookModal').on('hide.bs.modal', hide_webhook_modal);
   $('.show_edit_webhook').on('click', show_edit_webhook);
   $('.show_delete_webhook').on('click', show_delete_webhook);

--- a/templates/show_entry/change_history.html
+++ b/templates/show_entry/change_history.html
@@ -2,7 +2,7 @@
   <div class="col">
     <table class="table table-borderless airone-entry-table-history" id='attribute-history'>
       {% for history in value_history %}
-      <tr class='attr_info'>
+      <tr class='attr_info' attr_id='{{ history.attr_id }}'>
         <td class='attr_name'>{{ history.attr_name }}</td>
         <td>
           {% if history.prev %}

--- a/templates/show_entry/history_value.html
+++ b/templates/show_entry/history_value.html
@@ -36,33 +36,33 @@
   <span>{{ attrv.value|date:"Y-m-d" }}</span>
 
 {% elif a_type == attr_type.named_entry %}
-    <div class='row'>
-      <div class='col-3'>
-        {{ attrv.value.value }}
-      </div>
-      <div class='col-9'>
-        <a href='/entry/show/{{ attrv.referral.id }}/'>{{ attrv.referral.name }}</a>
-      </div>
+  <div class='row'>
+    <div class='col-3 attrv_name'>
+      {{ attrv.value.value }}
     </div>
+    <div class='col-9 attrv_referral'>
+      <a href='/entry/show/{{ attrv.value.referral.id }}/'>{{ attrv.value.referral.name }}</a>
+    </div>
+  </div>
 
 {% elif a_type == attr_type.array_named_entry %}
-    <ul class='list-group'>
-    {% for co_attrv in attrv.value %}
-      <li class='list-group-item'>
-        <div class='row'>
-          <div class='col-3'>
-            {{ co_attrv.value }}
-          </div>
-          <div class='col-9'>
-            <a href='/entry/show/{{ co_attrv.referral.id }}/'>{{ co_attrv.referral.name }}</a>
-          </div>
+  <ul class='list-group'>
+  {% for co_attrv in attrv.value %}
+    <li class='list-group-item'>
+      <div class='row'>
+        <div class='col-3 attrv_name'>
+          {{ co_attrv.value }}
         </div>
-      </li>
-    {% endfor %}
-    </ul>
+        <div class='col-9 attrv_referral'>
+          <a href='/entry/show/{{ co_attrv.referral.id }}/'>{{ co_attrv.referral.name }}</a>
+        </div>
+      </div>
+    </li>
+  {% endfor %}
+  </ul>
 
 {% elif a_type == attr_type.group %}
-  <a href='/group/edit/{{ attrv.value.id}}'>{{ attrv.value.name }}</a>
+  <a href='/group/edit/{{ attrv.value.id }}'>{{ attrv.value.name }}</a>
 
 {% elif a_type == attr_type.array_group %}
   <ul class='list-group'>

--- a/templates/show_entry/js_history.html
+++ b/templates/show_entry/js_history.html
@@ -127,7 +127,6 @@ function make_element_value_text(a_type, attrv) {
            `</div>`;
 
   } else if (a_type == attr_type.group) {
-    console.log("[onix-test(group)] attrv: ", attrv);
     return `<a href='/group/edit/${ attrv.value.id }'>${ attrv.value.name }</a>`;
 
   } else if (a_type == attr_type.date) {

--- a/templates/show_entry/js_history.html
+++ b/templates/show_entry/js_history.html
@@ -57,6 +57,7 @@ var attr_type = {
   'array_entry': {{ attr_type.array_entry }},
   'array_string': {{ attr_type.array_string }},
   'array_named_entry': {{ attr_type.array_named_entry }},
+  'array_group': {{ attr_type.array_group }},
 };
 function show_old_history(e) {
   MessageBox.clear();
@@ -101,8 +102,11 @@ function make_element_value_text(a_type, attrv) {
   if (a_type == attr_type.entry) {
     return `<a href='/entry/show/${ attrv.value.id }/'>${ attrv.value.name }</a>`;
 
-  } else if (a_type == attr_type.string || a_type == attr_type.textarea) {
+  } else if (a_type == attr_type.string) {
     return `<span class='url_conv'>${ attrv.value }</span>`;
+
+  } else if (a_type == attr_type.textarea) {
+    return `<span class='url_conv textarea'>${ attrv.value }</span>`;
 
   } else if (a_type == attr_type.boolean) {
     if(attrv.value) {
@@ -117,13 +121,14 @@ function make_element_value_text(a_type, attrv) {
       ref_value = `<a href='/entry/show/${ attrv.value.referral.id }/'>${ attrv.value.referral.name }</a>`;
     }
 
-    return `<div class ='row'>` +
-             `<div class ='col-3'>${ attrv.value.value }</div>` +
-             `<div class ='col-9'>${ ref_value }</div>` +
+    return `<div class='row'>` +
+             `<div class='col-3 attrv_name'>${ attrv.value.value }</div>` +
+             `<div class='col-9 attrv_referral'>${ ref_value }</div>` +
            `</div>`;
 
   } else if (a_type == attr_type.group) {
-    return `<a href='/group/edit/${ attrv.value.id }'>{{ attrv.value.name }}</a>`;
+    console.log("[onix-test(group)] attrv: ", attrv);
+    return `<a href='/group/edit/${ attrv.value.id }'>${ attrv.value.name }</a>`;
 
   } else if (a_type == attr_type.date) {
     return `<span>${ attrv.value }</span>`;
@@ -155,9 +160,19 @@ function make_element_value_text(a_type, attrv) {
       }
       result += `<li class='list-group-item'>` +
                   `<div class='row'>` +
-                    `<div class='col-3'>${ co_info.value  }</div>` +
-                    `<div class='col-9'>${ ref_value }</div>` +
+                    `<div class='col-3 attrv_name'>${ co_info.value  }</div>` +
+                    `<div class='col-9 attrv_referral'>${ ref_value }</div>` +
                   `</div>` +
+                `</li>`;
+    }
+    result += '</ul>';
+    return result;
+
+  } else if (a_type == attr_type.array_group) {
+    let result = "<ul class='list-group'>";
+    for (let co_info of attrv.value) {
+      result += `<li class='list-group-item'>` +
+                  `<a href='/group'>${ co_info.name }</a>` +
                 `</li>`;
     }
     result += '</ul>';
@@ -166,7 +181,7 @@ function make_element_value_text(a_type, attrv) {
 }
 
 function append_history_item(container, info) {
-  let elem_tr = $(`<tr class='attr_info'>`);
+  let elem_tr = $(`<tr class='attr_info' attr_id="${ info.attr_id }">`);
 
   // set attribute and attribute value id
   elem_tr.append(`<input type='hidden' class='attr_id' value='${ info.attr_id }' />`);


### PR DESCRIPTION
Close: https://github.com/dmm-com/airone/issues/387

This commit has following changes for changing history page of entry

* Fixed problem named_entry type value won't be shown correctly
* Fixed problem group and array_group type value won't be shown correctly when it was shown by "make_element_value_text" method
* Fixed minor coding style that is incorrect indent
* Added property to be able to identify each attribute