### PR TITLE
Fixed HTTP 404 exception error

### DIFF
--- a/airone/lib/log.py
+++ b/airone/lib/log.py
@@ -2,6 +2,7 @@ import traceback
 from logging import getLogger
 from time import time
 
+from django.conf import settings
 from django.core.mail import mail_admins
 from django.http import HttpResponseServerError
 
@@ -54,4 +55,5 @@ full traceback:
         # Print for DEBUG because email is not sent in dev environment
         print(message)
         mail_admins(subject, message)
-        return HttpResponseServerError("Internal Server Error")
+        if not settings.DEBUG:
+            return HttpResponseServerError("Internal Server Error")

--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -65,15 +65,15 @@ class Common(Configuration):
     ]
 
     MIDDLEWARE = [
-        "airone.lib.log.LoggingRequestMiddleware",
         "django.middleware.security.SecurityMiddleware",
+        "whitenoise.middleware.WhiteNoiseMiddleware",
+        "airone.lib.log.LoggingRequestMiddleware",
         "django.contrib.sessions.middleware.SessionMiddleware",
         "django.middleware.common.CommonMiddleware",
         "django.middleware.csrf.CsrfViewMiddleware",
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware",
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
-        "whitenoise.middleware.WhiteNoiseMiddleware",
         "airone.lib.db.AirOneReplicationMiddleware",
         # "debug_toolbar.middleware.DebugToolbarMiddleware",
     ]

--- a/airone/urls.py
+++ b/airone/urls.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.conf.urls import url, include
 from django.contrib.auth import views as auth_views
 from django.views.generic import RedirectView
-from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 from api_v1.urls import urlpatterns as api_v1_urlpatterns
 from airone.auth import view as auth_view
@@ -42,5 +41,3 @@ for extension in settings.AIRONE["EXTENSIONS"]:
     urlpatterns.append(
         url(r"^extension/%s" % extension, include(("%s.urls" % extension, extension)))
     )
-
-urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
There is a problem that the HTTP404 error becomes an internal server error.
Fixed by changing the order of WhiteNoiseMiddleware.
(c.f. http://whitenoise.evans.io/en/stable/django.html#enable-whitenoise)

Also changed to display an error when the debug parameter is True.