### PR TITLE
Fixed an error in getting data_value in advanced search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   Contributed by @hinashi
 
 ### Fixed
+* Fixed an error in getting data_value in advanced search.
+  Contributed by @hinashi
 
 ## v3.16.0
 

--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -851,7 +851,7 @@ def make_search_results(
 
                 if attrinfo["value"]:
                     ret_attrinfo["value"] = attrinfo["value"]
-                elif "date_value" in attrinfo and attrinfo["date_value"]:
+                elif attrinfo["date_value"]:
                     ret_attrinfo["value"] = attrinfo["date_value"].split("T")[0]
 
             elif attrinfo["type"] == AttrTypeValue["boolean"]:
@@ -885,7 +885,7 @@ def make_search_results(
 
                 # If there is no value, it will be skipped.
                 if attrinfo["key"] == attrinfo["value"] == attrinfo["referral_id"] == "":
-                    if "date_value" not in attrinfo:
+                    if not attrinfo["date_value"]:
                         continue
 
                 if attrinfo["type"] & AttrTypeValue["named"]:
@@ -899,7 +899,7 @@ def make_search_results(
                     )
 
                 elif attrinfo["type"] & AttrTypeValue["string"]:
-                    if "date_value" in attrinfo:
+                    if attrinfo["date_value"]:
                         ret_attrinfo["value"].append(attrinfo["date_value"].split("T")[0])
                     else:
                         ret_attrinfo["value"].append(attrinfo["value"])

--- a/entry/models.py
+++ b/entry/models.py
@@ -1543,6 +1543,7 @@ class Entry(ACLBase):
                 "type": entity_attr.type,
                 "key": "",
                 "value": "",
+                "date_value": None,
                 "referral_id": "",
                 "is_readble": True
                 if (not attr or attr.is_public or attr.default_permission >= ACLType.Readable.id)

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -3999,6 +3999,43 @@ class ModelTest(AironeTestCase):
                     )
 
     def test_get_es_document_without_attribute_value(self):
+        entity = self.create_entity_with_all_type_attributes(self._user)
+        entry = Entry.objects.create(name="entry", schema=entity, created_user=self._user)
+
+        entry.register_es()
+        result = Entry.search_entries(
+            self._user, [entity.id], entry_name="entry", is_output_all=True
+        )
+        self.assertEqual(
+            result["ret_values"][0],
+            {
+                "entity": {"id": entity.id, "name": "entity"},
+                "entry": {"id": entry.id, "name": "entry"},
+                "is_readble": True,
+                "attrs": {
+                    "bool": {"is_readble": True, "type": AttrTypeValue["boolean"], "value": ""},
+                    "date": {
+                        "is_readble": True,
+                        "type": AttrTypeValue["date"],
+                        "value": None,
+                    },
+                    "group": {
+                        "is_readble": True,
+                        "type": AttrTypeValue["group"],
+                        "value": {"id": "", "name": ""},
+                    },
+                    "name": {"is_readble": True, "type": AttrTypeValue["named_object"]},
+                    "obj": {
+                        "is_readble": True,
+                        "type": AttrTypeValue["object"],
+                        "value": {"id": "", "name": ""},
+                    },
+                    "str": {"is_readble": True, "type": AttrTypeValue["string"]},
+                    "text": {"is_readble": True, "type": AttrTypeValue["text"]},
+                },
+            },
+        )
+
         # If the AttributeValue does not exist, permission returns the default
         self._entity.attrs.add(self._attr.schema)
         self._entry.attrs.add(self._attr)
@@ -4012,6 +4049,7 @@ class ModelTest(AironeTestCase):
                     "type": self._attr.schema.type,
                     "key": "",
                     "value": "",
+                    "date_value": None,
                     "referral_id": "",
                     "is_readble": True,
                 }
@@ -4047,6 +4085,7 @@ class ModelTest(AironeTestCase):
                     "type": ref_attr.type,
                     "key": "",
                     "value": self._entry.name,
+                    "date_value": None,
                     "referral_id": self._entry.id,
                     "is_readble": True,
                 }
@@ -4067,6 +4106,7 @@ class ModelTest(AironeTestCase):
                     "type": ref_attr.type,
                     "key": "",
                     "value": "",  # expected not to have information about deleted entry
+                    "date_value": None,
                     "referral_id": "",  # expected not to have information about deleted entry
                     "is_readble": True,
                 }


### PR DESCRIPTION
In advanced search, there are cases where the display of date type results in an error.
This is when AttributeValue does not exist in the date type Attribute.