### PR TITLE
Fixed remove_from_attrv for array_named_entry attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   Contributed by @hinashi
 
 ### Fixed
+* Fixed remove_from_attrv for array_named_entry attribute
+  Contributed by @hinashi
 
 ## v3.22.0
 

--- a/entry/models.py
+++ b/entry/models.py
@@ -1096,7 +1096,7 @@ class Attribute(ACLBase):
                         "id": x.referral.id if x.referral else None,
                         "boolean": x.boolean,
                     }
-                    for x in attrv.data_array.filter(~Q(referral__id=referral.id))
+                    for x in attrv.data_array.exclude(referral=referral, value=value)
                 ]
 
             elif self.schema.type & AttrTypeValue["string"]:

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -3305,13 +3305,32 @@ class ModelTest(AironeTestCase):
             sorted(["ref-0", "ref-1"]),
         )
 
-        attrs["arr_name"].remove_from_attrv(user, referral=None)
-        attrv = attrs["arr_name"].get_latest_value()
-        self.assertEqual(sorted([x.value for x in attrv.data_array.all()]), sorted(["foo", "bar"]))
-        self.assertEqual(
-            sorted([x.referral.name for x in attrv.data_array.all()]),
-            sorted(["ref-0", "ref-1"]),
-        )
+        param_list = [
+            {
+                "referral": None,
+                "value": "",
+            },
+            {
+                "referral": entry_refs[0],
+                "value": "",
+            },
+            {
+                "referral": None,
+                "value": "foo",
+            },
+        ]
+        for param in param_list:
+            attrs["arr_name"].remove_from_attrv(
+                user, referral=param["referral"], value=param["value"]
+            )
+            attrv = attrs["arr_name"].get_latest_value()
+            self.assertEqual(
+                sorted([x.value for x in attrv.data_array.all()]), sorted(["foo", "bar"])
+            )
+            self.assertEqual(
+                sorted([x.referral.name for x in attrv.data_array.all()]),
+                sorted(["ref-0", "ref-1"]),
+            )
 
         attrs["arr_group"].remove_from_attrv(user, value=None)
         self.assertEqual(
@@ -3330,7 +3349,7 @@ class ModelTest(AironeTestCase):
             sorted([x.referral.name for x in attrv.data_array.all()]), sorted(["ref-1"])
         )
 
-        attrs["arr_name"].remove_from_attrv(user, referral=entry_refs[0])
+        attrs["arr_name"].remove_from_attrv(user, referral=entry_refs[0], value="foo")
         attrv = attrs["arr_name"].get_latest_value()
         self.assertEqual(sorted([x.value for x in attrv.data_array.all()]), sorted(["bar"]))
         self.assertEqual(


### PR DESCRIPTION
When using remove_from_attrv with array_named_entry attribute, only referral was specified.
Changed to specify both reference and value.