### PR TITLE
Reverted the initialization part of Elasticsearch class

### DIFF
--- a/acl/tests/test_view.py
+++ b/acl/tests/test_view.py
@@ -1,5 +1,4 @@
 import json
-from airone.lib.elasticsearch import ESS
 
 from group.models import Group
 from django.urls import reverse
@@ -135,7 +134,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.json()['redirect_url'], '/entry/edit/%s' % entry.id)
         self.assertEqual(user.permissions.last(), attr.writable)
         self.assertFalse(Attribute.objects.get(id=attr.id).is_public)
-        search_result = ESS().search(body={'query': {'term': {'name': entry.name}}})
+        search_result = self._es.search(body={'query': {'term': {'name': entry.name}}})
         self.assertFalse(search_result['hits']['hits'][0]['_source']['attr'][0]['is_readble'])
 
     def test_post_acl_set_entry(self):
@@ -149,7 +148,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.json()['redirect_url'], '/entry/show/%s' % entry.id)
         self.assertEqual(user.permissions.last(), entry.writable)
         self.assertFalse(Entry.objects.get(id=entry.id).is_public)
-        search_result = ESS().search(body={'query': {'term': {'name': entry.name}}})
+        search_result = self._es.search(body={'query': {'term': {'name': entry.name}}})
         self.assertFalse(search_result['hits']['hits'][0]['_source']['is_readble'])
 
     def test_post_acl_set_nothing(self):

--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -16,13 +16,13 @@ from entry.settings import CONFIG
 
 class ESS(Elasticsearch):
     MAX_TERM_SIZE = 32766
-    _INDEX = settings.ES_CONFIG['INDEX']
 
     def __init__(self, index=None, *args, **kwargs):
         self.additional_config = False
 
+        self._index = index
         if not index:
-            self._index = self._INDEX
+            self._index = settings.ES_CONFIG['INDEX']
 
         if ('timeout' not in kwargs) and (settings.ES_CONFIG['TIMEOUT'] is not None):
             kwargs['timeout'] = settings.ES_CONFIG['TIMEOUT']


### PR DESCRIPTION
The environment variables and class variables at the time of ESS class initialization were different.
Because to override environment variables during testing.
https://github.com/dmm-com/airone/blob/f511a96345baa43f6d4a1034c47845b73cc61da0/airone/lib/test.py#L14-L20
![image](https://user-images.githubusercontent.com/5561786/156687220-819f5e74-1794-4e59-b634-42456235ea7f.png)
