### PR TITLE
Fixed to parse celery exception error log

### DIFF
--- a/airone/celery.py
+++ b/airone/celery.py
@@ -55,4 +55,9 @@ full traceback:
 
     # Logger for DEBUG because email is not sent in dev environment
     Logger.error(message)
+
+    # Logger for Alert because long texts usually cannot be parsed by log server
+    Logger.error("An exception error has occurred")
+
+    # Send an email so that admins can receive errors
     mail_admins(subject, message)

--- a/airone/lib/log.py
+++ b/airone/lib/log.py
@@ -54,6 +54,8 @@ full traceback:
 
         # Print for DEBUG because email is not sent in dev environment
         print(message)
+
+        # Send an email so that admins can receive errors
         mail_admins(subject, message)
         if not settings.DEBUG:
             return HttpResponseServerError("Internal Server Error")


### PR DESCRIPTION
Normally, application logs are sent to a log server and aggregated.
At that time, if there is a long message such as an exception error, 
there is a problem that the format is different from other logs and cannot be parsed.
Added a simple log that can be parsed when an exception occurs in celery.

e.g.
`[ERROR] asctime:2022-08-12 10:11:45,867 module:celery   message:An exception error has occurred process:10756   thread:140528500768896`
