### PR TITLE
Fixed test to be run by Django testing framework

### DIFF
--- a/group/tests/test_api_v2.py
+++ b/group/tests/test_api_v2.py
@@ -1,8 +1,16 @@
 from airone.lib.test import AironeViewTest
+from user.models import User
+from group.models import Group
 
 
 class GroupAPITest(AironeViewTest):
-    def list(self):
+    def _create_user(self, name):
+        return User.objects.create(username=name)
+
+    def _create_group(self, name):
+        return Group.objects.create(name=name)
+
+    def test_list(self):
         self.admin_login()
 
         user = self._create_user("fuga")
@@ -13,11 +21,11 @@ class GroupAPITest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
         self.assertEqual(len(body), 1)
-        self.assertEqual(body[0].id, group.id)
-        self.assertEqual(len(body.members), 1)
-        self.assertEqual(body.members[0].id, user.id)
+        self.assertEqual(body[0]["id"], group.id)
+        self.assertEqual(len(body[0]["members"]), 1)
+        self.assertEqual(body[0]["members"][0]["id"], user.id)
 
-    def retrieve(self):
+    def test_retrieve(self):
         self.admin_login()
 
         user = self._create_user("fuga")
@@ -27,6 +35,6 @@ class GroupAPITest(AironeViewTest):
         resp = self.client.get("/group/api/v2/groups/%s" % group.id)
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
-        self.assertEqual(body.id, group.id)
-        self.assertEqual(len(body.members), 1)
-        self.assertEqual(body.members[0].id, user.id)
+        self.assertEqual(body["id"], group.id)
+        self.assertEqual(len(body["members"]), 1)
+        self.assertEqual(body["members"][0]["id"], user.id)


### PR DESCRIPTION
The previous method names of this test are not followed by naming
convention of unittest. So those tests didn't run by Django testing
framework. This commit fixed it.