### PR TITLE
Changed not to output if referral is not specified in search api

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -801,6 +801,7 @@ def make_search_results(
     user: User,
     res: Dict[str, Any],
     hint_attrs: List[Dict[str, str]],
+    hint_referral: Optional[str],
     limit: int,
 ) -> Dict[str, str]:
     """Acquires and returns the attribute values held by each search result
@@ -862,8 +863,10 @@ def make_search_results(
             "entity": {"id": entry.schema.id, "name": entry.schema.name},
             "entry": {"id": entry.id, "name": entry.name},
             "attrs": {},
-            "referrals": entry_info.get("referrals", []),
         }
+
+        if hint_referral is not None:
+            ret_info["referrals"] = entry_info.get("referrals", [])
 
         # Check for has permission to Entry
         if entry_info["is_readble"] or user.has_permission(entry, ACLType.Readable):

--- a/airone/tests/test_elasticsearch.py
+++ b/airone/tests/test_elasticsearch.py
@@ -358,7 +358,8 @@ class ElasticSearchTest(TestCase):
         }
 
         hint_attrs = [{"name": "test_attr", "keyword": "", "is_readble": True}]
-        results = elasticsearch.make_search_results(self._user, res, hint_attrs, 100)
+        hint_referral = ""
+        results = elasticsearch.make_search_results(self._user, res, hint_attrs, hint_referral, 100)
 
         self.assertEqual(results["ret_count"], 1)
         self.assertEqual(
@@ -382,6 +383,10 @@ class ElasticSearchTest(TestCase):
                 }
             ],
         )
+
+        hint_referral = None
+        results = elasticsearch.make_search_results(self._user, res, hint_attrs, hint_referral, 100)
+        self.assertFalse("referrals" in results["ret_values"])
 
     def test_make_search_results_for_simple(self):
         entry = Entry.objects.create(

--- a/api_v1/entry/views.py
+++ b/api_v1/entry/views.py
@@ -52,7 +52,7 @@ class EntrySearchAPI(APIView):
         hint_entities = request.data.get("entities")
         hint_entry_name = request.data.get("entry_name", "")
         hint_attrs = request.data.get("attrinfo")
-        hint_referral = request.data.get("referral", False)
+        hint_referral = request.data.get("referral")
         is_output_all = request.data.get("is_output_all", True)
         entry_limit = request.data.get("entry_limit", CONFIG_ENTRY.MAX_LIST_ENTRIES)
 
@@ -61,7 +61,7 @@ class EntrySearchAPI(APIView):
             or not isinstance(hint_entry_name, str)
             or not isinstance(hint_attrs, list)
             or not isinstance(is_output_all, bool)
-            or not isinstance(hint_referral, (str, bool))
+            or (hint_referral and not isinstance(hint_referral, str))
             or not isinstance(entry_limit, int)
         ):
             return Response(

--- a/api_v1/tests/entry/test_api.py
+++ b/api_v1/tests/entry/test_api.py
@@ -122,7 +122,6 @@ class APITest(AironeViewTest):
 
             result = resp.json()["result"]
             self.assertEqual(result["ret_count"], 2)
-            [self.assertEqual(x["referrals"], []) for x in result["ret_values"]]
 
         # send search request with 'hint_referral' parameter
         params = {

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -176,6 +176,9 @@ def export_search_result(self, job_id):
     referral_name = recv_data.get("referral_name")
     entry_name = recv_data.get("entry_name")
 
+    if has_referral and referral_name is None:
+        referral_name = ""
+
     resp = Entry.search_entries(
         user,
         recv_data["entities"],

--- a/dashboard/tests/test_view.py
+++ b/dashboard/tests/test_view.py
@@ -247,7 +247,6 @@ class ViewTest(AironeViewTest):
                     }
                 },
                 "is_readble": entry.is_public,
-                "referrals": [],
             },
         )
         self.assertEqual(resp.context["max_num"], 100)

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -178,6 +178,9 @@ def advanced_search_result(request):
     attrinfo = request.GET.get("attrinfo")
     entry_name = request.GET.get("entry_name", "")
 
+    if has_referral and referral_name is None:
+        referral_name = ""
+
     # forbid to input large size request
     if len(entry_name) > CONFIG_ENTRY.MAX_QUERY_SIZE:
         return HttpResponse("Sending parameter is too large", status=400)

--- a/entity/tests/test_view.py
+++ b/entity/tests/test_view.py
@@ -534,7 +534,6 @@ class ViewTest(AironeViewTest):
             },
         )
 
-        resp = Entry.search_entries(user, [ref_entity.id], hint_referral_entity_id=entity.id)
         params = {
             "name": "Changed-Entity",
             "note": "bar",
@@ -574,7 +573,7 @@ class ViewTest(AironeViewTest):
 
         # Check the elasticsearch data is also changed when
         # referred Entity name is changed.
-        res = Entry.search_entries(user, [ref_entity.id], is_output_all=True)
+        res = Entry.search_entries(user, [ref_entity.id], hint_referral="", is_output_all=True)
         self.assertEqual(res["ret_count"], 1)
         self.assertEqual(res["ret_values"][0]["referrals"][0]["schema"]["name"], "Changed-Entity")
 
@@ -892,7 +891,7 @@ class ViewTest(AironeViewTest):
 
         # Check the elasticsearch data (the referrals parameter) is also removed when
         # referring EntityAttr is deleted.
-        res = Entry.search_entries(user, [ref_entity.id], is_output_all=True)
+        res = Entry.search_entries(user, [ref_entity.id], hint_referral="", is_output_all=True)
         self.assertEqual(res["ret_count"], 1)
         self.assertEqual(res["ret_values"][0]["entry"]["id"], ref_entry.id)
         self.assertEqual(res["ret_values"][0]["referrals"], [])

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -188,7 +188,7 @@ class AdvancedSearchAPI(APIView):
         is_all_entities = request.data.get("is_all_entities", False)
         entry_limit = request.data.get("entry_limit", self.MAX_LIST_ENTRIES)
 
-        hint_referral = False
+        hint_referral = None
         if hint_has_referral:
             hint_referral = hint_referral_name
 
@@ -198,7 +198,7 @@ class AdvancedSearchAPI(APIView):
             or not isinstance(hint_attrs, list)
             or not isinstance(is_output_all, bool)
             or not isinstance(is_all_entities, bool)
-            or not isinstance(hint_referral, (str, bool))
+            or (hint_referral and not isinstance(hint_referral, str))
             or not isinstance(entry_limit, int)
         ):
             return Response(

--- a/entry/models.py
+++ b/entry/models.py
@@ -2106,7 +2106,7 @@ class Entry(ACLBase):
                         )
 
             # retrieve data from database on the basis of the result of elasticsearch
-            search_result = make_search_results(user, resp, hint_attrs, limit)
+            search_result = make_search_results(user, resp, hint_attrs, hint_referral, limit)
             results["ret_count"] += search_result["ret_count"]
             results["ret_values"].extend(search_result["ret_values"])
             limit -= search_result["ret_count"]

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -2720,7 +2720,11 @@ class ModelTest(AironeTestCase):
         entry = self.add_entry(user, "entry", entity, values={"attr": ref_entry0})
 
         # This checks initial es-documents of referral Entries (e0 and e1)
-        ret = Entry.search_entries(user, [ref_entity.id])
+        ret = Entry.search_entries(
+            user,
+            [ref_entity.id],
+            hint_referral="",
+        )
         self.assertEqual(ret["ret_count"], 2)
         expected_entry_info = [
             {
@@ -2747,7 +2751,11 @@ class ModelTest(AironeTestCase):
         entry.register_es()
 
         # Check es-documents after editing Entry
-        ret = Entry.search_entries(user, [ref_entity.id])
+        ret = Entry.search_entries(
+            user,
+            [ref_entity.id],
+            hint_referral="",
+        )
         for info in ret["ret_values"]:
             if info["entry"]["id"] == ref_entry0.id:
                 self.assertEqual(info["referrals"], [])
@@ -4496,7 +4504,6 @@ class ModelTest(AironeTestCase):
                 "entity": {"id": entity.id, "name": "all_attr_entity"},
                 "entry": {"id": entry.id, "name": "entry"},
                 "is_readble": True,
-                "referrals": [],
                 "attrs": {
                     "bool": {"is_readble": True, "type": AttrTypeValue["boolean"], "value": False},
                     "date": {

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -1018,7 +1018,11 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
 
         # check es-documents of both e0 (was referred before) and e2 (is referred now)
-        ret = Entry.search_entries(user, [ref_entity.id])
+        ret = Entry.search_entries(
+            user,
+            [ref_entity.id],
+            hint_referral="",
+        )
         self.assertEqual(ret["ret_count"], 3)
         for info in ret["ret_values"]:
             if info["entry"]["id"] == ref_entries[0].id:


### PR DESCRIPTION
In the previous release, EntrySearchAPI was changed to output referral.
Depending on the Entry, the number of referrals will be large.
Reverted not to output if there is no referral parameter.