### PR TITLE
Fixed logic to disable create button on entry list page

### DIFF
--- a/frontend/src/components/entry/EntryList.tsx
+++ b/frontend/src/components/entry/EntryList.tsx
@@ -73,6 +73,7 @@ export const EntryList: FC<Props> = ({ entityId, canCreateEntry = true }) => {
         <Button
           color="secondary"
           variant="contained"
+          disabled={!canCreateEntry}
           component={Link}
           to={newEntryPath(entityId)}
           sx={{ borderRadius: "24px" }}


### PR DESCRIPTION
c.f. https://github.com/dmm-com/airone/pull/571
A feature that disables create button on some entities.

- enabled
![image](https://user-images.githubusercontent.com/5561786/185524404-a5be365c-916c-4f7d-9b7a-024808b09bcd.png)
- disabled
![image](https://user-images.githubusercontent.com/5561786/185524380-19c9769f-b617-4a71-bc70-c33fb6f24784.png)
