### PR TITLE
Fixed to add Entity ID to PATH on entry detail page

### DIFF
--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -41,8 +41,12 @@ class GetEntryWithAttrSerializer(GetEntrySerializer):
                 elif attr.schema.type & AttrTypeValue['named']:
                     return [{
                         x.value: {
-                          'id': x.referral.id if x.referral else None,
-                          'name': x.referral.name if x.referral else '',
+                            'id': x.referral.id if x.referral else None,
+                            'name': x.referral.name if x.referral else '',
+                            'schema': {
+                                'id': x.referral.entry.schema.id,
+                                'name': x.referral.entry.schema.name,
+                            } if x.referral else {}
                         },
                     } for x in attrv.data_array.all()]
 
@@ -50,6 +54,10 @@ class GetEntryWithAttrSerializer(GetEntrySerializer):
                     return [{
                         'id': x.referral.id if x.referral else None,
                         'name': x.referral.name if x.referral else '',
+                        'schema': {
+                            'id': x.referral.entry.schema.id,
+                            'name': x.referral.entry.schema.name,
+                        } if x.referral else {}
                     } for x in attrv.data_array.all()]
 
                 elif attr.schema.type & AttrTypeValue['group']:
@@ -68,6 +76,10 @@ class GetEntryWithAttrSerializer(GetEntrySerializer):
                     attrv.value: {
                         'id': attrv.referral.id if attrv.referral else None,
                         'name': attrv.referral.name if attrv.referral else '',
+                        'schema': {
+                            'id': attrv.referral.entry.schema.id,
+                            'name': attrv.referral.entry.schema.name,
+                        } if attrv.referral else {}
                     }
                 }
 
@@ -75,6 +87,10 @@ class GetEntryWithAttrSerializer(GetEntrySerializer):
                 return {
                     'id': attrv.referral.id if attrv.referral else None,
                     'name': attrv.referral.name if attrv.referral else '',
+                    'schema': {
+                        'id': attrv.referral.entry.schema.id,
+                        'name': attrv.referral.entry.schema.name,
+                    } if attrv.referral else {}
                 }
 
             elif attr.schema.type & AttrTypeValue['boolean']:

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -44,57 +44,119 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp_data['schema'],
                          {'id': entry.schema.id, 'name': entry.schema.name})
 
