### PR TITLE
Added exclude entity parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## In development
 
 ### Added
-* Added exclude entity parama in search_entries_for_simple.
+* Added exclude entity parameter in search_entries_for_simple.
   Contributed by @hinashi
-* Added exclude entity parama in get_referred_objects.
+* Added exclude entity parameter in get_referred_objects.
   Contributed by @hinashi
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## In development
 
 ### Added
+* Added exclude entity parama in search_entries_for_simple.
+  Contributed by @hinashi
+* Added exclude entity parama in get_referred_objects.
+  Contributed by @hinashi
 
 ### Changed
 * Changed to allow parallel execution some job.

--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -223,7 +223,9 @@ def make_query(
     return query
 
 
-def make_query_for_simple(hint_string: str, hint_entity_name: str, offset: int) -> Dict[str, str]:
+def make_query_for_simple(
+    hint_string: str, hint_entity_name: str, exclude_entity_names: List[str], offset: int
+) -> Dict[str, str]:
     """Create a search query for Elasticsearch.
 
     Do the following:
@@ -260,6 +262,17 @@ def make_query_for_simple(hint_string: str, hint_entity_name: str, offset: int) 
                 }
             }
         )
+
+    if exclude_entity_names:
+        query["query"]["bool"]["must_not"] = [
+            {
+                "nested": {
+                    "path": "entity",
+                    "query": {"term": {"entity.name": exclude_entity_name}},
+                }
+            }
+            for exclude_entity_name in exclude_entity_names
+        ]
 
     return query
 

--- a/airone/tests/test_elasticsearch.py
+++ b/airone/tests/test_elasticsearch.py
@@ -201,7 +201,7 @@ class ElasticSearchTest(TestCase):
         )
 
     def test_make_query_for_simple(self):
-        query = elasticsearch.make_query_for_simple("hoge|fuga&1", None, 0)
+        query = elasticsearch.make_query_for_simple("hoge|fuga&1", None, [], 0)
         self.assertEqual(
             query,
             {
@@ -296,14 +296,21 @@ class ElasticSearchTest(TestCase):
         )
 
         # set hint_entity_name
-        query = elasticsearch.make_query_for_simple("hoge", "fuga", 0)
+        query = elasticsearch.make_query_for_simple("hoge", "fuga", [], 0)
         self.assertEqual(
             query["query"]["bool"]["must"][1],
             {"nested": {"path": "entity", "query": {"term": {"entity.name": "fuga"}}}},
         )
 
+        # set exclude_entity_names
+        query = elasticsearch.make_query_for_simple("hoge", None, ["fuga"], 0)
+        self.assertEqual(
+            query["query"]["bool"]["must_not"][0],
+            {"nested": {"path": "entity", "query": {"term": {"entity.name": "fuga"}}}},
+        )
+
         # set offset
-        query = elasticsearch.make_query_for_simple("hoge", "fuga", 100)
+        query = elasticsearch.make_query_for_simple("hoge", "fuga", [], 100)
         self.assertEqual(query["from"], 100)
 
     def test_make_search_results(self):

--- a/api_v1/entry/views.py
+++ b/api_v1/entry/views.py
@@ -103,6 +103,8 @@ class EntryReferredAPI(APIView):
         if param_entity:
             query &= Q(schema__name=param_entity)
 
+        filter_entities = [param_target_entity] if param_target_entity else []
+
         ret_data = []
         for entry in Entry.objects.filter(query):
             ret_data.append(
@@ -117,7 +119,7 @@ class EntryReferredAPI(APIView):
                             if param_quiet
                             else {"id": x.schema.id, "name": x.schema.name},
                         }
-                        for x in entry.get_referred_objects(filter_entities=[param_target_entity])
+                        for x in entry.get_referred_objects(filter_entities=filter_entities)
                     ],
                 }
             )

--- a/api_v1/entry/views.py
+++ b/api_v1/entry/views.py
@@ -117,7 +117,7 @@ class EntryReferredAPI(APIView):
                             if param_quiet
                             else {"id": x.schema.id, "name": x.schema.name},
                         }
-                        for x in entry.get_referred_objects(entity_name=param_target_entity)
+                        for x in entry.get_referred_objects(filter_entities=[param_target_entity])
                     ],
                 }
             )

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -93,7 +93,7 @@ def do_import_data(request, context):
 def _search_by_keyword(query, entity_name, per_page, page_num):
     # correct entries that contans query at EntryName or AttributeValue
     search_result = Entry.search_entries_for_simple(
-        query, entity_name, per_page, (page_num - 1) * per_page
+        query, entity_name, [], per_page, (page_num - 1) * per_page
     )
 
     return (search_result["ret_count"], search_result["ret_values"])

--- a/entry/models.py
+++ b/entry/models.py
@@ -1184,7 +1184,7 @@ class Entry(ACLBase):
 
         return attr
 
-    def get_referred_objects(self, entity_name=None):
+    def get_referred_objects(self, filter_entities=[], exclude_entities=[]):
         """
         This returns objects that refer current Entry in the AttributeValue
         """
@@ -1194,10 +1194,10 @@ class Entry(ACLBase):
 
         # if entity_name param exists, add schema name to reduce filter execution time
         query = Q(pk__in=ids, is_active=True)
-        if entity_name:
-            query &= Q(schema__name=entity_name)
+        if filter_entities:
+            query &= Q(schema__name__in=filter_entities)
 
-        return Entry.objects.filter(query)
+        return Entry.objects.filter(query).exclude(schema__name__in=exclude_entities)
 
     def may_append_attr(self, attr):
         """

--- a/entry/models.py
+++ b/entry/models.py
@@ -1810,6 +1810,7 @@ class Entry(ACLBase):
         kls,
         hint_attr_value,
         hint_entity_name=None,
+        exclude_entity_names=[],
         limit=CONFIG.MAX_LIST_ENTRIES,
         offset=0,
     ):
