### PR TITLE
Added special search character to get Entries that have substantial attribute values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   Contributed by @hinashi
 * Added exclude entity parameter in get_referred_objects.
   Contributed by @hinashi
+* Added special search character to get Entries
+  that have substantial attribute values.
+  Contributed by @userlocalhost
 
 ### Changed
 * Changed to allow parallel execution some job.

--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -630,12 +630,12 @@ def _make_an_attribute_filter(hint: Dict[str, str], keyword: str) -> Dict[str, D
         cond_attr.append(date_cond)
 
     else:
-        hint_kyeword_val = _get_hint_keyword_val(keyword)
-        cond_val = [{"match": {"attr.value": hint_kyeword_val}}]
+        hint_keyword_val = _get_hint_keyword_val(keyword)
+        cond_val = [{"match": {"attr.value": hint_keyword_val}}]
 
-        if hint_kyeword_val:
+        if hint_keyword_val:
             if "exact_match" not in hint:
-                cond_val.append({"regexp": {"attr.value": _get_regex_pattern(hint_kyeword_val)}})
+                cond_val.append({"regexp": {"attr.value": _get_regex_pattern(hint_keyword_val)}})
 
             cond_attr.append({"bool": {"should": cond_val}})
 

--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -635,31 +635,47 @@ def _make_an_attribute_filter(hint: Dict[str, str], keyword: str) -> Dict[str, D
 
         # This is an exceptional bypass processing to be able to search Entries
         # that has substantial Attribute.
-        if hint_keyword_val == '*':
+        if hint_keyword_val == "*":
             # This query get results that have any substantial values for non boolean attributes
-            query_has_substantial_value = {"bool": {"must": [
-                {"bool": {"must_not": {
-                    "term": {"attr.type": AttrTypeValue['boolean']},
-                }}},
-                {"regexp": {"attr.value": '.+'}},
-            ]}}
-
-            # This query get results that have date value
-            query_has_date_value = {
-                "exists": {"field": "attr.date_value"}
+            query_has_substantial_value = {
+                "bool": {
+                    "must": [
+                        {
+                            "bool": {
+                                "must_not": {
+                                    "term": {"attr.type": AttrTypeValue["boolean"]},
+                                }
+                            }
+                        },
+                        {"regexp": {"attr.value": ".+"}},
+                    ]
+                }
             }
 
-            # This query get results that have True value for boolean attributes
-            query_has_true_for_boolean = {"bool": {"must": [
-                {"term": {"attr.type": AttrTypeValue['boolean']}},
-                {"term": {"attr.value": "True"}},
-            ]}}
+            # This query get results that have date value
+            query_has_date_value = {"exists": {"field": "attr.date_value"}}
 
-            cond_attr.append({"bool": {"should": [
-                query_has_substantial_value,
-                query_has_date_value,
-                query_has_true_for_boolean,
-            ]}})
+            # This query get results that have True value for boolean attributes
+            query_has_true_for_boolean = {
+                "bool": {
+                    "must": [
+                        {"term": {"attr.type": AttrTypeValue["boolean"]}},
+                        {"term": {"attr.value": "True"}},
+                    ]
+                }
+            }
+
+            cond_attr.append(
+                {
+                    "bool": {
+                        "should": [
+                            query_has_substantial_value,
+                            query_has_date_value,
+                            query_has_true_for_boolean,
+                        ]
+                    }
+                }
+            )
 
         elif hint_keyword_val:
             if "exact_match" not in hint:

--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -94,7 +94,7 @@ class ESS(Elasticsearch):
                                         },
                                         "type": {
                                             "type": "integer",
-                                            "index": "true",
+                                            "index": "false",
                                         },
                                         "id": {
                                             "type": "integer",
@@ -636,42 +636,14 @@ def _make_an_attribute_filter(hint: Dict[str, str], keyword: str) -> Dict[str, D
         # This is an exceptional bypass processing to be able to search Entries
         # that has substantial Attribute.
         if hint_keyword_val == "*":
-            # This query get results that have any substantial values for non boolean attributes
-            query_has_substantial_value = {
-                "bool": {
-                    "must": [
-                        {
-                            "bool": {
-                                "must_not": {
-                                    "term": {"attr.type": AttrTypeValue["boolean"]},
-                                }
-                            }
-                        },
-                        {"regexp": {"attr.value": ".+"}},
-                    ]
-                }
-            }
-
-            # This query get results that have date value
-            query_has_date_value = {"exists": {"field": "attr.date_value"}}
-
-            # This query get results that have True value for boolean attributes
-            query_has_true_for_boolean = {
-                "bool": {
-                    "must": [
-                        {"term": {"attr.type": AttrTypeValue["boolean"]}},
-                        {"term": {"attr.value": "True"}},
-                    ]
-                }
-            }
-
             cond_attr.append(
                 {
                     "bool": {
                         "should": [
-                            query_has_substantial_value,
-                            query_has_date_value,
-                            query_has_true_for_boolean,
+                            # This query get results that have any substantial values
+                            {"regexp": {"attr.value": ".+"}},
+                            # This query get results that have date value
+                            {"exists": {"field": "attr.date_value"}},
                         ]
                     }
                 }

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -1791,7 +1791,7 @@ class ModelTest(AironeTestCase):
                 "type": AttrTypeValue["named_object"],
                 "value": {"name": "bar", "id": str(ref_entry.id)},
             },
-            "bool": {"type": AttrTypeValue["boolean"], "value": False},
+            "bool": {"type": AttrTypeValue["boolean"], "value": True},
             "group": {"type": AttrTypeValue["group"], "value": str(ref_group.id)},
             "date": {"type": AttrTypeValue["date"], "value": date(2018, 12, 31)},
             "arr_str": {
@@ -1973,6 +1973,18 @@ class ModelTest(AironeTestCase):
         ret = Entry.search_entries(user, [entity.id], [{"name": "str", "keyword": "FOO-10"}])
         self.assertEqual(ret["ret_count"], 1)
         self.assertEqual(ret["ret_values"][0]["entry"]["name"], "e-10")
+
+        # check to get Entries that only have substantial Attribute values
+        for attr in entity.attrs.filter(is_active=True):
+            result = Entry.search_entries(user, [entity.id], [{"name": attr.name, "keyword": '*'}])
+
+            # confirm "entry-black" Entry, which doesn't have any substantial Attribute values,
+            # doesn't exist on the result.
+            isin_entry_blank = any([x['entry']['name'] == "entry-blank" for x in result['ret_values']])
+            self.assertFalse(isin_entry_blank)
+
+            # confirm Entries, which have substantial Attribute values, are returned
+            self.assertEqual(result['ret_count'], 11)
 
     def test_search_entries_with_hint_referral(self):
         user = User.objects.create(username="hoge")

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -1978,15 +1978,20 @@ class ModelTest(AironeTestCase):
         for attr in entity.attrs.filter(is_active=True):
             result = Entry.search_entries(user, [entity.id], [{"name": attr.name, "keyword": "*"}])
 
-            # confirm "entry-black" Entry, which doesn't have any substantial Attribute values,
-            # doesn't exist on the result.
-            isin_entry_blank = any(
-                [x["entry"]["name"] == "entry-blank" for x in result["ret_values"]]
-            )
-            self.assertFalse(isin_entry_blank)
+            if attr.type != AttrTypeValue["boolean"]:
+                # confirm "entry-black" Entry, which doesn't have any substantial Attribute values,
+                # doesn't exist on the result.
+                isin_entry_blank = any(
+                    [x["entry"]["name"] == "entry-blank" for x in result["ret_values"]]
+                )
+                self.assertFalse(isin_entry_blank)
 
-            # confirm Entries, which have substantial Attribute values, are returned
-            self.assertEqual(result["ret_count"], 11)
+                # confirm Entries, which have substantial Attribute values, are returned
+                self.assertEqual(result["ret_count"], 11)
+
+            else:
+                # both True and False value will be matched for boolean type Attribute
+                self.assertEqual(result["ret_count"], 12)
 
     def test_search_entries_with_hint_referral(self):
         user = User.objects.create(username="hoge")

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -1976,15 +1976,17 @@ class ModelTest(AironeTestCase):
 
         # check to get Entries that only have substantial Attribute values
         for attr in entity.attrs.filter(is_active=True):
-            result = Entry.search_entries(user, [entity.id], [{"name": attr.name, "keyword": '*'}])
+            result = Entry.search_entries(user, [entity.id], [{"name": attr.name, "keyword": "*"}])
 
             # confirm "entry-black" Entry, which doesn't have any substantial Attribute values,
             # doesn't exist on the result.
-            isin_entry_blank = any([x['entry']['name'] == "entry-blank" for x in result['ret_values']])
+            isin_entry_blank = any(
+                [x["entry"]["name"] == "entry-blank" for x in result["ret_values"]]
+            )
             self.assertFalse(isin_entry_blank)
 
             # confirm Entries, which have substantial Attribute values, are returned
-            self.assertEqual(result['ret_count'], 11)
+            self.assertEqual(result["ret_count"], 11)
 
     def test_search_entries_with_hint_referral(self):
         user = User.objects.create(username="hoge")


### PR DESCRIPTION
This commit added new character(`*`) for search processing to retrieve Entries that have substantial attribute values.

Current implementation has another special search-character (`\`) to retrieve Entries that have empty attribute values. The feature that is added in this commit is opposite of this.

## Note
When you have already registered data to the Elasticsearch, you have to recreate index mapping by this change.