### PR TITLE
Stop raising exception on validating URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   Contributed by @hinashi
 * Fixed some model and UI problems related with new added Role feature
   Contributed by @userlocalhost
+* Added URL validation processing when user specify webhook configuration
+  for Entity
+  Contributed by @syucream
 
 ## v3.8.0
 

--- a/webhook/api_v1/views.py
+++ b/webhook/api_v1/views.py
@@ -1,6 +1,7 @@
 import json
 import requests
 import urllib3
+from requests.exceptions import ConnectionError
 from urllib3.exceptions import InsecureRequestWarning
 
 from airone.lib.acl import ACLType
@@ -68,18 +69,21 @@ def set_webhook(request, entity_id, recv_data):
         )
         entity.webhooks.add(webhook)
 
-    resp = requests.post(
-        recv_data["webhook_url"],
-        **{
-            "headers": request_headers,
-            "data": json.dumps({}),
-            "verify": False,
-        }
-    )
+    try:
+        resp = requests.post(
+            recv_data["webhook_url"],
+            **{
+                "headers": request_headers,
+                "data": json.dumps({}),
+                "verify": False,
+            }
+        )
+        # The is_verified parameter will be set True,
+        # when requests received HTTP 200 from specifying endpoint.
+        webhook.is_verified = resp.ok
+    except ConnectionError:
+        webhook.is_verified = False
 
-    # The is_verified parameter will be set True,
-    # when requests received HTTP 200 from specifying endpoint.
-    webhook.is_verified = resp.ok
     webhook.save()
 
     return JsonResponse({"webhook_id": webhook.id, "msg": "Succeded in registering Webhook"})

--- a/webhook/tests/test_api_v1.py
+++ b/webhook/tests/test_api_v1.py
@@ -1,4 +1,5 @@
 import json
+from requests.exceptions import ConnectionError
 
 from airone.lib.test import AironeViewTest
 from entity.models import Entity
@@ -100,6 +101,30 @@ class APITest(AironeViewTest):
         )
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.content.decode("utf-8"), "Invalid Webhook ID is specified")
+
+    @mock.patch("webhook.api_v1.views.requests")
+    def test_edit_unreachable_webhook(self, mock_requests):
+        user = self.guest_login()
+        entity = Entity.objects.create(name="test-entity", created_user=user)
+
+        mock_requests.post.side_effect = ConnectionError()
+
+        resp = self.client.post(
+            "/webhook/api/v1/set/%s" % entity.id,
+            json.dumps(
+                {
+                    "webhook_url": "https://example.com",
+                    "label": "test endpoint",
+                    "request_headers": [{"key": "content-type", "value": "application/json"}],
+                    "is_enabled": True,
+                }
+            ),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        webhook = Webhook.objects.get(id=resp.json()["webhook_id"])
+        self.assertFalse(webhook.is_verified)
 
     @mock.patch("webhook.api_v1.views.requests")
     def test_edit_webhook_instance(self, mock_requests):


### PR DESCRIPTION
It could cause such an exception:
```
Traceback (most recent call last):
File "/virtualenv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 598, in urlopen
httplib_response = self._make_request(conn, method, url,
File "/virtualenv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 357, in _make_request
conn.request(method, url, **httplib_request_kw)
File "/usr/lib/python3.8/http/client.py", line 1256, in request
self._send_request(method, url, body, headers, encode_chunked)
File "/usr/lib/python3.8/http/client.py", line 1302, in _send_request
self.endheaders(body, encode_chunked=encode_chunked)
File "/usr/lib/python3.8/http/client.py", line 1251, in endheaders
self._send_output(message_body, encode_chunked=encode_chunked)
File "/usr/lib/python3.8/http/client.py", line 1011, in _send_output
self.send(msg)
File "/usr/lib/python3.8/http/client.py", line 951, in send
self.connect()
File "/virtualenv/lib/python3.8/site-packages/urllib3/connection.py", line 166, in connect
conn = self._new_conn()
File "/virtualenv/lib/python3.8/site-packages/urllib3/connection.py", line 149, in _new_conn
raise NewConnectionError(
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x7f17cb9361f0>: Failed to establish a new connection: [Errno -2] Name or service not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/virtualenv/lib/python3.8/site-packages/requests/adapters.py", line 439, in send
resp = conn.urlopen(
File "/virtualenv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 638, in urlopen
retries = retries.increment(method, url, error=e, _pool=self,
File "/virtualenv/lib/python3.8/site-packages/urllib3/util/retry.py", line 388, in increment
raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='hogefuga.puyo', port=80): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f17cb9361f0>: Failed to establish a new connection: [Errno -2] Name or service not known'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/virtualenv/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/virtualenv/lib/python3.8/site-packages/ddtrace/contrib/trace_utils.py", line 165, in wrapper
return func(mod, pin, wrapped, instance, args, kwargs)
File "/virtualenv/lib/python3.8/site-packages/ddtrace/contrib/django/patch.py", line 224, in wrapped
return func(*args, **kwargs)
File "/airone/airone/lib/http.py", line 91, in http_post_handler
return func(*args, **kwargs)
File "/airone/webhook/api_v1/views.py", line 71, in set_webhook
resp = requests.post(
File "/virtualenv/lib/python3.8/site-packages/requests/api.py", line 116, in post
return request('post', url, data=data, json=json, **kwargs)
File "/virtualenv/lib/python3.8/site-packages/requests/api.py", line 60, in request
return session.request(method=method, url=url, **kwargs)
File "/virtualenv/lib/python3.8/site-packages/requests/sessions.py", line 524, in request
resp = self.send(prep, **send_kwargs)
File "/virtualenv/lib/python3.8/site-packages/ddtrace/contrib/requests/connection.py", line 102, in _wrap_send
response = func(*args, **kwargs)
File "/virtualenv/lib/python3.8/site-packages/requests/sessions.py", line 637, in send
r = adapter.send(request, **kwargs)
File "/virtualenv/lib/python3.8/site-packages/requests/adapters.py", line 516, in send
raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='hogefuga.puyo', port=80): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f17cb9361f0>: Failed to establish a new connection: [Errno -2] Name or service not known'))
```

The original implementation looks expecting that it sets `is_verified = False` so I did so.