### PR TITLE
Show a shorten name if entity name is too long

### DIFF
--- a/frontend/src/components/common/AironeBreadcrumbs.tsx
+++ b/frontend/src/components/common/AironeBreadcrumbs.tsx
@@ -22,6 +22,12 @@ const useStyles = makeStyles<Theme>((theme) => ({
       height: "56px",
       padding: "0px 24px",
     },
+    "& li": {
+      maxWidth: "300px",
+      textOverflow: "ellipsis",
+      overflow: "hidden",
+      whiteSpace: "nowrap",
+    },
   },
 }));
 

--- a/frontend/src/components/entity/EntityList.tsx
+++ b/frontend/src/components/entity/EntityList.tsx
@@ -111,7 +111,17 @@ export const EntityList: FC<Props> = ({
                     component={Link}
                     to={entityEntriesPath(entity.id)}
                   >
-                    <Typography variant="h6">{entity.name}</Typography>
+                    <Typography
+                      variant="h6"
+                      sx={{
+                        width: "300px",
+                        textOverflow: "ellipsis",
+                        overflow: "hidden",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {entity.name}
+                    </Typography>
                   </CardActionArea>
                 }
                 action={

--- a/frontend/src/pages/EntryListPage.tsx
+++ b/frontend/src/pages/EntryListPage.tsx
@@ -55,7 +55,17 @@ export const EntryListPage: FC<Props> = ({ canCreateEntry = true }) => {
           <Box width="50px" />
           <Box flexGrow="1">
             {!entity.loading && (
-              <Typography variant="h2" align="center">
+              <Typography
+                variant="h2"
+                align="center"
+                sx={{
+                  margin: "auto",
+                  maxWidth: "md",
+                  textOverflow: "ellipsis",
+                  overflow: "hidden",
+                  whiteSpace: "nowrap",
+                }}
+              >
                 {entity.value.name}
               </Typography>
             )}

--- a/frontend/src/pages/__snapshots__/EntityPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntityPage.test.tsx.snap
@@ -173,7 +173,7 @@ Object {
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                           >
                             aaa
                           </h6>
@@ -241,7 +241,7 @@ Object {
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                           >
                             aaaaa
                           </h6>
@@ -309,7 +309,7 @@ Object {
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                           >
                             bbbbb
                           </h6>
@@ -592,7 +592,7 @@ Object {
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                         >
                           aaa
                         </h6>
@@ -660,7 +660,7 @@ Object {
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                         >
                           aaaaa
                         </h6>
@@ -728,7 +728,7 @@ Object {
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                         >
                           bbbbb
                         </h6>

--- a/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
@@ -83,7 +83,7 @@ Object {
               class="MuiBox-root css-i9gxme"
             >
               <h2
-                class="MuiTypography-root MuiTypography-h2 MuiTypography-alignCenter css-icizyq-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-h2 MuiTypography-alignCenter css-1gmnrtv-MuiTypography-root"
               >
                 aaa
               </h2>
@@ -533,7 +533,7 @@ Object {
             class="MuiBox-root css-i9gxme"
           >
             <h2
-              class="MuiTypography-root MuiTypography-h2 MuiTypography-alignCenter css-icizyq-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-alignCenter css-1gmnrtv-MuiTypography-root"
             >
               aaa
             </h2>


### PR DESCRIPTION
Specify `text-overflow: ellipsis`, not to show too long name.

<img width="938" alt="image" src="https://user-images.githubusercontent.com/191684/180601065-8172c22c-ed40-4267-b5db-a9ce7922af33.png">
