### PR TITLE
Removed processing that creates unnecessary Attribute instances

### DIFF
--- a/airone/lib/event_notification.py
+++ b/airone/lib/event_notification.py
@@ -25,17 +25,11 @@ def _send_request_to_webhook_endpoint(entry, user, event_type):
 
 
 def notify_entry_create(entry, user):
-    # complement attrs before sending request
-    entry.complement_attrs(user)
-
     # send a request to the registered WebHook URL
     _send_request_to_webhook_endpoint(entry, user, "entry.create")
 
 
 def notify_entry_update(entry, user):
-    # complement attrs before sending request
-    entry.complement_attrs(user)
-
     # send a request to the registered WebHook URL
     _send_request_to_webhook_endpoint(entry, user, "entry.update")
 


### PR DESCRIPTION
This is a workaround processing not to create duplicate Attribute instances just after creating Entry by notify event job.