### PR TITLE
Show better entry name

### DIFF
--- a/frontend/src/components/common/AironeBreadcrumbs.tsx
+++ b/frontend/src/components/common/AironeBreadcrumbs.tsx
@@ -28,6 +28,10 @@ const useStyles = makeStyles<Theme>((theme) => ({
       overflow: "hidden",
       whiteSpace: "nowrap",
     },
+    "& li > p": {
+      textOverflow: "ellipsis",
+      overflow: "hidden",
+    },
   },
 }));
 

--- a/frontend/src/components/entry/EntryList.tsx
+++ b/frontend/src/components/entry/EntryList.tsx
@@ -104,7 +104,17 @@ export const EntryList: FC<Props> = ({ entityId, canCreateEntry = true }) => {
                         component={Link}
                         to={entryDetailsPath(entityId, entry.id)}
                       >
-                        <Typography variant="h6">{entry.name}</Typography>
+                        <Typography
+                          variant="h6"
+                          sx={{
+                            width: "300px",
+                            textOverflow: "ellipsis",
+                            overflow: "hidden",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {entry.name}
+                        </Typography>
                       </CardActionArea>
                     }
                     action={

--- a/frontend/src/components/entry/RestorableEntryList.tsx
+++ b/frontend/src/components/entry/RestorableEntryList.tsx
@@ -151,7 +151,17 @@ export const RestorableEntryList: FC<Props> = ({ entityId }) => {
                           setOpenModal(true);
                         }}
                       >
-                        <Typography variant="h6">{entry.name}</Typography>
+                        <Typography
+                          variant="h6"
+                          sx={{
+                            width: "300px",
+                            textOverflow: "ellipsis",
+                            overflow: "hidden",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {entry.name.replace(/_deleted_.*/, "")}
+                        </Typography>
                       </CardActionArea>
                     }
                     action={

--- a/frontend/src/pages/EntryDetailsPage.tsx
+++ b/frontend/src/pages/EntryDetailsPage.tsx
@@ -7,8 +7,10 @@ import {
   Grid,
   IconButton,
   Stack,
+  Theme,
   Typography,
 } from "@mui/material";
+import { makeStyles } from "@mui/styles";
 import React, { FC, useState } from "react";
 import { Link } from "react-router-dom";
 import { Element, scroller } from "react-scroll";
@@ -25,7 +27,18 @@ import { EntryControlMenu } from "components/entry/EntryControlMenu";
 import { EntryReferral } from "components/entry/EntryReferral";
 import { FailedToGetEntry } from "utils/Exceptions";
 
+const useStyles = makeStyles<Theme>((theme) => ({
+  title: {
+    height: "72px",
+    maxWidth: "700px",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+  },
+}));
+
 export const EntryDetailsPage: FC = () => {
+  const classes = useStyles();
+
   const { entityId, entryId } =
     useTypedParams<{ entityId: number; entryId: number }>();
 
@@ -67,9 +80,14 @@ export const EntryDetailsPage: FC = () => {
       <Container maxWidth="lg" sx={{ pt: "112px" }}>
         <Box display="flex">
           <Box width="50px" />
-          <Box flexGrow="1">
+          <Box
+            flexGrow="1"
+            display="flex"
+            flexDirection="column"
+            alignItems="center"
+          >
             {!entry.loading && (
-              <Typography variant="h2" align="center">
+              <Typography variant="h2" align="center" className={classes.title}>
                 {entry.value.name}
               </Typography>
             )}

--- a/frontend/src/pages/__snapshots__/EntryDetailsPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryDetailsPage.test.tsx.snap
@@ -9,13 +9,13 @@ Object {
         class="MuiBox-root css-1ylu0bo"
       >
         <div
-          class="makeStyles-frame-1 MuiBox-root css-0"
+          class="makeStyles-frame-2 MuiBox-root css-0"
         >
           <div
-            class="makeStyles-fixed-2 MuiBox-root css-0"
+            class="makeStyles-fixed-3 MuiBox-root css-0"
           >
             <div
-              class="makeStyles-breadcrumb-3 MuiBox-root css-0"
+              class="makeStyles-breadcrumb-4 MuiBox-root css-0"
             >
               <nav
                 aria-label="breadcrumb"
@@ -96,10 +96,10 @@ Object {
               class="MuiBox-root css-kgitkj"
             />
             <div
-              class="MuiBox-root css-i9gxme"
+              class="MuiBox-root css-1xanpi5"
             >
               <h2
-                class="MuiTypography-root MuiTypography-h2 MuiTypography-alignCenter css-icizyq-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-h2 MuiTypography-alignCenter makeStyles-title-1 css-icizyq-MuiTypography-root"
               >
                 aaa
               </h2>
@@ -394,13 +394,13 @@ Object {
       class="MuiBox-root css-1ylu0bo"
     >
       <div
-        class="makeStyles-frame-1 MuiBox-root css-0"
+        class="makeStyles-frame-2 MuiBox-root css-0"
       >
         <div
-          class="makeStyles-fixed-2 MuiBox-root css-0"
+          class="makeStyles-fixed-3 MuiBox-root css-0"
         >
           <div
-            class="makeStyles-breadcrumb-3 MuiBox-root css-0"
+            class="makeStyles-breadcrumb-4 MuiBox-root css-0"
           >
             <nav
               aria-label="breadcrumb"
@@ -481,10 +481,10 @@ Object {
             class="MuiBox-root css-kgitkj"
           />
           <div
-            class="MuiBox-root css-i9gxme"
+            class="MuiBox-root css-1xanpi5"
           >
             <h2
-              class="MuiTypography-root MuiTypography-h2 MuiTypography-alignCenter css-icizyq-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-alignCenter makeStyles-title-1 css-icizyq-MuiTypography-root"
             >
               aaa
             </h2>

--- a/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
@@ -225,7 +225,7 @@ Object {
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                           >
                             aaa
                           </h6>
@@ -286,7 +286,7 @@ Object {
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                           >
                             aaaaa
                           </h6>
@@ -347,7 +347,7 @@ Object {
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                           >
                             bbbbb
                           </h6>
@@ -675,7 +675,7 @@ Object {
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                         >
                           aaa
                         </h6>
@@ -736,7 +736,7 @@ Object {
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                         >
                           aaaaa
                         </h6>
@@ -797,7 +797,7 @@ Object {
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                         >
                           bbbbb
                         </h6>

--- a/frontend/src/pages/__snapshots__/RestoreEntryPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RestoreEntryPage.test.tsx.snap
@@ -221,7 +221,7 @@ Object {
                           type="button"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                           >
                             aaa
                           </h6>
@@ -286,7 +286,7 @@ Object {
                           type="button"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                           >
                             aaaaa
                           </h6>
@@ -351,7 +351,7 @@ Object {
                           type="button"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                           >
                             bbbbb
                           </h6>
@@ -679,7 +679,7 @@ Object {
                         type="button"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                         >
                           aaa
                         </h6>
@@ -744,7 +744,7 @@ Object {
                         type="button"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                         >
                           aaaaa
                         </h6>
@@ -809,7 +809,7 @@ Object {
                         type="button"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
                         >
                           bbbbb
                         </h6>


### PR DESCRIPTION
Not to break entry-related pages if an entry has too long name,

- Shorten entry name
- Eliminate `_deleted_*` from a deleted entry

<img width="907" alt="image" src="https://user-images.githubusercontent.com/191684/181925786-e970a5c3-9594-42d9-814f-0b77f2da8af4.png">
<img width="901" alt="image" src="https://user-images.githubusercontent.com/191684/181925801-67f4e509-fd96-44dc-a75b-b73bd85cf973.png">
