### PR TITLE
Changed to update job status to error when celery exception error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 ### Changed
+* Changed to update job status to error when celery exception error
+  Contributed by @hinashi
 
 * (New-UI) Show a shorten name if entity name is too long
   at Entity list view.

--- a/airone/celery.py
+++ b/airone/celery.py
@@ -56,3 +56,14 @@ full traceback:
     # Logger for DEBUG because email is not sent in dev environment
     Logger.error(message)
     mail_admins(subject, message)
+
+
+@task_failure.connect()
+def celery_task_failure_update_job_status(**kwargs):
+    """This event handler is update job status when an exception error in celery."""
+    from job.models import Job
+
+    job_id = kwargs["args"][0]
+    job = Job.objects.get(id=job_id)
+    job.status = Job.STATUS["ERROR"]
+    job.save(update_fields=["status"])

--- a/airone/tests/test_celery.py
+++ b/airone/tests/test_celery.py
@@ -1,10 +1,12 @@
+from billiard.einfo import ExceptionInfo
 from django.core import mail
-from django.test import TestCase
 
-from airone.celery import celery_task_failure_email
+from airone.celery import celery_task_failure_email, celery_task_failure_update_job_status
+from airone.lib.test import AironeViewTest
+from job.models import Job
 
 
-class CeleryTest(TestCase):
+class CeleryTest(AironeViewTest):
     def test_celery_task_failure_email(self):
         admins = [("admin", "airone@example.com")]
         task_name = "test_task"
@@ -28,3 +30,17 @@ class CeleryTest(TestCase):
             self.assertEqual(len(mail.outbox), 1)
             self.assertEqual(mail.outbox[0].to, [a[1] for a in admins])
             self.assertEqual(mail.outbox[0].subject, "ERROR Celery Task %s" % task_name)
+
+    def test_celery_task_failure_update_job_status(self):
+        user = self.guest_login()
+        job: Job = Job.objects.create(user=user, status=Job.STATUS["PROCESSING"])
+        celery_task_failure_update_job_status(
+            task_id="test_task_id",
+            exception=Exception("Test"),
+            args=[job.id],
+            kwargs={},
+            traceback=ExceptionInfo.traceback,
+            einfo=ExceptionInfo,
+        )
+        job.refresh_from_db()
+        self.assertEqual(job.status, Job.STATUS["ERROR"])


### PR DESCRIPTION
Jobs have a mechanism of dependent jobs.
When an exception error occurred in celery, there was a problem that dependent jobs were stuck.
Resolved by changing job status to update to error.