### PR TITLE
Fix: ValueError exception on update.

### DIFF
--- a/entry/models.py
+++ b/entry/models.py
@@ -524,6 +524,13 @@ class Attribute(ACLBase):
                 if isinstance(value, Entry):
                     value = value.id
 
+                # check if the value can be converted to int
+                try:
+                    int(value)
+                # e.g. value="" will result in the following exception
+                except ValueError:
+                    continue
+
                 if not last_value.data_array.filter(referral__id=value).exists():
                     return True
 

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -368,6 +368,31 @@ class ModelTest(AironeTestCase):
         self.assertFalse(attr.is_updated([e2, e1]))
         self.assertTrue(attr.is_updated([e1, e3]))
 
+    def test_attr_helper_of_attribute_with_array_object_values_at_empty(self):
+        e1 = Entry.objects.create(name="E1", created_user=self._user, schema=self._entity)
+        e2 = Entry.objects.create(name="E2", created_user=self._user, schema=self._entity)
+
+        entity = Entity.objects.create(name="e2", created_user=self._user)
+        entry = Entry.objects.create(name="_E", created_user=self._user, schema=entity)
+
+        attr = self.make_attr("attr2", attrtype=AttrTypeArrObj, entity=entity, entry=entry)
+        attr_value = AttributeValue.objects.create(created_user=self._user, parent_attr=attr)
+        attr_value.set_status(AttributeValue.STATUS_DATA_ARRAY_PARENT)
+
+        attr_value.data_array.add(
+            AttributeValue.objects.create(referral=e1, created_user=self._user, parent_attr=attr)
+        )
+
+        attr_value.data_array.add(
+            AttributeValue.objects.create(referral=e2, created_user=self._user, parent_attr=attr)
+        )
+
+        attr.values.add(attr_value)
+
+        self.assertFalse(attr.is_updated([e1.id, e2.id]))
+        e2.delete()
+        self.assertFalse(attr.is_updated([e1.id, ""]))  # value=""
+
     def test_attr_helper_of_attribute_with_named_ref(self):
         ref_entity = Entity.objects.create(name="referred_entity", created_user=self._user)
         ref_entry1 = Entry.objects.create(


### PR DESCRIPTION
# 問題
以下の操作をすることでエントリ更新時に例外が発生する。

- array_entry型の属性をもったエンティティを作成する
- エントリAを作成する
- 参照用エントリ B, C を作成する
- エントリAのarray_entry属性にエントリ B, Cを設定する
- 設定したエントリ2つのうち1つ エントリB を削除する
- エントリAのarray_entry属性に空の行を追加し保存する
- celeryで例外エラーが発生し、更新処理がエラーとなる

# 原因
-  値として空文字列を送っている

# 理由
- `is_updated()`の527行目に`referral__id=value`の部分にint以外の値、具体的には空文字列`''`が渡されている
https://github.com/dmm-com/airone/blob/1f9098c0c97d19c5d520f55bc00fefa2e34c2ae9/entry/models.py#L522-L528
filterの内部処理で、`referral__id`に渡された値はbase10のintに変換されるが、ここに空文字列を渡すとValueErrorが発生する。
空文字列をバックエンドに渡す方法として、フロント側のedit entryページでAdd rowを押すと、空の列(`value=""`)がselectedになった状態で追加される。このまま「保存」ボタンを押すと空文字列が送信される。

- 他のケースで例外が発生しなかった理由
上記手段以外で例外が起きなかった理由は、ほとんどのユースケースでは518行目でtrueになりreturnが叩かれるため
https://github.com/dmm-com/airone/blob/1f9098c0c97d19c5d520f55bc00fefa2e34c2ae9/entry/models.py#L517-L519

- 問題再現方法
問題の手順のような`last_value.data_array`と同じ長さで、空文字列を含むような送信をしてやれば、518行目のif文をすり抜けて例外が発生する。
例えば以下のケースでも例外を確認した。

  - array_entry属性に3個エントリを追加->２個のエントリを削除->編集画面で２つ空の行を追加
  - array_entry属性の値を書き換えて送信
  デベロッパーツールでoptionの値を書き換えてやることでも条件は満たせるため、例外を起こせる
![スクリーンショット 2022-09-15 11 30 12](https://user-images.githubusercontent.com/49955721/190299462-ffcb809b-1dbe-4e04-ab84-a639ecf7147e.png)

# 対策
filterに渡す前に値をintに変換できるか確認する。
ValueErrorの場合でも、他の値が更新が必要か確認したいためcontinueする。

