### PR TITLE
disableScrollLock on Menu

### DIFF
--- a/frontend/src/components/entity/EntityControlMenu.tsx
+++ b/frontend/src/components/entity/EntityControlMenu.tsx
@@ -75,6 +75,7 @@ export const EntityControlMenu: FC<Props> = ({
       open={Boolean(anchorElem)}
       onClose={() => handleClose(entityId)}
       anchorEl={anchorElem}
+      disableScrollLock
     >
       <MenuItem component={Link} to={entityPath(entityId)}>
         <Typography>編集</Typography>

--- a/frontend/src/components/entry/EntryControlMenu.tsx
+++ b/frontend/src/components/entry/EntryControlMenu.tsx
@@ -67,6 +67,7 @@ export const EntryControlMenu: FC<EntryControlProps> = ({
         vertical: "top",
         horizontal: "right",
       }}
+      disableScrollLock
     >
       <Box sx={{ width: 150 }}>
         <MenuItem component={Link} to={entryEditPath(entityId, entryId)}>


### PR DESCRIPTION
Show the scroll bar even if MUI Menu is opened.
<img width="1251" alt="image" src="https://user-images.githubusercontent.com/191684/188260570-bc8ea8f7-a06f-47c2-ad8d-f07f2c71eeb4.png">

MUI Menu hides the scroll bar if its opened. And the scroll bar doesn't overlay the page on (maybe, especially) Windows environment, so the page width is slightly flickering on opening the Menu. `disableScrollLock` should resolve it.