### PR TITLE
Added exclude specified attributes on entry edit page

### DIFF
--- a/frontend/src/pages/EditEntryPage.tsx
+++ b/frontend/src/pages/EditEntryPage.tsx
@@ -26,7 +26,11 @@ import { AironeBreadcrumbs } from "components/common/AironeBreadcrumbs";
 import { EntryControlMenu } from "components/entry/EntryControlMenu";
 import { EntryForm } from "components/entry/EntryForm";
 
-export const EditEntryPage: FC = () => {
+interface Props {
+  excludeAttrs: string[];
+}
+
+export const EditEntryPage: FC<Props> = ({ excludeAttrs = [] }) => {
   const { entityId, entryId } =
     useTypedParams<{ entityId: number; entryId: number }>();
 
@@ -58,33 +62,35 @@ export const EditEntryPage: FC = () => {
       setEntryInfo({
         name: entry.value.name,
         attrs: Object.fromEntries(
-          entry.value.attrs.map((attr): [string, EditableEntryAttrs] => {
-            function getAttrValue(attr) {
-              switch (attr.type) {
-                case djangoContext.attrTypeValue.array_string:
-                  return attr.value?.asArrayString?.length > 0
-                    ? attr.value
-                    : { asArrayString: [""] };
-                case djangoContext.attrTypeValue.array_named_object:
-                  return attr.value?.asArrayNamedObject?.length > 0
-                    ? attr.value
-                    : { asArrayNamedObject: [{ "": null }] };
-                default:
-                  return attr.value;
+          entry.value.attrs
+            .filter((attr) => !excludeAttrs.includes(attr.schema.name))
+            .map((attr): [string, EditableEntryAttrs] => {
+              function getAttrValue(attr) {
+                switch (attr.type) {
+                  case djangoContext.attrTypeValue.array_string:
+                    return attr.value?.asArrayString?.length > 0
+                      ? attr.value
+                      : { asArrayString: [""] };
+                  case djangoContext.attrTypeValue.array_named_object:
+                    return attr.value?.asArrayNamedObject?.length > 0
+                      ? attr.value
+                      : { asArrayNamedObject: [{ "": null }] };
+                  default:
+                    return attr.value;
+                }
               }
-            }
 
-            return [
-              attr.schema.name,
-              {
-                id: attr.id,
-                type: attr.type,
-                isMandatory: attr.isMandatory,
-                schema: attr.schema,
-                value: getAttrValue(attr),
-              },
-            ];
-          })
+              return [
+                attr.schema.name,
+                {
+                  id: attr.id,
+                  type: attr.type,
+                  isMandatory: attr.isMandatory,
+                  schema: attr.schema,
+                  value: getAttrValue(attr),
+                },
+              ];
+            })
         ),
       });
     } else if (


### PR DESCRIPTION
For some entities, you may not want users to be able to update attributes.
Added a function to exclude specific attributes from being edited.