### PR TITLE
Fixed elasticsearch nested object count limit error

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -58,103 +58,110 @@ class ESS(Elasticsearch):
         self.indices.create(
             index=self._index,
             ignore=400,
-            body={
-                "mappings": {
-                    "properties": {
-                        "name": {
-                            "type": "text",
-                            "index": "true",
-                            "analyzer": "keyword",
-                            "fields": {
-                                "keyword": {"type": "keyword"},
-                            },
+            settings={
+                "index": {
+                    "mapping": {
+                        "nested_objects": {
+                            "limit": settings.ES_CONFIG["MAXIMUM_NESTED_OBJECT_NUM"],
+                        }
+                    }
+                }
+            },
+            mappings={
+                "properties": {
+                    "name": {
+                        "type": "text",
+                        "index": "true",
+                        "analyzer": "keyword",
+                        "fields": {
+                            "keyword": {"type": "keyword"},
                         },
-                        "referrals": {
-                            "type": "nested",
-                            "properties": {
-                                "id": {
-                                    "type": "integer",
-                                    "index": "true",
-                                },
-                                "name": {
-                                    "type": "text",
-                                    "index": "true",
-                                    "analyzer": "keyword",
-                                },
-                                "schema": {
-                                    "type": "nested",
-                                    "properties": {
-                                        "id": {
-                                            "type": "integer",
-                                            "index": "true",
-                                        },
-                                        "name": {
-                                            "type": "text",
-                                            "index": "true",
-                                            "analyzer": "keyword",
-                                        },
+                    },
+                    "referrals": {
+                        "type": "nested",
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "index": "true",
+                            },
+                            "name": {
+                                "type": "text",
+                                "index": "true",
+                                "analyzer": "keyword",
+                            },
+                            "schema": {
+                                "type": "nested",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "index": "true",
+                                    },
+                                    "name": {
+                                        "type": "text",
+                                        "index": "true",
+                                        "analyzer": "keyword",
                                     },
                                 },
                             },
                         },
-                        "entity": {
-                            "type": "nested",
-                            "properties": {
-                                "id": {
-                                    "type": "integer",
-                                    "index": "true",
-                                },
-                                "name": {
-                                    "type": "text",
-                                    "index": "true",
-                                    "analyzer": "keyword",
-                                },
+                    },
+                    "entity": {
+                        "type": "nested",
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "index": "true",
+                            },
+                            "name": {
+                                "type": "text",
+                                "index": "true",
+                                "analyzer": "keyword",
                             },
                         },
-                        "attr": {
-                            "type": "nested",
-                            "properties": {
-                                "name": {
-                                    "type": "text",
-                                    "index": "true",
-                                    "analyzer": "keyword",
-                                },
-                                "type": {
-                                    "type": "integer",
-                                    "index": "false",
-                                },
-                                "id": {
-                                    "type": "integer",
-                                    "index": "false",
-                                },
-                                "key": {
-                                    "type": "text",
-                                    "index": "true",
-                                },
-                                "date_value": {
-                                    "type": "date",
-                                    "index": "true",
-                                },
-                                "value": {
-                                    "type": "text",
-                                    "index": "true",
-                                    "analyzer": "keyword",
-                                },
-                                "referral_id": {
-                                    "type": "integer",
-                                    "index": "false",
-                                },
-                                "is_readble": {
-                                    "type": "boolean",
-                                    "index": "true",
-                                },
+                    },
+                    "attr": {
+                        "type": "nested",
+                        "properties": {
+                            "name": {
+                                "type": "text",
+                                "index": "true",
+                                "analyzer": "keyword",
+                            },
+                            "type": {
+                                "type": "integer",
+                                "index": "false",
+                            },
+                            "id": {
+                                "type": "integer",
+                                "index": "false",
+                            },
+                            "key": {
+                                "type": "text",
+                                "index": "true",
+                            },
+                            "date_value": {
+                                "type": "date",
+                                "index": "true",
+                            },
+                            "value": {
+                                "type": "text",
+                                "index": "true",
+                                "analyzer": "keyword",
+                            },
+                            "referral_id": {
+                                "type": "integer",
+                                "index": "false",
+                            },
+                            "is_readble": {
+                                "type": "boolean",
+                                "index": "true",
                             },
                         },
-                        "is_readble": {
-                            "type": "boolean",
-                            "index": "true",
-                        },
-                    }
+                    },
+                    "is_readble": {
+                        "type": "boolean",
+                        "index": "true",
+                    },
                 }
             },
         )

--- a/airone/lib/test.py
+++ b/airone/lib/test.py
@@ -19,6 +19,7 @@ from .elasticsearch import ESS
         "NODES": settings.ES_CONFIG["NODES"],
         "INDEX": "test-airone",
         "MAXIMUM_RESULTS_NUM": 10000,
+        "MAXIMUM_NESTED_OBJECT_NUM": 999999,
         "TIMEOUT": 300,
     }
 )

--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -235,6 +235,7 @@ class Common(Configuration):
         "NODES": ["localhost:9200"],
         "INDEX": "airone",
         "MAXIMUM_RESULTS_NUM": 500000,
+        "MAXIMUM_NESTED_OBJECT_NUM": 999999,
         "TIMEOUT": None,
     }
 


### PR DESCRIPTION
After upgrading Elasticsearch, an error occurred in registering some entries.
```
RequestError(400, 'mapper_parsing_exception', {'error': {'root_cause': [{'type': 'mapper_parsing_exception', 'reason': 'The number of nested documents has exceeded the allowed limit of [10000]. This limit can be set by changing the [index.mapping.nested_objects.limit] index level setting.'}], 'type': 'mapper_parsing_exception', 'reason': 'The number of nested documents has exceeded the allowed limit of [10000]. This limit can be set by changing the [index.mapping.nested_objects.limit] index level setting.'}, 'status': 400})
```

It looks like Elasticsearch7 added a limit on the number of nested objects.
https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#limit-number-nested-json-objects