### PR TITLE
Changed job result backend of celery from rabbitmq to None

### DIFF
--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -25,7 +25,6 @@ class Common(Configuration):
     #: Only add pickle to this list if your broker is secured
     #: from unwanted access (see userguide/security.html)
     CELERY_ACCEPT_CONTENT = ['json']
-    CELERY_RESULT_BACKEND = 'rpc://'
     CELERY_TASK_SERIALIZER = 'json'
     CELERY_BROKER_HEARTBEAT = 0
 


### PR DESCRIPTION
We need to monitor the number of queues in rabbitmq to check the health of job passing from django to celery.
At that time, if save the job result of celery in rabbitmq, it will interfere with monitoring.