### PR TITLE
Update entry template and expand response context for E2E test

### DIFF
--- a/entry/api_v1/views.py
+++ b/entry/api_v1/views.py
@@ -259,7 +259,7 @@ def get_entry_info(request, entry_id):
             'id': entry.schema.id,
             'name': entry.schema.name,
         },
-        'attrs': sorted([dict({'name': x.schema.name, 'index': x.schema.index},
+        'attrs': sorted([dict({'id': x.id, 'name': x.schema.name, 'index': x.schema.index},
                               **x.get_latest_value().get_value(with_metainfo=True))
                          for x in entry.attrs.all() if user.has_permission(x, ACLType.Readable)],
                         key=lambda x: x['index'])

--- a/entry/tests/test_api_v1.py
+++ b/entry/tests/test_api_v1.py
@@ -615,6 +615,11 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()['id'], entry.id)
 
+        # check context for attributes
+        for attrinfo in resp.json()['attrs']:
+            self.assertEqual(sorted(attrinfo.keys()),
+                             sorted(['id', 'name', 'type', 'index', 'value']))
+
     def test_create_entry_attr(self):
         user = self.guest_login()
 

--- a/templates/list_entry/deleted_list.js
+++ b/templates/list_entry/deleted_list.js
@@ -132,8 +132,8 @@ function reconstruct_modal_body_for_job(job) {
   // clear old context
   elem_container.empty();
 
-  elem_container.append(`<tr><td>Deleted by:</td><td>${ job.user }</td></tr>`);
-  elem_container.append(`<tr><td>Deleted at:</td><td>${ job.updated_at }</td></tr>`);
+  elem_container.append(`<tr class="deleting_user"><td class='label'>Deleted by:</td><td class='value'>${ job.user }</td></tr>`);
+  elem_container.append(`<tr class="deleting_time"><td class='label'>Deleted at:</td><td class='value'>${ job.updated_at }</td></tr>`);
 }
 
 function reconstruct_modal_body_for_entry(data) {
@@ -143,10 +143,10 @@ function reconstruct_modal_body_for_entry(data) {
   elem_container.empty();
 
   for(let attr of data.attrs) {
-    let elem_tr = $('<tr/>');
-    let elem_td = $('<td/>');
+    let elem_tr = $(`<tr attr_id="${ attr.id }"/>`);
+    let elem_td = $(`<td class="attr_value"/>`);
 
-    elem_tr.append($(`<td>${ attr.name }</td>`));
+    elem_tr.append($(`<td class="attr_label">${ attr.name }</td>`));
 
     if(attr.type == {{ attr_type.string }}) {
       elem_td.append($(`<span class='url_conv'>${ attr.value }</span>`));


### PR DESCRIPTION
This commit update template of restore entry page and expand internal
API for Entry to be able to identify each attribute from E2E test.