### PR TITLE
Specify "platform" parameter at the docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2.0'
 services:
   mysql:
+    platform: linux/x86_64
     image: mysql:5.7.34
     container_name: mysql
     hostname: mysql


### PR DESCRIPTION
Some docker image might require to specify "platform" parameter
to run it on a cross-platform environment as below.
```
~/dev/airone$ docker-compose up -d
Creating network "airone_default" with the default driver
Creating volume "airone_mysql" with local driver
Pulling mysql (mysql:5.7.34)...
5.7.34: Pulling from library/mysql
ERROR: no matching manifest for linux/arm64/v8 in the manifest list entries
~/dev/airone$
```

This commit wrote it to each docker image configurations to fix its problem.