### PR TITLE
Update selected referrals on changing order of attributes

### DIFF
--- a/frontend/src/components/entity/entityForm/AttributeRow.tsx
+++ b/frontend/src/components/entity/entityForm/AttributeRow.tsx
@@ -133,7 +133,7 @@ export const AttributeRow: FC<Props> = ({
     return referralEntities.filter((e) =>
       currentAttr?.referral?.includes(e.id)
     );
-  }, [referralEntities]);
+  }, [referralEntities, currentAttr?.referral]);
 
   return (
     <TableRow


### PR DESCRIPTION
before the selected referrals are not updated appropriately when changing order of attributes, so the referrals look like being  broken:
<img width="850" alt="image" src="https://user-images.githubusercontent.com/191684/185733316-810e1068-f00c-491a-8804-2345261fd972.png">
