### PR TITLE
Added warning dialog in edit entity page

### DIFF
--- a/frontend/src/pages/EditEntityPage.tsx
+++ b/frontend/src/pages/EditEntityPage.tsx
@@ -1,7 +1,7 @@
 import { Box, Typography } from "@mui/material";
 import { useSnackbar } from "notistack";
 import React, { FC, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, Prompt } from "react-router-dom";
 import { useHistory } from "react-router-dom";
 import { useAsync } from "react-use";
 
@@ -169,6 +169,7 @@ export const EditEntityPage: FC = () => {
           setSubmittable={setSubmittable}
         />
       </Box>
+      <Prompt message="編集した内容は失われてしまいますが、このページを離れてもよろしいですか？" />
     </Box>
   );
 };


### PR DESCRIPTION
Added a dialog that appears when you leave the entity edit page.
(c.f. https://v5.reactrouter.com/core/api/Prompt)
![image](https://user-images.githubusercontent.com/5561786/174274224-84245573-effc-4212-833e-4c30dabb37fd.png)

