### PR TITLE
Fixed problem of exported data structure at referral schema

### DIFF
--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -142,7 +142,7 @@ def _yaml_export(job, values, recv_data, has_referral):
         if has_referral is not False:
             data["referrals"] = [
                 {
-                    "entity": x["schema"],
+                    "entity": x["schema"]["name"],
                     "entry": x["name"],
                 }
                 for x in entry_info["referrals"]

--- a/dashboard/tests/test_view.py
+++ b/dashboard/tests/test_view.py
@@ -1478,5 +1478,5 @@ class ViewTest(AironeViewTest):
         self.assertEqual(len(resp_data["ReferredEntity"]), 1)
         referrals = resp_data["ReferredEntity"][0]["referrals"]
         self.assertEqual(len(referrals), 1)
-        self.assertEqual(referrals[0]["entity"]["name"], "entity")
+        self.assertEqual(referrals[0]["entity"], "entity")
         self.assertEqual(referrals[0]["entry"], "entry")


### PR DESCRIPTION
This PR fixes problem of YAML exported data structure of advanced search, that referral schema is not compatible with previous version.