### PR TITLE
Enabled to run elasticsearch for dev when seccomp is not available

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     hostname: elasticsearch
     environment:
       transport.host: localhost
+      bootstrap.system_call_filter: "false"
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
In an environment that the seccomp is unavailable, Elasticsearch for dev which is run by docker-compose won't run correctly because it requires its feature by default as below.
```
elasticsearch    | java.lang.UnsupportedOperationException: seccomp unavailable: CONFIG_SECCOMP not compiled into kernel, CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER are needed
elasticsearch    |      at org.elasticsearch.bootstrap.SystemCallFilter.linuxImpl(SystemCallFilter.java:342) ~[elasticsearch-6.8.16.jar:6.8.16]
elasticsearch    |      at org.elasticsearch.bootstrap.SystemCallFilter.init(SystemCallFilter.java:617) ~[elasticsearch-6.8.16.jar:6.8.16]
elasticsearch    |      at org.elasticsearch.bootstrap.JNANatives.tryInstallSystemCallFilter(JNANatives.java:260) [elasticsearch-6.8.16.jar:6.8.16]
elasticsearch    |      at org.elasticsearch.bootstrap.Natives.tryInstallSystemCallFilter(Natives.java:113) [elasticsearch-6.8.16.jar:6.8.16]
elasticsearch    |      at org.elasticsearch.bootstrap.Bootstrap.initializeNatives(Bootstrap.java:108) [elasticsearch-6.8.16.jar:6.8.16]
elasticsearch    |      at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:170) [elasticsearch-6.8.16.jar:6.8.16]
elasticsearch    |      at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:333) [elasticsearch-6.8.16.jar:6.8.16]
elasticsearch    |      at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:159) [elasticsearch-6.8.16.jar:6.8.16]
elasticsearch    |      at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:150) [elasticsearch-6.8.16.jar:6.8.16]
elasticsearch    |      at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:86) [elasticsearch-6.8.16.jar:6.8.16]
elasticsearch    |      at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:124) [elasticsearch-cli-6.8.16.jar:6.8.16]
elasticsearch    |      at org.elasticsearch.cli.Command.main(Command.java:90) [elasticsearch-cli-6.8.16.jar:6.8.16]
```

This change configures Elasticsearch to ignore its check to be able to build development AirOne environment.
(c.f. https://www.elastic.co/guide/en/elasticsearch/reference/current/_system_call_filter_check.html)