### PR TITLE
Deny duplicated active entity attribute names

### DIFF
--- a/entity/tests/test_view.py
+++ b/entity/tests/test_view.py
@@ -177,6 +177,24 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 400)
         self.assertIsNone(Entity.objects.first())
 
+        # with duplicated attr names
+        params = {
+            'note': 'fuga',
+            'is_toplevel': False,
+            'attrs': [
+                {'name': 'foo', 'type': str(AttrTypeStr), 'is_delete_in_chain': False,
+                 'is_mandatory': True, 'row_index': '1'},
+                {'name': 'foo', 'type': str(AttrTypeStr), 'is_delete_in_chain': False,
+                 'is_mandatory': False, 'row_index': '2'},
+            ],
+        }
+        resp = self.client.post(reverse('entity:do_create'),
+                                json.dumps(params),
+                                'application/json')
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIsNone(Entity.objects.first())
+
     def test_create_post_with_invalid_attrs(self):
         self.admin_login()
 
@@ -310,6 +328,23 @@ class ViewTest(AironeViewTest):
                 {'name': 'a' * (EntityAttr._meta.get_field('name').max_length + 1),
                  'type': str(AttrTypeStr), 'is_delete_in_chain': False,
                  'is_mandatory': True, 'row_index': '1'},
+            ],
+        }
+        resp = self.client.post(reverse('entity:do_edit', args=[entity.id]),
+                                json.dumps(params),
+                                'application/json')
+        self.assertEqual(resp.status_code, 400)
+
+        # with duplicated attr names
+        params = {
+            'name': 'hoge',
+            'note': 'fuga',
+            'is_toplevel': False,
+            'attrs': [
+                {'name': 'foo', 'type': str(AttrTypeStr), 'is_delete_in_chain': False,
+                 'is_mandatory': True, 'row_index': '1'},
+                {'name': 'foo', 'type': str(AttrTypeStr), 'is_delete_in_chain': False,
+                 'is_mandatory': True, 'row_index': '2'},
             ],
         }
         resp = self.client.post(reverse('entity:do_edit', args=[entity.id]),

--- a/entity/views.py
+++ b/entity/views.py
@@ -1,3 +1,4 @@
+import collections
 import re
 import io
 import yaml
@@ -75,7 +76,7 @@ def create(request):
 @http_get
 def edit(request, entity_id):
     user = User.objects.get(id=request.user.id)
-    entity, error = get_object_with_check_permission(user, Entity, entity_id,  ACLType.Writable)
+    entity, error = get_object_with_check_permission(user, Entity, entity_id, ACLType.Writable)
     if error:
         return error
 
@@ -108,16 +109,16 @@ def edit(request, entity_id):
     {'name': 'is_toplevel', 'type': bool},
     {'name': 'attrs', 'type': list, 'meta': [
         {'name': 'name', 'type': str, 'checker': lambda x: (
-            x['name'] and not re.match(r'^\s*$', x['name']) and
-            len(x['name']) <= EntityAttr._meta.get_field('name').max_length
+                x['name'] and not re.match(r'^\s*$', x['name']) and
+                len(x['name']) <= EntityAttr._meta.get_field('name').max_length
         )},
         {'name': 'type', 'type': str, 'checker': lambda x: (
-            any([y == int(x['type']) for y in AttrTypes])
+                any([y == int(x['type']) for y in AttrTypes])
         )},
         {'name': 'is_mandatory', 'type': bool},
         {'name': 'is_delete_in_chain', 'type': bool},
         {'name': 'row_index', 'type': str, 'checker': lambda x: (
-            re.match(r"^[0-9]*$", x['row_index'])
+                re.match(r"^[0-9]*$", x['row_index'])
         )}
     ]}
 ])
@@ -138,6 +139,12 @@ def do_edit(request, entity_id, recv_data):
 
         if any([not Entity.objects.filter(id=x).exists() for x in attr['ref_ids']]):
             return HttpResponse('Specified referral is invalid', status=400)
+
+    # duplication checks
+    counter = collections.Counter([attr['name'] for attr in recv_data['attrs']
+                                   if 'deleted' not in attr or not attr['deleted']])
+    if len([v for v, count in counter.items() if count > 1]):
+        return HttpResponse('Duplicated attribute names are not allowed', status=400)
 
     # prevent to show edit page under the processing
     if entity.get_status(Entity.STATUS_EDITING):
@@ -172,23 +179,23 @@ def do_edit(request, entity_id, recv_data):
 
 @http_post([
     {'name': 'name', 'type': str, 'checker': lambda x: (
-        x['name'] and not Entity.objects.filter(name=x['name']).exists() and
-        len(x['name']) <= Entity._meta.get_field('name').max_length
+            x['name'] and not Entity.objects.filter(name=x['name']).exists() and
+            len(x['name']) <= Entity._meta.get_field('name').max_length
     )},
     {'name': 'note', 'type': str},
     {'name': 'is_toplevel', 'type': bool},
     {'name': 'attrs', 'type': list, 'meta': [
         {'name': 'name', 'type': str, 'checker': lambda x: (
-            x['name'] and not re.match(r'^\s*$', x['name']) and
-            len(x['name']) <= EntityAttr._meta.get_field('name').max_length
+                x['name'] and not re.match(r'^\s*$', x['name']) and
+                len(x['name']) <= EntityAttr._meta.get_field('name').max_length
         )},
         {'name': 'type', 'type': str, 'checker': lambda x: (
-            any([y == int(x['type']) for y in AttrTypes])
+                any([y == int(x['type']) for y in AttrTypes])
         )},
         {'name': 'is_mandatory', 'type': bool},
         {'name': 'is_delete_in_chain', 'type': bool},
         {'name': 'row_index', 'type': str, 'checker': lambda x: (
-            re.match(r"^[0-9]*$", x['row_index'])
+                re.match(r"^[0-9]*$", x['row_index'])
         )}
     ]},
 ])
@@ -204,6 +211,12 @@ def do_create(request, recv_data):
 
         if any([not Entity.objects.filter(id=x).exists() for x in attr['ref_ids']]):
             return HttpResponse('Specified referral is invalid', status=400)
+
+    # duplication checks
+    counter = collections.Counter([attr['name'] for attr in recv_data['attrs']
+                                   if 'deleted' not in attr or not attr['deleted']])
+    if len([v for v, count in counter.items() if count > 1]):
+        return HttpResponse('Duplicated attribute names are not allowed', status=400)
 
     # get user object that current access
     user = User.objects.get(id=request.user.id)
@@ -357,7 +370,8 @@ def dashboard(request, entity_id):
             sum([x['count'] for x in summarized_data[attr]['referral_count']])
 
         summarized_data[attr]['no_referral_ratio'] = '%2.1f' % \
-            ((100 * summarized_data[attr]['no_referral_count']) / total_entry_count)
+                                                     ((100 * summarized_data[attr][
+                                                         'no_referral_count']) / total_entry_count)
 
         # sort by referral counts
         summarized_data[attr]['referral_count'] = sorted(summarized_data[attr]['referral_count'],


### PR DESCRIPTION
Duplicated entity attribute names confuse us, especially narrow down parts.

Ideally I want to implement with UNIQUE constraint in DB, but it requires to ensure uniqueness on the pair of `ACLBase.name` and `EntityAttr.parent_entity_id` so it was impossible. Alternatively I introduce duplication check on Django view.