### PR TITLE
Fixed celery exception error not being outputted

### DIFF
--- a/airone/celery.py
+++ b/airone/celery.py
@@ -4,6 +4,8 @@ from celery import Celery
 from celery.signals import task_failure
 from django.core.mail import mail_admins
 
+from airone.lib.log import Logger
+
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'airone.settings')
 os.environ.setdefault('DJANGO_CONFIGURATION', 'Dev')
@@ -40,4 +42,6 @@ full traceback:
 {einfo}
 """.format(**kwargs)
 
+    # Logger for DEBUG because email is not sent in dev environment
+    Logger.error(message)
     mail_admins(subject, message)


### PR DESCRIPTION
I have confirmed the standard output of Celery as below.

```
[ERROR] asctime:2022-03-29 12:28:34,521 module:celery   message:
Task Name: entity.tasks.create_entity
Task ID: 4664ba5a-a05e-43dc-a092-40d0fb61e603
Task args: [40]
Task kwargs: {}

raised exception:
DataError(1406, "Data too long for column 'name' at row 1")
```