### PR TITLE
Redirect to restore-entry page if accessing to entry details page has been deleted

### DIFF
--- a/frontend/src/Routes.ts
+++ b/frontend/src/Routes.ts
@@ -29,8 +29,9 @@ export const importEntriesPath = (entityId: number | string) =>
   basePath + `entities/${entityId}/entries/import`;
 export const entityEntriesPath = (entityId: number | string) =>
   basePath + `entities/${entityId}/entries`;
-export const restoreEntryPath = (entityId: number | string) =>
-  basePath + `entities/${entityId}/restore`;
+export const restoreEntryPath = (entityId: number | string, keyword?: string) =>
+  basePath +
+  `entities/${entityId}/restore${keyword != null ? "?keyword=" + keyword : ""}`;
 export const showEntryHistoryPath = (entryId: number | string) =>
   basePath + `entries/${entryId}/history`;
 

--- a/frontend/src/components/entry/RestorableEntryList.tsx
+++ b/frontend/src/components/entry/RestorableEntryList.tsx
@@ -40,6 +40,7 @@ import { FailedToGetEntity } from "utils/Exceptions";
 
 interface Props {
   entityId: number;
+  initialKeyword?: string | null;
 }
 
 const useStyles = makeStyles<Theme>((theme) => ({
@@ -66,12 +67,15 @@ const StyledTableRow = styled(TableRow)(() => ({
   },
 }));
 
-export const RestorableEntryList: FC<Props> = ({ entityId }) => {
+export const RestorableEntryList: FC<Props> = ({
+  entityId,
+  initialKeyword,
+}) => {
   const classes = useStyles();
 
   const history = useHistory();
 
-  const [keyword, setKeyword] = useState("");
+  const [keyword, setKeyword] = useState(initialKeyword ?? "");
   const [page, setPage] = React.useState(1);
   const [openModal, setOpenModal] = useState(false);
   const [selectedEntryId, setSelectedEntryId] = useState<number>();

--- a/frontend/src/pages/EntryDetailsPage.test.tsx
+++ b/frontend/src/pages/EntryDetailsPage.test.tsx
@@ -20,6 +20,7 @@ test("should match snapshot", async () => {
   const entry = {
     id: 1,
     name: "aaa",
+    isActive: true,
     schema: {
       id: 2,
       name: "bbb",

--- a/frontend/src/pages/EntryDetailsPage.tsx
+++ b/frontend/src/pages/EntryDetailsPage.tsx
@@ -10,13 +10,18 @@ import {
   Typography,
 } from "@mui/material";
 import React, { FC, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import { Element, scroller } from "react-scroll";
 import { useAsync } from "react-use";
 
 import { useTypedParams } from "../hooks/useTypedParams";
 
-import { entitiesPath, entityEntriesPath, topPath } from "Routes";
+import {
+  entitiesPath,
+  entityEntriesPath,
+  restoreEntryPath,
+  topPath,
+} from "Routes";
 import { aironeApiClientV2 } from "apiclient/AironeApiClientV2";
 import { AironeBreadcrumbs } from "components/common/AironeBreadcrumbs";
 import { Loading } from "components/common/Loading";
@@ -28,6 +33,7 @@ import { FailedToGetEntry } from "utils/Exceptions";
 export const EntryDetailsPage: FC = () => {
   const { entityId, entryId } =
     useTypedParams<{ entityId: number; entryId: number }>();
+  const history = useHistory();
 
   const [entryAnchorEl, setEntryAnchorEl] =
     useState<HTMLButtonElement | null>();
@@ -40,6 +46,11 @@ export const EntryDetailsPage: FC = () => {
     throw new FailedToGetEntry(
       "Failed to get Entry from AirOne APIv2 endpoint"
     );
+  }
+
+  // If it'd been deleted, show restore-entry page instead
+  if (!entry.loading && !entry.value.isActive) {
+    history.replace(restoreEntryPath(entry.value.schema.id, entry.value.name));
   }
 
   return (

--- a/frontend/src/pages/RestoreEntryPage.tsx
+++ b/frontend/src/pages/RestoreEntryPage.tsx
@@ -16,6 +16,9 @@ import { Loading } from "components/common/Loading";
 export const RestoreEntryPage: FC = () => {
   const { entityId } = useTypedParams<{ entityId: number }>();
 
+  const params = new URLSearchParams(location.search);
+  const keyword = params.get("keyword");
+
   const [entityAnchorEl, setEntityAnchorEl] =
     useState<HTMLButtonElement | null>();
 
@@ -75,7 +78,7 @@ export const RestoreEntryPage: FC = () => {
           </Box>
         </Box>
 
-        <RestorableEntryList entityId={entityId} />
+        <RestorableEntryList entityId={entityId} initialKeyword={keyword} />
       </Container>
     </Box>
   );


### PR DESCRIPTION
Like the current UI. To avoid to operate to a deleted entry accidentally.