### PR TITLE
Show job type name on export V2

### DIFF
--- a/frontend/src/utils/JobUtil.ts
+++ b/frontend/src/utils/JobUtil.ts
@@ -37,6 +37,7 @@ export const jobOperationLabel = (jobOperation: number): string => {
     case JobOperations.IMPORT_ENTRY_V2:
       return "インポート";
     case JobOperations.EXPORT_ENTRY:
+    case JobOperations.EXPORT_ENTRY_V2:
     case JobOperations.EXPORT_SEARCH_RESULT:
       return "エクスポート";
     case JobOperations.COPY_ENTRY:

--- a/templates/list_jobs.html
+++ b/templates/list_jobs.html
@@ -91,6 +91,8 @@
               インポート
             {% elif job.operation|divmod:100 == JOB.OPERATION.EXPORT %}
               エクスポート
+            {% elif job.operation|divmod:100 == JOB.OPERATION.EXPORT_V2 %}
+              エクスポート
             {% elif job.operation|divmod:100 == JOB.OPERATION.EXPORT_SEARCH_RESULT %}
               エクスポート
             {% elif job.operation|divmod:100 == JOB.OPERATION.RESTORE %}


### PR DESCRIPTION
Support entry export v2 job operation on listing jobs. It's a missing part of https://github.com/dmm-com/airone/pull/638