-        self.assertEqual(resp_data['attrs']['val'],
-                         {'type': AttrTypeValue['string'], 'value': 'hoge',
-                          'id': entry.attrs.get(schema__name='val').id,
-                          'schema_id': entry.attrs.get(schema__name='val').schema.id})
-        self.assertEqual(resp_data['attrs']['ref'],
-                         {'type': AttrTypeValue['object'], 'value': {
-                             'id': ref_entry.id, 'name': ref_entry.name},
-                          'id': entry.attrs.get(schema__name='ref').id,
-                          'schema_id': entry.attrs.get(schema__name='ref').schema.id})
-        self.assertEqual(resp_data['attrs']['name'],
-                         {'type': AttrTypeValue['named_object'], 'value': {
-                             'hoge': {'id': ref_entry.id, 'name': ref_entry.name}},
-                          'id': entry.attrs.get(schema__name='name').id,
-                          'schema_id': entry.attrs.get(schema__name='name').schema.id})
-        self.assertEqual(resp_data['attrs']['bool'],
-                         {'type': AttrTypeValue['boolean'], 'value': False,
-                          'id': entry.attrs.get(schema__name='bool').id,
-                          'schema_id': entry.attrs.get(schema__name='bool').schema.id})
-        self.assertEqual(resp_data['attrs']['date'],
-                         {'type': AttrTypeValue['date'], 'value': '2018-12-31',
-                          'id': entry.attrs.get(schema__name='date').id,
-                          'schema_id': entry.attrs.get(schema__name='date').schema.id})
-        self.assertEqual(resp_data['attrs']['group'],
-                         {'type': AttrTypeValue['group'], 'value': {
-                             'id': group.id, 'name': group.name},
-                          'id': entry.attrs.get(schema__name='group').id,
-                          'schema_id': entry.attrs.get(schema__name='group').schema.id})
-        self.assertEqual(resp_data['attrs']['groups'],
-                         {'type': AttrTypeValue['array_group'], 'value': [{
-                             'id': group.id, 'name': group.name}],
-                          'id': entry.attrs.get(schema__name='groups').id,
-                          'schema_id': entry.attrs.get(schema__name='groups').schema.id})
-        self.assertEqual(resp_data['attrs']['text'],
-                         {'type': AttrTypeValue['text'], 'value': 'fuga',
-                          'id': entry.attrs.get(schema__name='text').id,
-                          'schema_id': entry.attrs.get(schema__name='text').schema.id})
-        self.assertEqual(resp_data['attrs']['vals'],
-                         {'type': AttrTypeValue['array_string'], 'value': ['foo', 'bar'],
-                          'id': entry.attrs.get(schema__name='vals').id,
-                          'schema_id': entry.attrs.get(schema__name='vals').schema.id})
-        self.assertEqual(resp_data['attrs']['refs'],
-                         {'type': AttrTypeValue['array_object'], 'value': [{
-                             'id': ref_entry.id, 'name': ref_entry.name}],
-                          'id': entry.attrs.get(schema__name='refs').id,
-                          'schema_id': entry.attrs.get(schema__name='refs').schema.id})
-        self.assertEqual(resp_data['attrs']['names'],
-                         {'type': AttrTypeValue['array_named_object'], 'value': [
-                             {'foo': {'id': ref_entry.id, 'name': ref_entry.name}},
-                             {'bar': {'id': ref_entry.id, 'name': ref_entry.name}}],
-                          'id': entry.attrs.get(schema__name='names').id,
-                          'schema_id': entry.attrs.get(schema__name='names').schema.id})
+        self.assertEqual(resp_data['attrs']['val'], {
+            'type': AttrTypeValue['string'],
+            'value': 'hoge',
+            'id': entry.attrs.get(schema__name='val').id,
+            'schema_id': entry.attrs.get(schema__name='val').schema.id,
+        })
+        self.assertEqual(resp_data['attrs']['ref'], {
+            'type': AttrTypeValue['object'],
+            'value': {
+                'id': ref_entry.id,
+                'name': ref_entry.name,
+                'schema': {
+                    'id': ref_entry.schema.id,
+                    'name': ref_entry.schema.name,
+                },
+            },
+            'id': entry.attrs.get(schema__name='ref').id,
+            'schema_id': entry.attrs.get(schema__name='ref').schema.id,
+        })
+        self.assertEqual(resp_data['attrs']['name'], {
+            'type': AttrTypeValue['named_object'],
+            'value': {
+                'hoge': {
+                    'id': ref_entry.id,
+                    'name': ref_entry.name,
+                    'schema': {
+                        'id': ref_entry.schema.id,
+                        'name': ref_entry.schema.name,
+                    },
+                },
+            },
+            'id': entry.attrs.get(schema__name='name').id,
+            'schema_id': entry.attrs.get(schema__name='name').schema.id,
+        })
+        self.assertEqual(resp_data['attrs']['bool'], {
+            'type': AttrTypeValue['boolean'],
+            'value': False,
+            'id': entry.attrs.get(schema__name='bool').id,
+            'schema_id': entry.attrs.get(schema__name='bool').schema.id,
+        })
+        self.assertEqual(resp_data['attrs']['date'], {
+            'type': AttrTypeValue['date'],
+            'value': '2018-12-31',
+            'id': entry.attrs.get(schema__name='date').id,
+            'schema_id': entry.attrs.get(schema__name='date').schema.id,
+        })
+        self.assertEqual(resp_data['attrs']['group'], {
+            'type': AttrTypeValue['group'],
+            'value': {
+                'id': group.id,
+                'name': group.name,
+            },
+            'id': entry.attrs.get(schema__name='group').id,
+            'schema_id': entry.attrs.get(schema__name='group').schema.id,
+        })
+        self.assertEqual(resp_data['attrs']['groups'], {
+            'type': AttrTypeValue['array_group'],
+            'value': [{
+                'id': group.id,
+                'name': group.name,
+            }],
+            'id': entry.attrs.get(schema__name='groups').id,
+            'schema_id': entry.attrs.get(schema__name='groups').schema.id,
+        })
+        self.assertEqual(resp_data['attrs']['text'], {
+            'type': AttrTypeValue['text'],
+            'value': 'fuga',
+            'id': entry.attrs.get(schema__name='text').id,
+            'schema_id': entry.attrs.get(schema__name='text').schema.id,
+        })
+        self.assertEqual(resp_data['attrs']['vals'], {
+            'type': AttrTypeValue['array_string'],
+            'value': ['foo', 'bar'],
+            'id': entry.attrs.get(schema__name='vals').id,
+            'schema_id': entry.attrs.get(schema__name='vals').schema.id,
+        })
+        self.assertEqual(resp_data['attrs']['refs'], {
+            'type': AttrTypeValue['array_object'],
+            'value': [{
+                'id': ref_entry.id,
+                'name': ref_entry.name,
+                'schema': {
+                    'id': ref_entry.schema.id,
+                    'name': ref_entry.schema.name,
+                },
+            }],
+            'id': entry.attrs.get(schema__name='refs').id,
+            'schema_id': entry.attrs.get(schema__name='refs').schema.id,
+        })
+        self.assertEqual(resp_data['attrs']['names'], {
+            'type': AttrTypeValue['array_named_object'],
+            'value': [{
+                'foo': {
+                    'id': ref_entry.id,
+                    'name': ref_entry.name,
+                    'schema': {
+                        'id': ref_entry.schema.id,
+                        'name': ref_entry.schema.name,
+                    },
+                },
+            }, {
+                'bar': {
+                    'id': ref_entry.id,
+                    'name': ref_entry.name,
+                    'schema': {
+                        'id': ref_entry.schema.id,
+                        'name': ref_entry.schema.name,
+                    },
+                },
+            }],
+            'id': entry.attrs.get(schema__name='names').id,
+            'schema_id': entry.attrs.get(schema__name='names').schema.id,
+        })
 
     def test_serach_entry(self):
         user = self.guest_login()

