### PR TITLE
Refactored APIv2 and fixed EntryList

### DIFF
--- a/entity/api_v2/serializers.py
+++ b/entity/api_v2/serializers.py
@@ -1,0 +1,47 @@
+from airone.lib.acl import ACLType
+from entity.models import Entity
+from entry.models import Entry
+from entry.settings import CONFIG as CONFIG_ENTRY
+from rest_framework import serializers
+from user.models import User
+
+
+class EntitySerializer(serializers.ModelSerializer):
+    entries = serializers.SerializerMethodField(method_name='get_entries')
+    is_toplevel = serializers.SerializerMethodField(method_name='get_is_toplevel')
+    attributes = serializers.SerializerMethodField(method_name='get_attributes')
+
+    class Meta:
+        model = Entity
+        fields = ('id', 'name', 'note', 'is_toplevel', 'attributes', 'entries')
+
+    def get_entries(self, entity: Entity):
+        request = self.context.get('request')
+        is_active = request.GET.get('is_active_entry', True) if request else True
+
+        entries = Entry.objects.filter(schema=entity, is_active=is_active).order_by('name')
+        return [{
+            'id': e.id,
+            'name': e.name,
+            'status': e.status,
+        } for e in entries[:CONFIG_ENTRY.MAX_LIST_ENTRIES]]
+
+    def get_is_toplevel(self, entity: Entity):
+        return (entity.status & Entity.STATUS_TOP_LEVEL) != 0
+
+    def get_attributes(self, entity: Entity):
+        request = self.context.get('request')
+        user = User.objects.get(id=request.user.id)
+
+        return [{
+            'id': x.id,
+            'name': x.name,
+            'type': x.type,
+            'is_mandatory': x.is_mandatory,
+            'is_delete_in_chain': x.is_delete_in_chain,
+            'referrals': [{
+                'id': r.id,
+                'name': r.name,
+            } for r in x.referral.all()],
+        } for x in entity.attrs.filter(is_active=True).order_by('index')
+            if user.has_permission(x, ACLType.Writable)]

--- a/entity/api_v2/urls.py
+++ b/entity/api_v2/urls.py
@@ -4,6 +4,5 @@ from . import views
 
 urlpatterns = [
     url(r'^history/(\d+)$', views.history, name='history'),
-    url(r'^entities/(\d+)$', views.get_entity, name='get_entity'),
     url(r'^(?P<pk>\d+)$', views.GetEntity.as_view({'get': 'retrieve'})),
 ]

--- a/entity/api_v2/urls.py
+++ b/entity/api_v2/urls.py
@@ -5,4 +5,5 @@ from . import views
 urlpatterns = [
     url(r'^history/(\d+)$', views.history, name='history'),
     url(r'^entities/(\d+)$', views.get_entity, name='get_entity'),
+    url(r'^(?P<pk>\d+)$', views.GetEntity.as_view({'get': 'retrieve'})),
 ]

--- a/entity/api_v2/views.py
+++ b/entity/api_v2/views.py
@@ -1,5 +1,4 @@
 from user.models import History
-from airone.lib.acl import ACLType
 from airone.lib.profile import airone_profile
 from airone.lib.http import http_get
 
@@ -7,7 +6,6 @@ from django.http.response import JsonResponse, HttpResponse
 
 from entity.models import Entity
 from entity.api_v2.serializers import EntitySerializer
-from user.models import User
 
 from rest_framework import viewsets
 

--- a/entity/api_v2/views.py
+++ b/entity/api_v2/views.py
@@ -38,34 +38,6 @@ def history(request, entity_id):
     } for h in histories], safe=False)
 
 
-def get_entity(request, entity_id):
-    user = User.objects.get(id=request.user.id)
-
-    if not Entity.objects.filter(id=entity_id).exists():
-        return HttpResponse('Failed to get entity of specified id', status=400)
-
-    # entity to be editted is given by url
-    entity = Entity.objects.get(id=entity_id)
-
-    return JsonResponse({
-        'name': entity.name,
-        'note': entity.note,
-        'is_toplevel': (entity.status & Entity.STATUS_TOP_LEVEL) != 0,
-        'attributes': [{
-            'id': x.id,
-            'name': x.name,
-            'type': x.type,
-            'is_mandatory': x.is_mandatory,
-            'is_delete_in_chain': x.is_delete_in_chain,
-            'referrals': [{
-                'id': r.id,
-                'name': r.name,
-            } for r in x.referral.all()],
-        } for x in entity.attrs.filter(is_active=True).order_by('index')
-            if user.has_permission(x, ACLType.Writable)],
-    })
-
-
 class GetEntity(viewsets.ReadOnlyModelViewSet):
     queryset = Entity.objects.filter(is_active=True)
     serializer_class = EntitySerializer

--- a/entity/api_v2/views.py
+++ b/entity/api_v2/views.py
@@ -6,7 +6,10 @@ from airone.lib.http import http_get
 from django.http.response import JsonResponse, HttpResponse
 
 from entity.models import Entity
+from entity.api_v2.serializers import EntitySerializer
 from user.models import User
+
+from rest_framework import viewsets
 
 
 @airone_profile
@@ -61,3 +64,8 @@ def get_entity(request, entity_id):
         } for x in entity.attrs.filter(is_active=True).order_by('index')
             if user.has_permission(x, ACLType.Writable)],
     })
+
+
+class GetEntity(viewsets.ReadOnlyModelViewSet):
+    queryset = Entity.objects.filter(is_active=True)
+    serializer_class = EntitySerializer

