### PR TITLE
Update to use APIv2 to get Entries that are associated with specific Entity

### DIFF
--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -15,8 +15,8 @@ class GetEntrySerializer(serializers.ModelSerializer):
 
     def get_schema(self, entry) -> Dict[str, Any]:
         return {
-                'id': entry.schema.id,
-                'name': entry.schema.name,
+            'id': entry.schema.id,
+            'name': entry.schema.name,
         }
 
     def get_attrs(self, obj) -> Dict[str, Any]:

--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -7,17 +7,25 @@ from typing import Any, Dict
 
 class GetEntrySerializer(serializers.ModelSerializer):
     schema = serializers.SerializerMethodField()
-    attrs = serializers.SerializerMethodField()
 
     class Meta:
         model = Entry
-        fields = ('id', 'name', 'schema', 'attrs')
+        fields = ('id', 'name', 'schema')
 
     def get_schema(self, entry) -> Dict[str, Any]:
         return {
             'id': entry.schema.id,
             'name': entry.schema.name,
         }
+
+
+class GetEntryWithAttrSerializer(GetEntrySerializer):
+    schema = serializers.SerializerMethodField()
+    attrs = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Entry
+        fields = ('id', 'name', 'schema', 'attrs')
 
     def get_attrs(self, obj) -> Dict[str, Any]:
         def get_attr_value(attr):

--- a/entry/api_v2/urls.py
+++ b/entry/api_v2/urls.py
@@ -4,6 +4,6 @@ from . import views
 
 urlpatterns = [
     url(r'^entries/(?P<entity_id>\d+)$', views.entryAPI.as_view({'get': 'list'})),
-    url(r'(?P<pk>\d+)$', views.entryAPI.as_view({'get': 'retrieve'})),
+    url(r'(?P<pk>\d+)$', views.entryWithAttrAPI.as_view({'get': 'retrieve'})),
     url(r'^search$', views.searchAPI.as_view({'get': 'list'}))
 ]

--- a/entry/api_v2/urls.py
+++ b/entry/api_v2/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
+    url(r'^entries/(?P<entity_id>\d+)$', views.entryAPI.as_view({'get': 'list'})),
     url(r'(?P<pk>\d+)$', views.entryAPI.as_view({'get': 'retrieve'})),
     url(r'^search$', views.searchAPI.as_view({'get': 'list'}))
 ]

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -1,7 +1,10 @@
 from rest_framework import viewsets
+from rest_framework.exceptions import NotAcceptable
 from django.db.models import Q
 
-from entry.api_v2.serializers import GetEntrySerializer, GetEntrySimpleSerializer
+from entry.api_v2.serializers import GetEntrySerializer
+from entry.api_v2.serializers import GetEntrySimpleSerializer
+from entry.api_v2.serializers import GetEntryWithAttrSerializer
 from entry.models import AttributeValue, Entry
 
 
@@ -16,7 +19,16 @@ class entryAPI(viewsets.ReadOnlyModelViewSet):
             return Entry.objects.filter(is_active=is_active,
                                         schema__id=self.kwargs['entity_id'])
         else:
-            return Entry.objects.filter(is_active=is_active)
+            return NotAcceptable()
+
+
+class entryWithAttrAPI(viewsets.ReadOnlyModelViewSet):
+    serializer_class = GetEntryWithAttrSerializer
+    ordering_fields = ['name']
+
+    def get_queryset(self):
+        is_active = self.request.GET.get('is_active', 'true').lower() == 'true'
+        return Entry.objects.filter(is_active=is_active)
 
 
 class searchAPI(viewsets.ReadOnlyModelViewSet):

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -6,8 +6,17 @@ from entry.models import AttributeValue, Entry
 
 
 class entryAPI(viewsets.ReadOnlyModelViewSet):
-    queryset = Entry.objects.filter(is_active=True)
     serializer_class = GetEntrySerializer
+    ordering_fields = ['name']
+
+    def get_queryset(self):
+        is_active = self.request.GET.get('is_active', 'true').lower() == 'true'
+
+        if 'entity_id' in self.kwargs:
+            return Entry.objects.filter(is_active=is_active,
+                                        schema__id=self.kwargs['entity_id'])
+        else:
+            return Entry.objects.filter(is_active=is_active)
 
 
 class searchAPI(viewsets.ReadOnlyModelViewSet):

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -319,6 +319,8 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(sorted([x['name'] for x in resp.json()]),
                          sorted(['e-0', 'e-1', 'e-2']))
+        self.assertTrue(all([sorted(['id', 'name', 'schema']) == sorted(x.keys())
+                             for x in resp.json()]))
 
     def test_get_deleted_entries_of_specific_entity(self):
         user = self.guest_login()

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -302,3 +302,34 @@ class ViewTest(AironeViewTest):
         self.assertEqual(len(resp_data), 1)
         self.assertEqual(resp_data[0]['id'], ref_entry1.id)
         self.assertEqual(resp_data[0]['name'], ref_entry1.name)
