### PR TITLE
(WIP) Enable to select Entity to register the Elasticsearch

### DIFF
--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -188,6 +188,7 @@ def render(request, template, context={}):
     context["STATUS_ENTITY"]["TOP_LEVEL"] = entity_models.Entity.STATUS_TOP_LEVEL
     context["STATUS_ENTITY"]["CREATING"] = entry_models.Entity.STATUS_CREATING
     context["STATUS_ENTITY"]["EDITING"] = entry_models.Entity.STATUS_EDITING
+    context["STATUS_ENTITY"]["NOT_INDEXED"] = entry_models.Entity.STATUS_NOT_INDEXED
 
     # set Construct for Entry status
     context["STATUS_ENTRY"] = {}

--- a/entity/models.py
+++ b/entity/models.py
@@ -49,6 +49,10 @@ class Entity(ACLBase):
     STATUS_CREATING = 1 << 1
     STATUS_EDITING = 1 << 2
 
+    # Entries that are related with this Entity won't be registered to the elasticsearch
+    # when this status is set
+    STATUS_NOT_INDEXED = 1 << 3
+
     note = models.CharField(max_length=200, blank=True)
     attrs = models.ManyToManyField(EntityAttr)
 

--- a/entity/tests/test_view.py
+++ b/entity/tests/test_view.py
@@ -109,6 +109,7 @@ class ViewTest(AironeViewTest):
             "name": "hoge",
             "note": "fuga",
             "is_toplevel": True,
