### PR TITLE
Fixed an error when copying a lot of entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Changed
 
 ### Fixed
+* Fixed an error when copying a lot of entries
+  Contributed by @hinashi
 
 ## v3.8.0
 

--- a/acl/views.py
+++ b/acl/views.py
@@ -96,7 +96,7 @@ def set(request, recv_data):
     if not request.user.has_permission(acl_obj, ACLType.Full):
         return HttpResponse(
             "User(%s) doesn't have permission to change this ACL" % request.user.username,
-            status=400
+            status=400,
         )
 
     acl_obj.is_public = False

--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -157,6 +157,7 @@ def render(request, template, context={}):
             "EDIT": JobOperation.EDIT_ENTRY.value,
             "DELETE": JobOperation.DELETE_ENTRY.value,
             "COPY": JobOperation.COPY_ENTRY.value,
+            "DO_COPY": JobOperation.DO_COPY_ENTRY.value,
             "IMPORT": JobOperation.IMPORT_ENTRY.value,
             "EXPORT": JobOperation.EXPORT_ENTRY.value,
             "RESTORE": JobOperation.RESTORE_ENTRY.value,

--- a/api_v1/job/views.py
+++ b/api_v1/job/views.py
@@ -28,6 +28,7 @@ class JobAPI(APIView):
                 "edit": JobOperation.EDIT_ENTRY.value,
                 "delete": JobOperation.DELETE_ENTRY.value,
                 "copy": JobOperation.COPY_ENTRY.value,
+                "do_copy": JobOperation.DO_COPY_ENTRY.value,
                 "import": JobOperation.IMPORT_ENTRY.value,
                 "export": JobOperation.EXPORT_ENTRY.value,
                 "export_search_result": JobOperation.EXPORT_SEARCH_RESULT.value,

--- a/api_v1/tests/job/test_api.py
+++ b/api_v1/tests/job/test_api.py
@@ -50,6 +50,7 @@ class APITest(AironeViewTest):
                 "edit": JobOperation.EDIT_ENTRY.value,
                 "delete": JobOperation.DELETE_ENTRY.value,
                 "copy": JobOperation.COPY_ENTRY.value,
+                "do_copy": JobOperation.DO_COPY_ENTRY.value,
                 "import": JobOperation.IMPORT_ENTRY.value,
                 "export": JobOperation.EXPORT_ENTRY.value,
                 "export_search_result": JobOperation.EXPORT_SEARCH_RESULT.value,
@@ -154,7 +155,7 @@ class APITest(AironeViewTest):
         self.assertEqual(entry.attrs.first().get_latest_value().value, "fuga")
 
         # make and send a job to copy entry
-        job = Job.new_copy(user, entry, params={"new_name": "new_entry"})
+        job = Job.new_do_copy(user, entry, params={"new_name": "new_entry"})
         resp = self.client.post("/api/v1/job/run/%d" % job.id)
 
         self.assertEqual(resp.status_code, 200)

--- a/job/models.py
+++ b/job/models.py
@@ -42,6 +42,7 @@ class JobOperation(Enum):
     NOTIFY_CREATE_ENTRY = 13
     NOTIFY_UPDATE_ENTRY = 14
     NOTIFY_DELETE_ENTRY = 15
+    DO_COPY_ENTRY = 16
 
 
 class Job(models.Model):
@@ -92,6 +93,7 @@ class Job(models.Model):
 
     CANCELABLE_OPERATIONS = [
         JobOperation.CREATE_ENTRY.value,
+        JobOperation.COPY_ENTRY.value,
         JobOperation.IMPORT_ENTRY.value,
         JobOperation.EXPORT_ENTRY.value,
         JobOperation.REGISTER_REFERRALS.value,
@@ -275,6 +277,7 @@ class Job(models.Model):
                 JobOperation.EDIT_ENTRY.value: entry_task.edit_entry_attrs,
                 JobOperation.DELETE_ENTRY.value: entry_task.delete_entry,
                 JobOperation.COPY_ENTRY.value: entry_task.copy_entry,
+                JobOperation.DO_COPY_ENTRY.value: entry_task.do_copy_entry,
                 JobOperation.IMPORT_ENTRY.value: entry_task.import_entries,
                 JobOperation.EXPORT_ENTRY.value: entry_task.export_entries,
                 JobOperation.RESTORE_ENTRY.value: entry_task.restore_entry,
@@ -332,6 +335,16 @@ class Job(models.Model):
             user,
             target,
             JobOperation.COPY_ENTRY.value,
+            text,
+            json.dumps(params, sort_keys=True),
+        )
+
+    @classmethod
+    def new_do_copy(kls, user, target, text="", params={}):
+        return kls._create_new_job(
+            user,
+            target,
+            JobOperation.DO_COPY_ENTRY.value,
             text,
             json.dumps(params, sort_keys=True),
         )

--- a/templates/list_jobs.html
+++ b/templates/list_jobs.html
@@ -83,6 +83,8 @@
               削除
             {% elif job.operation|divmod:100 == JOB.OPERATION.COPY %}
               コピー
+            {% elif job.operation|divmod:100 == JOB.OPERATION.DO_COPY %}
+              コピー
             {% elif job.operation|divmod:100 == JOB.OPERATION.IMPORT %}
               インポート
             {% elif job.operation|divmod:100 == JOB.OPERATION.EXPORT %}


### PR DESCRIPTION
There is a problem that an error occurs due to the high load of DB when copying a lot of entries.
One job is created for each destination entry.
Since it is a dependent job, it queries the DB once per second.

In this PR, the copy jobs have been combined into one.