### PR TITLE
Fixed pip installation failing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - run:
           name: Install additional dependencies
           command: |
-            sudo apt-get install -y libldap2-dev libsasl2-dev
+            sudo apt-get install -y libldap2-dev libsasl2-dev libxmlsec1-dev
       - run:
           name: Testing
           command: |
@@ -79,7 +79,7 @@ jobs:
           name: Install additional dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install -y libldap2-dev libsasl2-dev
+            sudo apt-get install -y libldap2-dev libsasl2-dev libxmlsec1-dev
       - run:
           name: flake8
           command: |
@@ -103,7 +103,7 @@ jobs:
           name: Install additional dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install -y libldap2-dev libsasl2-dev
+            sudo apt-get install -y libldap2-dev libsasl2-dev libxmlsec1-dev
       - run:
           name: mypy
           command: |

--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -108,6 +108,9 @@ class Common(Configuration):
     # https://docs.djangoproject.com/en/2.2/ref/settings/#secure-proxy-ssl-header
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+    # https://docs.djangoproject.com/en/3.2/ref/settings/#use-x-forwarded-port
+    USE_X_FORWARDED_PORT = True
+
     # https://docs.djangoproject.com/en/3.2/ref/settings/#session-cookie-secure
     SESSION_COOKIE_SECURE = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ skipsdist = TRUE
 passenv = AIRONE_BACKEND_DB CODECOV_*
 commands =
   rm -f db.sqlite3
+  pip install -r requirements.txt
   pip install -r requirements-dev.txt
   python manage.py makemigrations
   python manage.py migrate
@@ -26,6 +27,7 @@ whitelist_externals = rm
 passenv = AIRONE_BACKEND_DB CODECOV_*
 commands =
   rm -f db.sqlite3
+  pip install -r requirements.txt
   pip install -r requirements-dev.txt
   python manage.py makemigrations
   python manage.py migrate


### PR DESCRIPTION
Added library installation because python3-SAML installation fails.

When starting AirOne under a proxy such as nginx, the SSO response URL has a different port number and an error occurs.
The USE_X_FORWARDED_PORT option has been enabled and resolved.