### PR TITLE
Make card headers responsible

### DIFF
--- a/frontend/src/components/entity/EntityList.tsx
+++ b/frontend/src/components/entity/EntityList.tsx
@@ -107,6 +107,9 @@ export const EntityList: FC<Props> = ({
                   mt: "24px",
                   mx: "16px",
                   mb: "16px",
+                  ".MuiCardHeader-content": {
+                    width: "80%",
+                  },
                 }}
                 title={
                   <CardActionArea
@@ -116,7 +119,6 @@ export const EntityList: FC<Props> = ({
                     <Typography
                       variant="h6"
                       sx={{
-                        width: "300px",
                         textOverflow: "ellipsis",
                         overflow: "hidden",
                         whiteSpace: "nowrap",

--- a/frontend/src/components/entry/EntryList.tsx
+++ b/frontend/src/components/entry/EntryList.tsx
@@ -98,6 +98,9 @@ export const EntryList: FC<Props> = ({ entityId, canCreateEntry = true }) => {
                       mt: "24px",
                       mx: "16px",
                       mb: "16px",
+                      ".MuiCardHeader-content": {
+                        width: "80%",
+                      },
                     }}
                     title={
                       <CardActionArea
@@ -107,7 +110,6 @@ export const EntryList: FC<Props> = ({ entityId, canCreateEntry = true }) => {
                         <Typography
                           variant="h6"
                           sx={{
-                            width: "300px",
                             textOverflow: "ellipsis",
                             overflow: "hidden",
                             whiteSpace: "nowrap",

--- a/frontend/src/pages/__snapshots__/EntityPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntityPage.test.tsx.snap
@@ -158,7 +158,7 @@ Object {
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-zwt9xa-MuiPaper-root-MuiCard-root"
                 >
                   <div
-                    class="MuiCardHeader-root css-1woct9j-MuiCardHeader-root"
+                    class="MuiCardHeader-root css-123p1mg-MuiCardHeader-root"
                   >
                     <div
                       class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -172,7 +172,7 @@ Object {
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-c6mpt2-MuiTypography-root"
                           >
                             aaa
                           </h6>
@@ -226,7 +226,7 @@ Object {
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-zwt9xa-MuiPaper-root-MuiCard-root"
                 >
                   <div
-                    class="MuiCardHeader-root css-1woct9j-MuiCardHeader-root"
+                    class="MuiCardHeader-root css-123p1mg-MuiCardHeader-root"
                   >
                     <div
                       class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -240,7 +240,7 @@ Object {
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-c6mpt2-MuiTypography-root"
                           >
                             aaaaa
                           </h6>
@@ -294,7 +294,7 @@ Object {
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-zwt9xa-MuiPaper-root-MuiCard-root"
                 >
                   <div
-                    class="MuiCardHeader-root css-1woct9j-MuiCardHeader-root"
+                    class="MuiCardHeader-root css-123p1mg-MuiCardHeader-root"
                   >
                     <div
                       class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -308,7 +308,7 @@ Object {
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-c6mpt2-MuiTypography-root"
                           >
                             bbbbb
                           </h6>
@@ -576,7 +576,7 @@ Object {
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-zwt9xa-MuiPaper-root-MuiCard-root"
               >
                 <div
-                  class="MuiCardHeader-root css-1woct9j-MuiCardHeader-root"
+                  class="MuiCardHeader-root css-123p1mg-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -590,7 +590,7 @@ Object {
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-c6mpt2-MuiTypography-root"
                         >
                           aaa
                         </h6>
@@ -644,7 +644,7 @@ Object {
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-zwt9xa-MuiPaper-root-MuiCard-root"
               >
                 <div
-                  class="MuiCardHeader-root css-1woct9j-MuiCardHeader-root"
+                  class="MuiCardHeader-root css-123p1mg-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -658,7 +658,7 @@ Object {
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-c6mpt2-MuiTypography-root"
                         >
                           aaaaa
                         </h6>
@@ -712,7 +712,7 @@ Object {
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-zwt9xa-MuiPaper-root-MuiCard-root"
               >
                 <div
-                  class="MuiCardHeader-root css-1woct9j-MuiCardHeader-root"
+                  class="MuiCardHeader-root css-123p1mg-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -726,7 +726,7 @@ Object {
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-c6mpt2-MuiTypography-root"
                         >
                           bbbbb
                         </h6>

--- a/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
@@ -225,7 +225,7 @@ Object {
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-zwt9xa-MuiPaper-root-MuiCard-root"
                 >
                   <div
-                    class="MuiCardHeader-root css-1woct9j-MuiCardHeader-root"
+                    class="MuiCardHeader-root css-123p1mg-MuiCardHeader-root"
                   >
                     <div
                       class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -239,7 +239,7 @@ Object {
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-c6mpt2-MuiTypography-root"
                           >
                             aaa
                           </h6>
@@ -286,7 +286,7 @@ Object {
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-zwt9xa-MuiPaper-root-MuiCard-root"
                 >
                   <div
-                    class="MuiCardHeader-root css-1woct9j-MuiCardHeader-root"
+                    class="MuiCardHeader-root css-123p1mg-MuiCardHeader-root"
                   >
                     <div
                       class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -300,7 +300,7 @@ Object {
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-c6mpt2-MuiTypography-root"
                           >
                             aaaaa
                           </h6>
@@ -347,7 +347,7 @@ Object {
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-zwt9xa-MuiPaper-root-MuiCard-root"
                 >
                   <div
-                    class="MuiCardHeader-root css-1woct9j-MuiCardHeader-root"
+                    class="MuiCardHeader-root css-123p1mg-MuiCardHeader-root"
                   >
                     <div
                       class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -361,7 +361,7 @@ Object {
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-h6 css-c6mpt2-MuiTypography-root"
                           >
                             bbbbb
                           </h6>
@@ -689,7 +689,7 @@ Object {
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-zwt9xa-MuiPaper-root-MuiCard-root"
               >
                 <div
-                  class="MuiCardHeader-root css-1woct9j-MuiCardHeader-root"
+                  class="MuiCardHeader-root css-123p1mg-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -703,7 +703,7 @@ Object {
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-c6mpt2-MuiTypography-root"
                         >
                           aaa
                         </h6>
@@ -750,7 +750,7 @@ Object {
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-zwt9xa-MuiPaper-root-MuiCard-root"
               >
                 <div
-                  class="MuiCardHeader-root css-1woct9j-MuiCardHeader-root"
+                  class="MuiCardHeader-root css-123p1mg-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -764,7 +764,7 @@ Object {
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-c6mpt2-MuiTypography-root"
                         >
                           aaaaa
                         </h6>
@@ -811,7 +811,7 @@ Object {
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-zwt9xa-MuiPaper-root-MuiCard-root"
               >
                 <div
-                  class="MuiCardHeader-root css-1woct9j-MuiCardHeader-root"
+                  class="MuiCardHeader-root css-123p1mg-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -825,7 +825,7 @@ Object {
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-z9ajoc-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-h6 css-c6mpt2-MuiTypography-root"
                         >
                           bbbbb
                         </h6>


### PR DESCRIPTION
It enables users browsing on a small window to see entity/entry titles and the menu.

https://user-images.githubusercontent.com/191684/188263028-93d78df7-b44f-4b6a-aec2-2c877440908f.mov