+
+    def test_get_entries_of_specific_entity(self):
+        user = self.guest_login()
+
+        # Create Entities and Entries for using this test-case
+        entities = [self.create_entity(user, 'E-%d' % x) for x in range(2)]
+        for index in range(3):
+            self.add_entry(user, 'e-%d' % index, entities[0])
+
+        # Create an Entry that is related with another Entity "E-1"
+        self.add_entry(user, 'spare-entry', entities[0])
+
+        # This expects to return only Entries that is related with Entity "E-0"
+        resp = self.client.get('/entry/api/v2/entries/%d' % entities[0].id)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(sorted([x['name'] for x in resp.json()['results']]),
+                         sorted(['e-0', 'e-1', 'e-2']))
+
+    def test_get_deleted_entries_of_specific_entity(self):
+        user = self.guest_login()
+
+        # Create an Entity and Entry, then delete it
+        entity = self.create_entity(user, 'Entity')
+        entry = self.add_entry(user, 'deleted-entry', entity)
+        entry.delete()
+
+        # Check this respond deleted entry
+        resp = self.client.get('/entry/api/v2/entries/%d?is_active=False' % entity.id)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()['count'], 1)
+        self.assertIn('deleted-entry', resp.json()['results'][0]['name'])

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -312,12 +312,12 @@ class ViewTest(AironeViewTest):
             self.add_entry(user, 'e-%d' % index, entities[0])
 
         # Create an Entry that is related with another Entity "E-1"
-        self.add_entry(user, 'spare-entry', entities[0])
+        self.add_entry(user, 'spare-entry', entities[1])
 
         # This expects to return only Entries that is related with Entity "E-0"
         resp = self.client.get('/entry/api/v2/entries/%d' % entities[0].id)
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(sorted([x['name'] for x in resp.json()['results']]),
+        self.assertEqual(sorted([x['name'] for x in resp.json()]),
                          sorted(['e-0', 'e-1', 'e-2']))
 
     def test_get_deleted_entries_of_specific_entity(self):
@@ -331,8 +331,8 @@ class ViewTest(AironeViewTest):
         # Check this respond deleted entry
         resp = self.client.get('/entry/api/v2/entries/%d?is_active=False' % entity.id)
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json()['count'], 1)
-        self.assertIn('deleted-entry', resp.json()['results'][0]['name'])
+        self.assertEqual(len(resp.json()), 1)
+        self.assertIn('deleted-entry', resp.json()[0]['name'])
 
     def test_entry_after_entity_attr_was_deleted(self):
         user = self.guest_login()

--- a/frontend/src/pages/EntryListPage.tsx
+++ b/frontend/src/pages/EntryListPage.tsx
@@ -20,12 +20,12 @@ import {
   entityPath,
   importEntriesPath,
   topPath,
-} from "../Routes";
-import { aironeApiClientV2 } from "../apiclient/AironeApiClientV2";
-import { AironeBreadcrumbs } from "../components/common/AironeBreadcrumbs";
-import { Loading } from "../components/common/Loading";
-import { EntryList as Entry } from "../components/entry/EntryList";
-import { getEntries, exportEntries } from "../utils/AironeAPIClient";
+} from "Routes";
+import { aironeApiClientV2 } from "apiclient/AironeApiClientV2";
+import { AironeBreadcrumbs } from "components/common/AironeBreadcrumbs";
+import { Loading } from "components/common/Loading";
+import { EntryList as Entry } from "components/entry/EntryList";
+import { getEntries, exportEntries } from "utils/AironeAPIClient";
 
 const useStyles = makeStyles<Theme>((theme) => ({
   button: {

--- a/frontend/src/pages/EntryListPage.tsx
+++ b/frontend/src/pages/EntryListPage.tsx
@@ -103,8 +103,7 @@ export const EntryListPage: FC<EntryListProps> = ({
 
   const entries = useAsync(async () => {
     const resp = await getEntries(entityId, true);
-    const data = await resp.json();
-    return data.results;
+    return await resp.json();
   });
 
   return (

--- a/frontend/src/utils/AironeAPIClient.ts
+++ b/frontend/src/utils/AironeAPIClient.ts
@@ -61,9 +61,7 @@ export function getEntries(
   isActive = true
 ): Promise<Response> {
   const isActiveParam = isActive ? "True" : "False";
-  return fetch(
-    `/entry/api/v2/entries/${entityId}?is_active=${isActiveParam}`
-  );
+  return fetch(`/entry/api/v2/entries/${entityId}?is_active=${isActiveParam}`);
 }
 
 export function getAttrReferrals(attr_id) {

--- a/frontend/src/utils/AironeAPIClient.ts
+++ b/frontend/src/utils/AironeAPIClient.ts
@@ -62,7 +62,7 @@ export function getEntries(
 ): Promise<Response> {
   const isActiveParam = isActive ? "True" : "False";
   return fetch(
-    `/entry/api/v1/get_entries/${entityId}?is_active=${isActiveParam}`
+    `/entry/api/v2/entries/${entityId}?is_active=${isActiveParam}`
   );
 }
 


### PR DESCRIPTION
This commit adds an API endpoint to get Entries that are related with specified Entity and change new-ui EntryList to use it.

And previous implementation uses '/entry/api/v1/get_entries' that returns Entries without sorting to list Entries of specific Entity. Instead of that, this commit use '/entry/api/v2/entries' that also returns Entries of associated Entity, sorted by alphabetical order. And that API endpoint plans to apply pagination feature.