--- a/frontend/src/components/entry/AttributeValue.tsx
+++ b/frontend/src/components/entry/AttributeValue.tsx
@@ -27,24 +27,40 @@ const ElemString: FC<{ attrValue: string }> = ({ attrValue }) => {
   );
 };
 
-const ElemObject: FC<{ attrValue: { id: number; name: string } }> = ({
-  attrValue,
-}) => {
+const ElemObject: FC<{
+  attrValue: {
+    id: number;
+    name: string;
+    schema?: { id: number; name: string };
+  };
+}> = ({ attrValue }) => {
   return (
-    // TODO edit entityId
-    <Box component={Link} to={entryDetailsPath(0, attrValue.id)}>
+    <Box
+      component={Link}
+      to={entryDetailsPath(attrValue.schema?.id ?? 0, attrValue.id)}
+    >
       {attrValue.name}
     </Box>
   );
 };
 
-const ElemNamedObject: FC<{ attrValue: any }> = ({ attrValue }) => {
+const ElemNamedObject: FC<{
+  attrValue: {
+    [key: string]: {
+      id: number;
+      name: string;
+      schema?: { id: number; name: string };
+    };
+  };
+}> = ({ attrValue }) => {
   const key = Object.keys(attrValue)[0];
   return (
     <Box display="flex">
       <Box>{key}: </Box>
-      // TODO edit entityId
-      <Box component={Link} to={entryDetailsPath(0, attrValue[key].id)}>
+      <Box
+        component={Link}
+        to={entryDetailsPath(attrValue[key].schema?.id ?? 0, attrValue[key].id)}
+      >
         {attrValue[key].name}
       </Box>
     </Box>


### PR DESCRIPTION
Changed to return the schema of object type attribute in entry APIv2.
But advanced search is not yet supported.
![image](https://user-images.githubusercontent.com/5561786/155910940-a28c3881-c781-4497-a425-f28d628edda1.png)
