### PR TITLE
Avoid triggering to update state frequently

### DIFF
--- a/frontend/src/pages/EditEntityPage.tsx
+++ b/frontend/src/pages/EditEntityPage.tsx
@@ -39,7 +39,7 @@ export const EditEntityPage: FC = () => {
     } else {
       return undefined;
     }
-  });
+  }, []);
 
   const referralEntities = useAsync(async () => {
     const entities = await aironeApiClientV2.getEntities();
@@ -130,7 +130,7 @@ export const EditEntityPage: FC = () => {
           }) ?? [],
       });
     }
-  }, [entity]);
+  }, [entity.loading, entity.value]);
 
   if (entity.loading || referralEntities.loading) {
     return <Loading />;


### PR DESCRIPTION
Edit entity page is too slow because updating a state is  frequently triggered. I set `deps` to the states not to trigger so heavy.