### PR TITLE
Fix #425 Validate if entry_id is digit

### DIFF
--- a/api_v1/tests/test_api.py
+++ b/api_v1/tests/test_api.py
@@ -516,6 +516,10 @@ class APITest(AironeViewTest):
         resp = self.client.get('/api/v1/entry')
         self.assertEqual(resp.status_code, 400)
 
+        # send request with invalid entry_id
+        resp = self.client.get('/api/v1/entry', {'entry_id': 'not digit'})
+        self.assertEqual(resp.status_code, 400)
+
         # send request with invalid name of Entity
         resp = self.client.get('/api/v1/entry', {'entity': 'foo', 'entry': 'bar'})
         self.assertEqual(resp.status_code, 404)

--- a/api_v1/views.py
+++ b/api_v1/views.py
@@ -121,6 +121,9 @@ class EntryAPI(APIView):
                     {'result': 'Parameter any of "entry", "entry_id" or "entity" is mandatory'},
                     status=status.HTTP_400_BAD_REQUEST)
 
+        if param_entry_id and not param_entry_id.isdigit():
+            return Response({'result': 'Parameter "entry_id" is numerically'},
+                            status=status.HTTP_400_BAD_REQUEST)
         if not param_offset.isdigit():
             return Response({'result': 'Parameter "offset" is numerically'},
                             status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
To fix https://github.com/dmm-com/airone/issues/425, validate if `entry_id` param is digit.