### PR TITLE
Fixed duplicate to send email at the time of error

### DIFF
--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -249,7 +249,7 @@ class Common(Configuration):
 
     LOGGING: Dict[str, Any] = {
         'version': 1,
-        'disable_existing_loggers': False,
+        'disable_existing_loggers': True,
         'formatters': {
             'all': {
                 'format': '\t'.join([
@@ -281,11 +281,6 @@ class Common(Configuration):
                 'level': 'INFO',
                 'propagate': False,
             },
-            'django.server': {
-                'handlers': ['file', 'console'],
-                'level': 'INFO',
-                'propagate': False,
-            }
         }
     }
     # If log dir is not exists create it.


### PR DESCRIPTION
Disable the default mail_admins handler for django.

disable_existing_loggers
(c.f. https://docs.djangoproject.com/en/4.0/topics/logging/#configuring-logging-1)