### PR TITLE
Fix broken entry referral API V2

### DIFF
--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -162,7 +162,7 @@ class EntryReferralAPI(viewsets.ReadOnlyModelViewSet):
 
         entry = Entry.objects.filter(pk=entry_id).first()
         if not entry:
-            return None
+            return []
 
         ids = AttributeValue.objects.filter(
             Q(referral=entry, is_latest=True) | Q(referral=entry, parent_attrv__is_latest=True)

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -1219,3 +1219,30 @@ class ViewTest(AironeViewTest):
                 ["ref", "name", "bool", "date", "group", "groups", "text", "vals", "refs", "names"]
             ),
         )
+
+    def test_referral(self):
+        entry = self.add_entry(
+            self.user,
+            "Entry",
+            self.entity,
+            values={
+                "ref": self.ref_entry.id,
+            },
+        )
+
+        resp = self.client.get("/entry/api/v2/%s/referral/" % self.ref_entry.id)
+        self.assertEqual(resp.status_code, 200)
+
+        resp_data = resp.json()
+        results = resp_data["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], entry.id)
+        self.assertEqual(results[0]["name"], entry.name)
+
+    def test_referral_unrelated_to_entry(self):
+        resp = self.client.get("/entry/api/v2/%s/referral/" % 99999)  # invalid entry id
+        self.assertEqual(resp.status_code, 200)
+
+        resp_data = resp.json()
+        results = resp_data["results"]
+        self.assertEqual(len(results), 0)


### PR DESCRIPTION
> TypeError: object of type 'NoneType' has no len()

Fix this issue