@@ -1822,9 +1823,12 @@ class Entry(ACLBase):
         3. Process the search results, and return. (make_search_results_for_attrv)
 
         Args:
-            hint_attr_value (str): Search string for AttributeValue
+            hint_attr_value (str): Required.
+                Search string for AttributeValue
             hint_entity_name (str): Defaults to None.
                 Search string for Entity Name
+            exclude_entity_names (list[str]): Defaults to [].
+                Entity name string list to exclude from search
             limit (int): Defaults to 100.
                 Maximum number of search results to return
             offset (int): Defaults to 0.
@@ -1850,7 +1854,9 @@ class Entry(ACLBase):
                 "ret_values": [],
             }
 
-        query = make_query_for_simple(hint_attr_value, hint_entity_name, offset)
+        query = make_query_for_simple(
+            hint_attr_value, hint_entity_name, exclude_entity_names, offset
+        )
 
         resp = execute_query(query, limit)
 

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -3889,6 +3889,20 @@ class ModelTest(AironeTestCase):
         self.assertEqual(ret["ret_count"], 1)
         self.assertEqual([x["name"] for x in ret["ret_values"]], ["entry"])
 
+    def test_search_entries_for_simple_with_exclude_entity_names(self):
+        self._entry.register_es()
+        entity = Entity.objects.create(name="entity2", created_user=self._user)
+        entry = Entry.objects.create(name="entry2", schema=entity, created_user=self._user)
+        entry.register_es()
+
+        ret = Entry.search_entries_for_simple("entry")
+        self.assertEqual(ret["ret_count"], 2)
+        self.assertEqual([x["name"] for x in ret["ret_values"]], ["entry", "entry2"])
+
+        ret = Entry.search_entries_for_simple("entry", exclude_entity_names=["entity"])
+        self.assertEqual(ret["ret_count"], 1)
+        self.assertEqual([x["name"] for x in ret["ret_values"]], ["entry2"])
+
     def test_search_entries_for_simple_with_limit_offset(self):
         for i in range(0, 10):
             entry = Entry.objects.create(

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -636,7 +636,7 @@ class ModelTest(AironeTestCase):
             self.assertEqual(list(referred_entries), [self._entry])
 
     def test_get_referred_objects_with_entity_param(self):
-        for i in range(3, 5):
+        for i in range(3, 6):
             entity = Entity.objects.create(name="Entity" + str(i), created_user=self._user)
             entry = Entry.objects.create(
                 name="entry" + str(i), created_user=self._user, schema=entity
@@ -661,11 +661,15 @@ class ModelTest(AironeTestCase):
         # This function checks that this get_referred_objects method only get
         # unique reference objects except for the self referred object.
         referred_entries = self._entry.get_referred_objects()
-        self.assertEqual(referred_entries.count(), 2)
+        self.assertEqual(referred_entries.count(), 3)
 
-        referred_entries = self._entry.get_referred_objects(entity_name="Entity3")
+        referred_entries = self._entry.get_referred_objects(filter_entities=["Entity3"])
         self.assertEqual(referred_entries.count(), 1)
         self.assertEqual(referred_entries.first().name, "entry3")
+
+        referred_entries = self._entry.get_referred_objects(exclude_entities=["Entity3"])
+        self.assertEqual(referred_entries.count(), 2)
+        self.assertEqual([x.name for x in referred_entries], ["entry4", "entry5"])
 
     def test_coordinating_attribute_with_dynamically_added_one(self):
         newattr = EntityAttr.objects.create(


### PR DESCRIPTION
There are cases where you want to exclude some entities with search_entries_for_simple and get_referred_objects.
Added parameter to exclude.