### PR TITLE
Blush-up a fixing of ValueError exception on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Fixed
 
+* Fixed a problem that an exception will be occurred at edit Entry page.
+  Contributed by @ritsuxis
+
 ## v3.21.0
 
 ### Added

--- a/entry/models.py
+++ b/entry/models.py
@@ -521,17 +521,17 @@ class Attribute(ACLBase):
             # the case of appending or deleting
             for value in recv_value:
                 # formalize value type
-                if isinstance(value, Entry):
-                    value = value.id
-
-                # check if the value can be converted to int
                 try:
-                    int(value)
-                # e.g. value="" will result in the following exception
-                except ValueError:
-                    continue
+                    if isinstance(value, Entry):
+                        entry_id = value.id
+                    else:
+                        entry_id = int(value)
 
-                if not last_value.data_array.filter(referral__id=value).exists():
+                except ValueError:
+                    # When user specify an invalid value (e.g. ""), ValueError will be occcured
+                    entry_id = 0
+
+                if not last_value.data_array.filter(referral__id=entry_id).exists():
                     return True
 
         elif self.schema.type == AttrTypeValue["boolean"]:

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -395,7 +395,7 @@ class ModelTest(AironeTestCase):
 
         self.assertFalse(attr.is_updated([e1.id, e2.id]))
         e2.delete()
-        self.assertFalse(attr.is_updated([e1.id, ""]))  # value=""
+        self.assertTrue(attr.is_updated([e1.id, ""]))  # value=""
 
     def test_attr_helper_of_attribute_with_named_ref(self):
         ref_entity = Entity.objects.create(name="referred_entity", created_user=self._user)

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -363,6 +363,10 @@ class ModelTest(AironeTestCase):
         self.assertTrue(attr.is_updated([e3.id]))  # delete & update
         self.assertTrue(attr.is_updated([e1.id, e2.id, e3.id]))  # create
         self.assertTrue(attr.is_updated([e1.id, e3.id, e4.id]))  # create & update
+        self.assertTrue(attr.is_updated([]))
+        self.assertTrue(attr.is_updated(["", e1.id]))
+        self.assertTrue(attr.is_updated(["0", e1.id]))
+        self.assertTrue(attr.is_updated(["hoge", e1.id]))
 
         # checks that this method also accepts Entry
         self.assertFalse(attr.is_updated([e2, e1]))


### PR DESCRIPTION
This commit blushed up #626 that exchange an invalid value to 0, which indicates there is no Entry refers when an Attribute of array_entry type is updated.
(c.f. https://github.com/dmm-com/airone/pull/626#pullrequestreview-1108479184)