### PR TITLE
Show error details simply if entry modification failed

### DIFF
--- a/entity/tests/test_api_v2.py
+++ b/entity/tests/test_api_v2.py
@@ -2243,7 +2243,7 @@ class ViewTest(AironeViewTest):
             "application/json",
         )
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.json(), {"non_field_errors": ["specified name(hoge) already exists"]})
+        self.assertEqual(resp.json(), {"name": ["specified name(hoge) already exists"]})
 
         entry.delete()
         resp = self.client.post(

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -604,7 +604,7 @@ class ViewTest(AironeViewTest):
             "/entry/api/v2/%s/" % entry.id, json.dumps({"name": "hoge"}), "application/json"
         )
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.json(), {"non_field_errors": ["specified name(hoge) already exists"]})
+        self.assertEqual(resp.json(), {"name": ["specified name(hoge) already exists"]})
 
         hoge_entry.delete()
         resp = self.client.put(

--- a/frontend/src/pages/EditEntryPage.tsx
+++ b/frontend/src/pages/EditEntryPage.tsx
@@ -222,33 +222,51 @@ export const EditEntryPage: FC = () => {
     );
 
     if (entryId == undefined) {
-      await aironeApiClientV2
-        .createEntry(entityId, entryInfo.name, updatedAttr)
-        .then((resp) => {
-          enqueueSnackbar("エントリの作成が完了しました", {
-            variant: "success",
-          });
-          history.push(entityEntriesPath(entityId));
-        })
-        .catch((e) => {
-          enqueueSnackbar("エントリの作成が失敗しました", {
-            variant: "error",
-          });
+      try {
+        await aironeApiClientV2.createEntry(
+          entityId,
+          entryInfo.name,
+          updatedAttr
+        );
+        enqueueSnackbar("エントリの作成が完了しました", {
+          variant: "success",
         });
+        history.push(entityEntriesPath(entityId));
+      } catch (e) {
+        if (e instanceof Response) {
+          if (!e.ok) {
+            const text = await e.text();
+            enqueueSnackbar(`エントリの作成が失敗しました。詳細: ${text}`, {
+              variant: "error",
+            });
+          }
+        } else {
+          throw e;
+        }
+      }
     } else {
-      await aironeApiClientV2
-        .updateEntry(entryId, entryInfo.name, updatedAttr)
-        .then((resp) => {
-          enqueueSnackbar("エントリの更新が完了しました", {
-            variant: "success",
-          });
-          history.push(entryDetailsPath(entityId, entryId));
-        })
-        .catch((e) => {
-          enqueueSnackbar("エントリの更新が失敗しました", {
-            variant: "error",
-          });
+      try {
+        await aironeApiClientV2.updateEntry(
+          entryId,
+          entryInfo.name,
+          updatedAttr
+        );
+        enqueueSnackbar("エントリの更新が完了しました", {
+          variant: "success",
         });
+        history.push(entryDetailsPath(entityId, entryId));
+      } catch (e) {
+        if (e instanceof Response) {
+          if (!e.ok) {
+            const text = await e.text();
+            enqueueSnackbar(`エントリの更新が失敗しました。詳細: ${text}`, {
+              variant: "error",
+            });
+          }
+        } else {
+          throw e;
+        }
+      }
     }
   };
 


### PR DESCRIPTION
Show error messages responded from API on the snackbar if entry creation/update failed.

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/191684/185737237-485bf425-1909-44e3-a5df-3410463bdc36.png">

IMO, we need to improve it more. The error message from API is not so human readable.