### PR TITLE
Added processing for safety's sake not to create duplicate Entries in accident

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 * Fixed an error in getting data_value in advanced search.
   Contributed by @hinashi
 
+* Fixed problem that duplicate named Entries might be created
+  when multiple requests were coming at the exact same time.
+  Contributed by @userlocalhost, @hinashi
+
 ## v3.16.0
 
 ### Changed


### PR DESCRIPTION
This commit adds safety's sake processing just in case for the situation to create
duplicate Entries when multiple requests passed through existence check.
By this processing, Even through multiple requests coming here, Django prevents
from creating multiple Entries.