### PR TITLE
Adjust action buttons for jobs being specific status

### DIFF
--- a/frontend/src/components/job/JobList.tsx
+++ b/frontend/src/components/job/JobList.tsx
@@ -187,7 +187,7 @@ export const JobList: FC<Props> = ({ jobs }) => {
                     }
                   })()}
                 </Box>
-                <Box mx="12px">
+                <Box flexGrow="1" mx="16px">
                   {![
                     JobStatuses.DONE,
                     JobStatuses.PROCESSING,
@@ -196,21 +196,23 @@ export const JobList: FC<Props> = ({ jobs }) => {
                     <Button
                       variant="contained"
                       color="error"
-                      className={classes.button}
+                      sx={{ my: "4px" }}
                       onClick={() => handleRerun(job.id)}
                     >
                       再実行
                     </Button>
                   )}
-                  {![JobStatuses.DONE, JobStatuses.CANCELED].includes(
-                    job.status
-                  ) && (
+                  {![
+                    JobStatuses.DONE,
+                    JobStatuses.ERROR,
+                    JobStatuses.CANCELED,
+                  ].includes(job.status) && (
                     <Confirmable
                       componentGenerator={(handleOpen) => (
                         <Button
                           variant="contained"
                           color="secondary"
-                          className={classes.button}
+                          sx={{ my: "4px" }}
                           onClick={handleOpen}
                         >
                           キャンセル

--- a/frontend/src/pages/__snapshots__/JobPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/JobPage.test.tsx.snap
@@ -179,10 +179,10 @@ Object {
                       </p>
                     </div>
                     <div
-                      class="MuiBox-root css-1ho43uv"
+                      class="MuiBox-root css-fu33gk"
                     >
                       <button
-                        class="MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root makeStyles-button-6 css-1sszw6i-MuiButtonBase-root-MuiButton-root"
+                        class="MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-fc0zcf-MuiButtonBase-root-MuiButton-root"
                         tabindex="0"
                         type="button"
                       >
@@ -195,7 +195,7 @@ Object {
                         class="MuiBox-root css-0"
                       >
                         <button
-                          class="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root makeStyles-button-6 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
+                          class="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-1c5ka3i-MuiButtonBase-root-MuiButton-root"
                           tabindex="0"
                           type="button"
                         >
@@ -277,7 +277,7 @@ Object {
                       </p>
                     </div>
                     <div
-                      class="MuiBox-root css-1ho43uv"
+                      class="MuiBox-root css-fu33gk"
                     />
                   </div>
                 </td>
@@ -573,10 +573,10 @@ Object {
                     </p>
                   </div>
                   <div
-                    class="MuiBox-root css-1ho43uv"
+                    class="MuiBox-root css-fu33gk"
                   >
                     <button
-                      class="MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root makeStyles-button-6 css-1sszw6i-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-fc0zcf-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
                     >
@@ -589,7 +589,7 @@ Object {
                       class="MuiBox-root css-0"
                     >
                       <button
-                        class="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root makeStyles-button-6 css-zcbmsk-MuiButtonBase-root-MuiButton-root"
+                        class="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-1c5ka3i-MuiButtonBase-root-MuiButton-root"
                         tabindex="0"
                         type="button"
                       >
@@ -671,7 +671,7 @@ Object {
                     </p>
                   </div>
                   <div
-                    class="MuiBox-root css-1ho43uv"
+                    class="MuiBox-root css-fu33gk"
                   />
                 </div>
               </td>


### PR DESCRIPTION
Remove cancel button for failed jobs on job list page, and adjust margins around those buttons.

- before 

<img width="1377" alt="image" src="https://user-images.githubusercontent.com/191684/201618935-2978471b-f44b-4a7c-a2a6-9102c74ed7c9.png">

- after

<img width="1379" alt="image" src="https://user-images.githubusercontent.com/191684/201618837-9fbdaf8d-100b-4cd0-91c8-b3d85297df9f.png">
