### PR TITLE
Fix not to occur a warning on entity referral auto complete field

### DIFF
--- a/frontend/src/components/entity/entityForm/AttributeRow.tsx
+++ b/frontend/src/components/entity/entityForm/AttributeRow.tsx
@@ -128,6 +128,12 @@ export const AttributeRow: FC<Props> = ({
     setEntityInfo({ ...entityInfo, attrs: [...allAttrs] });
   };
 
+  const initialSelectedReferrals = useMemo(() => {
+    return referralEntities.filter((e) =>
+      currentAttr?.referral?.includes(e.id)
+    );
+  }, [referralEntities]);
+
   return (
     <TableRow
       className={
@@ -173,9 +179,7 @@ export const AttributeRow: FC<Props> = ({
                 <AutoCompletedField
                   options={referralEntities}
                   getOptionLabel={(option: Entity) => option.name}
-                  defaultValue={referralEntities.filter((e) =>
-                    currentAttr.referral.includes(e.id)
-                  )}
+                  defaultValue={initialSelectedReferrals}
                   handleChangeSelectedValue={(value: Entity[]) => {
                     handleChangeAttributeValue(
                       index,

--- a/frontend/src/pages/EditEntityPage.test.tsx
+++ b/frontend/src/pages/EditEntityPage.test.tsx
@@ -70,7 +70,7 @@ test("should match snapshot", async () => {
       require("../apiclient/AironeApiClientV2").aironeApiClientV2,
       "getEntities"
     )
-    .mockResolvedValue(Promise.resolve(entities));
+    .mockResolvedValue(Promise.resolve({ results: entities }));
   /* eslint-enable */
 
   // wait async calls and get rendered fragment


### PR DESCRIPTION
Currently the `defaultValue` is changed after `AutoCompletedField` component. It occurs a warning.