### PR TITLE
Enable restoring entry modal scrollable

### DIFF
--- a/frontend/src/components/entry/RestorableEntryList.tsx
+++ b/frontend/src/components/entry/RestorableEntryList.tsx
@@ -48,6 +48,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
+    margin: "5% 0",
   },
   paper: {
     backgroundColor: theme.palette.background.paper,
@@ -55,6 +56,8 @@ const useStyles = makeStyles<Theme>((theme) => ({
     boxShadow: theme.shadows[5],
     padding: theme.spacing(2, 4, 2),
     width: "50%",
+    maxHeight: "100%",
+    overflowY: "scroll",
   },
 }));
 


### PR DESCRIPTION
If an entry has many attributes, perhaps its impossible to show all the items. This PR makes the modal to show it with scrolling.

<img width="963" alt="image" src="https://user-images.githubusercontent.com/191684/183240525-92829058-0da5-4357-b11e-da8f93415518.png">
