### PR TITLE
Switch to entry list page on canceling to create an entry

### DIFF
--- a/frontend/src/pages/EditEntryPage.tsx
+++ b/frontend/src/pages/EditEntryPage.tsx
@@ -253,7 +253,11 @@ export const EditEntryPage: FC = () => {
   };
 
   const handleCancel = () => {
-    history.replace(entryDetailsPath(entityId, entryId));
+    if (entryId != null) {
+      history.replace(entryDetailsPath(entityId, entryId));
+    } else {
+      history.replace(entityEntriesPath(entityId));
+    }
   };
 
   if (entity.loading || entry.loading) {


### PR DESCRIPTION
SSIA, not to fail to show entry detail page. The entry detail page is unavailable for uncreated entry :)