+            "is_not_indexed": True,
             "attrs": [
                 {
                     "name": "foo",
@@ -162,6 +163,7 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.first()
         self.assertEqual(entity.name, "hoge")
         self.assertTrue(entity.status & Entity.STATUS_TOP_LEVEL)
+        self.assertTrue(entity.status & Entity.STATUS_NOT_INDEXED)
 
         # tests for EntityAttribute objects
         self.assertEqual(len(EntityAttr.objects.all()), 6)
@@ -177,6 +179,7 @@ class ViewTest(AironeViewTest):
         params = {
             "note": "fuga",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "foo",
@@ -204,6 +207,7 @@ class ViewTest(AironeViewTest):
             "name": "a" * (Entity._meta.get_field("name").max_length + 1),
             "note": "fuga",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "foo",
@@ -230,6 +234,7 @@ class ViewTest(AironeViewTest):
         params = {
             "note": "fuga",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "foo",
@@ -259,6 +264,7 @@ class ViewTest(AironeViewTest):
             "name": "hoge",
             "note": "fuga",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "",
@@ -277,6 +283,7 @@ class ViewTest(AironeViewTest):
             "name": "hoge",
             "note": "fuga",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "foo",
@@ -297,6 +304,7 @@ class ViewTest(AironeViewTest):
             "name": "hoge",
             "note": "fuga",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "a" * (EntityAttr._meta.get_field("name").max_length + 1),
@@ -319,6 +327,7 @@ class ViewTest(AironeViewTest):
             "name": "hoge",
             "note": "fuga",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": "puyo",
         }
         resp = self.client.post(reverse("entity:do_create"), json.dumps(params), "application/json")
@@ -355,6 +364,7 @@ class ViewTest(AironeViewTest):
             "name": "hoge",
             "note": "fuga",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "foo",
@@ -379,6 +389,7 @@ class ViewTest(AironeViewTest):
             "name": "a" * (Entity._meta.get_field("name").max_length + 1),
             "note": "fuga",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "foo",
@@ -401,6 +412,7 @@ class ViewTest(AironeViewTest):
             "name": "hoge",
             "note": "fuga",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "a" * (EntityAttr._meta.get_field("name").max_length + 1),
@@ -423,6 +435,7 @@ class ViewTest(AironeViewTest):
             "name": "hoge",
             "note": "fuga",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "foo",
@@ -463,6 +476,7 @@ class ViewTest(AironeViewTest):
             "name": "foo",
             "note": "bar",
             "is_toplevel": True,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "foo",
@@ -487,12 +501,14 @@ class ViewTest(AironeViewTest):
             "application/json",
         )
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(Entity.objects.get(id=entity.id).name, "foo")
-        self.assertEqual(Entity.objects.get(id=entity.id).note, "bar")
-        self.assertEqual(Entity.objects.get(id=entity.id).attrs.count(), 2)
-        self.assertEqual(Entity.objects.get(id=entity.id).attrs.get(id=attr.id).name, "foo")
-        self.assertEqual(Entity.objects.get(id=entity.id).attrs.last().name, "bar")
-        self.assertTrue(Entity.objects.get(id=entity.id).status & Entity.STATUS_TOP_LEVEL)
+        entity = Entity.objects.get(id=entity.id)
+        self.assertEqual(entity.name, "foo")
+        self.assertEqual(entity.note, "bar")
+        self.assertEqual(entity.attrs.count(), 2)
+        self.assertEqual(entity.attrs.get(id=attr.id).name, "foo")
+        self.assertEqual(entity.attrs.last().name, "bar")
+        self.assertTrue(entity.status & Entity.STATUS_TOP_LEVEL)
+        self.assertFalse(entity.status & Entity.STATUS_NOT_INDEXED)
 
         # tests for operation history is registered correctly
         self.assertEqual(History.objects.count(), 5)
@@ -521,6 +537,7 @@ class ViewTest(AironeViewTest):
             "name": "foo",
             "note": "bar",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "foo",
@@ -562,6 +579,7 @@ class ViewTest(AironeViewTest):
             "name": "foo",
             "note": "bar",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "baz",
@@ -601,6 +619,7 @@ class ViewTest(AironeViewTest):
             "name": "foo",
             "note": "bar",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "baz",
@@ -653,6 +672,7 @@ class ViewTest(AironeViewTest):
             "name": "foo",
             "note": "bar",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "baz",
@@ -693,6 +713,7 @@ class ViewTest(AironeViewTest):
             "name": "foo",
             "note": "bar",
             "is_toplevel": True,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "foo",
@@ -735,6 +756,7 @@ class ViewTest(AironeViewTest):
             "name": "hoge",
             "note": "fuga",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "a",
@@ -760,6 +782,7 @@ class ViewTest(AironeViewTest):
             "name": "hoge",
             "note": "fuga",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "a",
@@ -809,6 +832,7 @@ class ViewTest(AironeViewTest):
             "name": "new-entity",
             "note": "hoge",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "foo",
@@ -1128,6 +1152,7 @@ class ViewTest(AironeViewTest):
             "name": "hoge",
             "note": "fuga",
             "is_toplevel": True,
+            "is_not_indexed": False,
             "attrs": [],
         }
         resp = self.client.post(reverse("entity:do_create"), json.dumps(params), "application/json")
@@ -1146,6 +1171,7 @@ class ViewTest(AironeViewTest):
             "name": "entity",
             "note": "note",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "attr",
@@ -1194,6 +1220,7 @@ class ViewTest(AironeViewTest):
             "name": "new-entity",
             "note": "hoge",
             "is_toplevel": False,
+            "is_not_indexed": False,
             "attrs": [
                 # change attribute name and mandatory parameter
                 {
@@ -1398,6 +1425,7 @@ class ViewTest(AironeViewTest):
             "name": "hoge",
             "note": "fuga",
             "is_toplevel": True,
+            "is_not_indexed": False,
             "attrs": [
                 {
                     "name": "foo",
@@ -1436,6 +1464,7 @@ class ViewTest(AironeViewTest):
             "name": "hoge-changed",
             "note": "fuga",
             "is_toplevel": True,
+            "is_not_indexed": False,
             "attrs": [],
         }
         resp = self.client.post(
@@ -1467,6 +1496,7 @@ class ViewTest(AironeViewTest):
             "name": "hoge-changed",
             "note": "fuga",
             "is_toplevel": True,
+            "is_not_indexed": False,
             "attrs": [],
         }
         resp = self.client.post(

--- a/entry/models.py
+++ b/entry/models.py
@@ -1636,6 +1636,10 @@ class Entry(ACLBase):
         return document
 
     def register_es(self, es=None, skip_refresh=False):
+        # do nothing when "is_not_indexed" parameter is set on the related Entity
+        if self.schema.is_not_indexed:
+            return
+
         if not es:
             es = ESS()
 

--- a/static/js/entity.js
+++ b/static/js/entity.js
@@ -130,7 +130,8 @@ $('#edit-form').submit(function(event){
       }
       return ret;
     }).get(),
-    'is_toplevel': $('input[name=is_toplevel]').is(':checked')
+    'is_not_indexed': $('input[name=is_not_indexed]:checked').val() !== undefined,
+    'is_toplevel': $('input[name=is_toplevel]:checked').val() !== undefined,
   });
 
   // disable all input parameter to specify sending request

--- a/templates/edit_entity_content.html
+++ b/templates/edit_entity_content.html
@@ -22,6 +22,14 @@
             <td><input type="checkbox" name="is_toplevel" /></td>
           {% endif %}
         </tr>
+        <tr>
+          <td>エントリを検索結果に表示させない</td>
+          {% if entity.status|bitwise_and:STATUS_ENTITY.NOT_INDEXED %}
+            <td><input type="checkbox" name="is_not_indexed" checked="checked"/></td>
+          {% else %}
+            <td><input type="checkbox" name="is_not_indexed" /></td>
+          {% endif %}
+        </tr>
       </table>
 
       <table class="table table-bordered">


### PR DESCRIPTION
In the current implementation, all Entries will be registered to the Elasticsearch.
This commit added an option to select whether Entry will be register to the Elasticsearch at creating/editing Entity.

## Application Result
<img width="1192" alt="スクリーンショット 2022-08-31 17 40 01" src="https://user-images.githubusercontent.com/469934/187635833-8d33bed8-7a3d-4716-afc5-f59c117ceece.png">
