### PR TITLE
Fixed error in updating array_object attribute

### DIFF
--- a/entry/models.py
+++ b/entry/models.py
@@ -527,6 +527,8 @@ class Attribute(ACLBase):
                 try:
                     if isinstance(value, Entry):
                         entry_id = value.id
+                    elif not value:
+                        entry_id = 0
                     else:
                         entry_id = int(value)
 

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -347,6 +347,7 @@ class ModelTest(AironeTestCase):
         self.assertTrue(attr.is_updated([e1.id, e2.id, e3.id]))  # create
         self.assertTrue(attr.is_updated([e1.id, e3.id, e4.id]))  # create & update
         self.assertTrue(attr.is_updated([]))
+        self.assertTrue(attr.is_updated([None, e1.id]))
         self.assertTrue(attr.is_updated(["", e1.id]))
         self.assertTrue(attr.is_updated(["0", e1.id]))
         self.assertTrue(attr.is_updated(["hoge", e1.id]))


### PR DESCRIPTION
There is a problem that an error occurs when None is specified when updating the array_object attribute.