### PR TITLE
Update processing to prevent creating unnecessary NOTIFY_UPDATE_ENTRY Job at EntryAPI of api.v1

### DIFF
--- a/api_v1/tests/test_api.py
+++ b/api_v1/tests/test_api.py
@@ -1043,7 +1043,11 @@ class APITest(AironeViewTest):
 
         # check creating NOTIFY_UPDATE_ENTRY is restricted because entry is not actually changed
         self.assertEqual(updated_entry.id, entry.id)
-        self.assertFalse(Job.objects.filter(target=entry, operation=JobOperation.NOTIFY_UPDATE_ENTRY.value).exists())
+        self.assertFalse(
+            Job.objects.filter(
+                target=entry, operation=JobOperation.NOTIFY_UPDATE_ENTRY.value
+            ).exists()
+        )
 
     @mock.patch("entry.tasks.notify_entry_update", mock.Mock(return_value=mock.Mock()))
     @mock.patch(

--- a/api_v1/views.py
+++ b/api_v1/views.py
@@ -42,6 +42,22 @@ class EntryAPI(APIView):
             # processing
         }
 
+        # This variable indicates whether NOTIFY UPDATE ENTRY Job will be created.
+        # This is necessary to create minimum necessary NOTIFY_UPDATE_ENTRY Job.
+        will_notify_update_entry = False
+
+        # Common processing to update Entry's name and set will_notify_update_entry variable
+        def _update_entry_name(entry):
+            # Set Entry status that indicates target Entry is under editing processing
+            # to prevent to updating this entry from others.
+            entry.set_status(Entry.STATUS_EDITING)
+
+            # Set will_notify_update_entry when name parameter is different with target Entry's name
+            if entry.name != sel.validated_data["name"]:
+                entry.name = sel.validated_data["name"]
+                entry.save(update_fields=["name"])
+                will_notify_update_entry = True
+
         entry_condition = {
             "schema": sel.validated_data["entity"],
             "name": sel.validated_data["name"],
@@ -58,19 +74,11 @@ class EntryAPI(APIView):
                 )
 
             entry = Entry.objects.get(id=sel.validated_data["id"])
-            entry.name = sel.validated_data["name"]
-            entry.save(update_fields=["name"])
-            entry.set_status(Entry.STATUS_EDITING)
-
-            # create job to notify entry event to the registered WebHook
-            job_notify = Job.new_notify_update_entry(request.user, entry)
+            _update_entry_name(entry)
 
         elif Entry.objects.filter(**entry_condition).exists():
             entry = Entry.objects.get(**entry_condition)
-            entry.set_status(Entry.STATUS_EDITING)
-
-            # create job to notify entry event to the registered WebHook
-            job_notify = Job.new_notify_update_entry(request.user, entry)
+            _update_entry_name(entry)
 
         else:
             entry = Entry.objects.create(
@@ -92,9 +100,15 @@ class EntryAPI(APIView):
                 value
             ):
                 attr.add_value(request.user, value)
+                will_notify_update_entry = True
 
                 # This enables to let user know what attributes are changed in this request
                 resp_data["updated_attrs"][name] = raw_request_data["attrs"][name]
+
+        if will_notify_update_entry:
+            # Create job to notify event, which indicates target entry is updated,
+            # to the registered WebHook.
+            job_notify = Job.new_notify_update_entry(request.user, entry)
 
         # register target Entry to the Elasticsearch
         entry.register_es()

--- a/api_v1/views.py
+++ b/api_v1/views.py
@@ -53,10 +53,13 @@ class EntryAPI(APIView):
             entry.set_status(Entry.STATUS_EDITING)
 
             # Set will_notify_update_entry when name parameter is different with target Entry's name
+            _will_notify_update_entry = False
             if entry.name != sel.validated_data["name"]:
                 entry.name = sel.validated_data["name"]
                 entry.save(update_fields=["name"])
-                will_notify_update_entry = True
+                _will_notify_update_entry = True
+
+            return _will_notify_update_entry
 
         entry_condition = {
             "schema": sel.validated_data["entity"],
@@ -74,11 +77,11 @@ class EntryAPI(APIView):
                 )
 
             entry = Entry.objects.get(id=sel.validated_data["id"])
-            _update_entry_name(entry)
+            will_notify_update_entry = _update_entry_name(entry)
 
         elif Entry.objects.filter(**entry_condition).exists():
             entry = Entry.objects.get(**entry_condition)
-            _update_entry_name(entry)
+            will_notify_update_entry = _update_entry_name(entry)
 
         else:
             entry = Entry.objects.create(


### PR DESCRIPTION
In the previous implementation, EntryAPI.post create NOTIFY_UPDATE_ENTRY Job whenever it is called.
This commit refactored it that only create its Job when target Entry attribute values or its name are actually updated.