### PR TITLE
Added processing to check user belonged to role as member or administrative user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## In development
 
 ### Added
+* Added new parameter "as_member" at the Role.is_belonged_to() method to be able to
+  confirm that specified user is belonged to this role as member.
+  Contributed by @userlocalhost
 
 ### Changed
 

--- a/role/models.py
+++ b/role/models.py
@@ -35,13 +35,16 @@ class Role(models.Model):
 
         return False
 
-    def is_belonged_to(self, user):
-        """check wether specified User is belonged to this Role"""
+    def is_belonged_to(self, user, as_member=False):
+        """This checks wether specified User is belonged to this Role.
+        When "as_member" parameter is True, then this method only doesn't check
+        admin users and groups.
+        """
         if user.id in [
             u.id
             for u in set(
                 list(self.users.filter(is_active=True))
-                + list(self.admin_users.filter(is_active=True))
+                + ([] if as_member else list(self.admin_users.filter(is_active=True)))
             )
         ]:
             return True
@@ -53,7 +56,7 @@ class Role(models.Model):
                     g.id
                     for g in set(
                         list(self.groups.filter(is_active=True))
-                        + list(self.admin_groups.filter(is_active=True))
+                        + ([] if as_member else list(self.admin_groups.filter(is_active=True)))
                     )
                 ]
             )

--- a/role/tests/test_model.py
+++ b/role/tests/test_model.py
@@ -14,6 +14,7 @@ class ModelTest(RoleTestBase):
 
         self.assertTrue(self.role.is_belonged_to(self.users["userA"]))
         self.assertFalse(self.role.is_belonged_to(self.users["userB"]))
+        self.assertTrue(self.role.is_belonged_to(self.users["userA"], as_member=True))
 
     def test_is_belonged_to_registered_in_groups(self):
         # set userA belongs to groupA as groups member
@@ -24,6 +25,7 @@ class ModelTest(RoleTestBase):
 
         self.assertTrue(self.role.is_belonged_to(self.users["userA"]))
         self.assertFalse(self.role.is_belonged_to(self.users["userB"]))
+        self.assertTrue(self.role.is_belonged_to(self.users["userA"], as_member=True))
 
     def test_is_belonged_to_registered_in_admin_users(self):
         # set userA belongs to test Role as admin user
@@ -31,6 +33,7 @@ class ModelTest(RoleTestBase):
 
         self.assertTrue(self.role.is_belonged_to(self.users["userA"]))
         self.assertFalse(self.role.is_belonged_to(self.users["userB"]))
+        self.assertFalse(self.role.is_belonged_to(self.users["userA"], as_member=True))
 
     def test_is_belonged_to_registered_in_admin_groups(self):
         # set userA belongs to groupA as groups member
@@ -41,6 +44,7 @@ class ModelTest(RoleTestBase):
 
         self.assertTrue(self.role.is_belonged_to(self.users["userA"]))
         self.assertFalse(self.role.is_belonged_to(self.users["userB"]))
+        self.assertFalse(self.role.is_belonged_to(self.users["userA"], as_member=True))
 
     def test_is_belonged_to_parent_group(self):
         """This test create Role (role1) that belongs following hierarchical groups


### PR DESCRIPTION
This commit adds new parameter "as_member" at the Role.is_belonged_to() method to be able to confirm that specified user is belonged to this role as member. This feature is necessary to distinguish user is belonged to its role as normal member or administrative one.
<img width="445" alt="スクリーンショット 2022-09-21 16 50 01" src="https://user-images.githubusercontent.com/469934/191446647-b80c9468-fa18-4018-8344-b56de416a3e5.png">
