### PR TITLE
Return null if referral is not active

### DIFF
--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -355,7 +355,7 @@ class EntryRetrieveSerializer(EntryBaseSerializer):
                                     "name": x.referral.entry.schema.name,
                                 },
                             }
-                            if x.referral
+                            if x.referral and x.referral.is_active
                             else None,
                         }
                         for x in attrv.data_array.all()
@@ -373,7 +373,7 @@ class EntryRetrieveSerializer(EntryBaseSerializer):
                                     "name": x.referral.entry.schema.name,
                                 },
                             }
-                            if x.referral
+                            if x.referral and x.referral.is_active
                             else None
                             for x in attrv.data_array.all()
                         ]
@@ -419,7 +419,7 @@ class EntryRetrieveSerializer(EntryBaseSerializer):
                             "name": attrv.referral.entry.schema.name,
                         },
                     }
-                    if attrv.referral
+                    if attrv.referral and attrv.referral.is_active
                     else None
                 }
                 return {"as_named_object": named}
@@ -434,7 +434,7 @@ class EntryRetrieveSerializer(EntryBaseSerializer):
                             "name": attrv.referral.entry.schema.name,
                         },
                     }
-                    if attrv.referral
+                    if attrv.referral and attrv.referral.is_active
                     else None
                 }
 

--- a/frontend/src/components/entry/entryForm/EditAttributeValue.tsx
+++ b/frontend/src/components/entry/entryForm/EditAttributeValue.tsx
@@ -232,7 +232,7 @@ const ElemReferral: FC<
           sx={{ width: "280px" }}
           multiple={multiple}
           options={referrals}
-          getOptionLabel={(option) => option.name}
+          getOptionLabel={(option) => option?.name}
           isOptionEqualToValue={(option, value) => option.id === value?.id}
           value={attrValue ?? null}
           onChange={(e, value) => {


### PR DESCRIPTION
Currently the entry details page shows deleted referral(s). To avoid it, it returns null on the API if referral is not active.