### PR TITLE
Use flake8, black and isort with VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,16 @@
 {
-    "python.defaultInterpreterPath": ".venv/bin/python"
+  "python.linting.enabled": true,
+  "python.linting.pylintEnabled": false,
+  "python.linting.flake8Enabled": true,
+  "python.linting.flake8Args": ["--max-line-length=120"],
+  "editor.formatOnSave": true,
+  "python.formatting.provider": "black",
+  "python.formatting.blackArgs": ["--line-length", "120"],
+  "python.sortImports.args": ["--profile", "black"],
+  "[python]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": true
+    }
+  },
+  "python.defaultInterpreterPath": ".venv/bin/python"
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
+isort
 flake8
+black
 mypy
 types-six
 types-requests
@@ -6,4 +8,3 @@ types-PyYAML
 types-pytz
 types-mock
 requests-html==0.10.0
-black


### PR DESCRIPTION
Add some configs into `.vscode/settings.json` to use flake8, black and isort with VS Code.

And add python isort package to `requirements-dev.txt`.