--- a/frontend/src/pages/Entry.tsx
+++ b/frontend/src/pages/Entry.tsx
@@ -25,7 +25,7 @@ import { CreateButton } from "components/common/CreateButton";
 import { EditButton } from "components/common/EditButton";
 import { Loading } from "components/common/Loading";
 import { EntryList } from "components/entry/EntryList";
-import { exportEntries, getEntries, getEntity } from "utils/AironeAPIClient";
+import { exportEntries, getEntity } from "utils/AironeAPIClient";
 
 const useStyles = makeStyles<Theme>((theme) => ({
   button: {
@@ -47,14 +47,8 @@ export const Entry: FC = () => {
     return await resp.json();
   });
 
-  const entries = useAsync(async () => {
-    const resp = await getEntries(entityId, true);
-    const data = await resp.json();
-    return data.results;
-  });
-
   const deletedEntries = useAsync(async () => {
-    const resp = await getEntries(entityId, false);
+    const resp = await getEntity(entityId, false);
     const data = await resp.json();
     return data.results;
   });
@@ -132,12 +126,12 @@ export const Entry: FC = () => {
       <Box hidden={tabValue !== 0}>ダッシュボード</Box>
 
       <Box hidden={tabValue !== 1}>
-        {entries.loading ? (
+        {entity.loading ? (
           <Loading />
         ) : (
           <EntryList
             entityId={entityId}
-            entries={entries.value}
+            entries={entity.value.entries}
             restoreMode={false}
           />
         )}
@@ -149,7 +143,7 @@ export const Entry: FC = () => {
         {!deletedEntries.loading && (
           <EntryList
             entityId={entityId}
-            entries={deletedEntries.value}
+            entries={deletedEntries.value.entries}
             restoreMode={true}
           />
         )}

--- a/frontend/src/pages/EntryList.tsx
+++ b/frontend/src/pages/EntryList.tsx
@@ -20,11 +20,11 @@ import {
   entityPath,
   importEntriesPath,
   topPath,
-} from "../Routes";
-import { AironeBreadcrumbs } from "../components/common/AironeBreadcrumbs";
-import { Loading } from "../components/common/Loading";
-import { EntryList as Entry } from "../components/entry/EntryList";
-import { getEntries, getEntity, exportEntries } from "../utils/AironeAPIClient";
+} from "Routes";
+import { AironeBreadcrumbs } from "components/common/AironeBreadcrumbs";
+import { Loading } from "components/common/Loading";
+import { EntryList as Entry } from "components/entry/EntryList";
+import { getEntity, exportEntries } from "utils/AironeAPIClient";
 
 const useStyles = makeStyles<Theme>((theme) => ({
   button: {
@@ -95,12 +95,6 @@ export const EntryList: FC = () => {
     return await resp.json();
   });
 
-  const entries = useAsync(async () => {
-    const resp = await getEntries(entityId, true);
-    const data = await resp.json();
-    return data.results;
-  });
-
   return (
     <Box>
       <AironeBreadcrumbs>
@@ -152,12 +146,12 @@ export const EntryList: FC = () => {
           }}
         />
 
-        {entries.loading ? (
+        {entity.loading ? (
           <Loading />
         ) : (
           <Entry
             entityId={entityId}
-            entries={entries.value}
+            entries={entity.value.entries}
             restoreMode={false}
           />
         )}

--- a/frontend/src/utils/AironeAPIClient.ts
+++ b/frontend/src/utils/AironeAPIClient.ts
@@ -29,7 +29,7 @@ export function postLogout(): Promise<Response> {
 
 export function getEntity(
   entityId: number,
-  isActiveEntry = true,
+  isActiveEntry = true
 ): Promise<Response> {
   const isActiveParam = isActiveEntry ? "True" : "False";
   return fetch(`/entity/api/v2/${entityId}?is_active_entry=${isActiveParam}`);

--- a/frontend/src/utils/AironeAPIClient.ts
+++ b/frontend/src/utils/AironeAPIClient.ts
@@ -27,8 +27,12 @@ export function postLogout(): Promise<Response> {
   });
 }
 
-export function getEntity(entityId: number): Promise<Response> {
-  return fetch(`/entity/api/v2/entities/${entityId}`);
+export function getEntity(
+  entityId: number,
+  isActiveEntry = true,
+): Promise<Response> {
+  const isActiveParam = isActiveEntry ? "True" : "False";
+  return fetch(`/entity/api/v2/${entityId}?is_active_entry=${isActiveParam}`);
 }
 
 export function getEntities(): Promise<Response> {
@@ -62,16 +66,6 @@ export function getEntityAttrs(entityIds: number[]): Promise<Response> {
 
 export function getEntrySearch(query: string): Promise<Response> {
   return fetch(`/entry/api/v2/search?query=${query}`);
-}
-
-export function getEntries(
-  entityId: number,
-  isActive = true
-): Promise<Response> {
-  const isActiveParam = isActive ? "True" : "False";
-  return fetch(
-    `/entry/api/v1/get_entries/${entityId}?is_active=${isActiveParam}`
-  );
 }
 
 export function getAttrReferrals(attr_id) {


### PR DESCRIPTION
This commit fixed EntryList page to list entries as alphabetical order.
Along with this fixing, this commit also refactored Entity and Entry v2
API not to send redundant requests for getting Entries that are related
with specified Entity. This integrates getEntity and getEntries API
handler using DRF for returning them with Entity information at the 
same time. By this change, UI processing don't have to send multiple
requests to get Entity and Entires that are related with it.