### PR TITLE
Specify the base Serializer if we handle it on our logic

### DIFF
--- a/entity/api_v2/views.py
+++ b/entity/api_v2/views.py
@@ -6,7 +6,7 @@ from django.http.response import HttpResponse, JsonResponse
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
-from rest_framework import filters, generics, status, viewsets
+from rest_framework import filters, generics, serializers, status, viewsets
 from rest_framework.exceptions import ValidationError
 from rest_framework.pagination import LimitOffsetPagination, PageNumberPagination
 from rest_framework.permissions import BasePermission, IsAuthenticated
@@ -204,6 +204,7 @@ class EntityHistoryAPI(viewsets.ReadOnlyModelViewSet):
 
 class EntityImportAPI(generics.GenericAPIView):
     parser_classes = [YAMLParser]
+    serializer_class = serializers.Serializer
 
     def post(self, request):
         import_datas = request.data

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -4,12 +4,11 @@ from typing import Any, Dict, List
 from django.db.models import Q
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
-from rest_framework import generics, status, viewsets
+from rest_framework import generics, serializers, status, viewsets
 from rest_framework.exceptions import NotFound
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 import custom_view
 from airone.lib.acl import ACLType
@@ -174,11 +173,13 @@ class searchAPI(viewsets.ReadOnlyModelViewSet):
         return results["ret_values"]
 
 
-class AdvancedSearchAPI(APIView):
+class AdvancedSearchAPI(generics.GenericAPIView):
     """
     NOTE for now it's just copied from /api/v1/entry/search, but it should be
     rewritten with DRF components.
     """
+
+    serializer_class = serializers.Serializer
 
     MAX_LIST_ENTRIES = 100
     MAX_QUERY_SIZE = 64
@@ -438,6 +439,7 @@ class EntryAttrReferralsAPI(viewsets.ReadOnlyModelViewSet):
 
 class EntryImportAPI(generics.GenericAPIView):
     parser_classes = [YAMLParser]
+    serializer_class = serializers.Serializer
 
     def post(self, request):
         import_datas = request.data

--- a/group/api_v2/views.py
+++ b/group/api_v2/views.py
@@ -3,10 +3,9 @@ from typing import List, TypedDict
 
 import yaml
 from django.http import HttpResponse
-from rest_framework import generics, status, viewsets
+from rest_framework import generics, serializers, status, viewsets
 from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.serializers import Serializer
 
 from airone.lib.drf import YAMLParser
 from group.api_v2.serializers import (
@@ -44,7 +43,7 @@ class GroupAPI(viewsets.ModelViewSet):
         serializer = {
             "create": GroupCreateUpdateSerializer,
             "update": GroupCreateUpdateSerializer,
-            "destroy": Serializer,
+            "destroy": serializers.Serializer,
         }
         return serializer.get(self.action, GroupSerializer)
 
@@ -58,6 +57,7 @@ class GroupTreeAPI(viewsets.ReadOnlyModelViewSet):
 class GroupImportAPI(generics.GenericAPIView):
     parser_classes = [YAMLParser]
     permission_classes = [IsAuthenticated]
+    serializer_class = serializers.Serializer
 
     def post(self, request):
         import_datas = request.data
@@ -104,6 +104,7 @@ class GroupImportAPI(generics.GenericAPIView):
 
 class GroupExportAPI(generics.RetrieveAPIView):
     permission_classes = [IsAuthenticated]
+    serializer_class = serializers.Serializer
 
     def get(self, request, *args, **kwargs):
         data: List[GroupExport] = []

--- a/role/api_v2/views.py
+++ b/role/api_v2/views.py
@@ -1,4 +1,4 @@
-from rest_framework import generics, status, viewsets
+from rest_framework import generics, serializers, status, viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -29,6 +29,7 @@ class RoleAPI(viewsets.ModelViewSet):
 class RoleImportAPI(generics.GenericAPIView):
     parser_classes = [YAMLParser]
     permission_classes = [IsAuthenticated]
+    serializer_class = serializers.Serializer
 
     def post(self, request):
         import_datas = request.data

--- a/user/api_v2/views.py
+++ b/user/api_v2/views.py
@@ -11,7 +11,7 @@ from django.template import loader
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import filters, generics, status, viewsets
+from rest_framework import filters, generics, serializers, status, viewsets
 from rest_framework.authtoken.models import Token
 from rest_framework.generics import get_object_or_404
 from rest_framework.pagination import PageNumberPagination
@@ -93,6 +93,7 @@ class UserTokenAPI(viewsets.ModelViewSet):
 class UserImportAPI(generics.GenericAPIView):
     parser_classes = [YAMLParser]
     permission_classes = [IsAuthenticated]
+    serializer_class = serializers.Serializer
 
     def post(self, request):
         import_datas = request.data
@@ -155,6 +156,7 @@ class UserImportAPI(generics.GenericAPIView):
 
 class UserExportAPI(generics.RetrieveAPIView):
     permission_classes = [IsAuthenticated]
+    serializer_class = serializers.Serializer
 
     def get(self, request, *args, **kwargs):
         data: List[UserExport] = []


### PR DESCRIPTION
To fix these errors occurred at running `npm run generate:client`

```
Error #0: EntityImportAPI: exception raised while getting serializer. Hint: Is get_serializer_class() returning None or is get_queryset() not working without a request? Ignoring the view for now. (Exception: 'EntityImportAPI' should either include a `serializer_class` attribute, or override the `get_serializer_class()` method.)
Error #1: AdvancedSearchAPI: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Ignoring view for now.
Error #2: EntryImportAPI: exception raised while getting serializer. Hint: Is get_serializer_class() returning None or is get_queryset() not working without a request? Ignoring the view for now. (Exception: 'EntryImportAPI' should either include a `serializer_class` attribute, or override the `get_serializer_class()` method.)
Error #3: GroupExportAPI: exception raised while getting serializer. Hint: Is get_serializer_class() returning None or is get_queryset() not working without a request? Ignoring the view for now. (Exception: 'GroupExportAPI' should either include a `serializer_class` attribute, or override the `get_serializer_class()` method.)
Error #4: GroupImportAPI: exception raised while getting serializer. Hint: Is get_serializer_class() returning None or is get_queryset() not working without a request? Ignoring the view for now. (Exception: 'GroupImportAPI' should either include a `serializer_class` attribute, or override the `get_serializer_class()` method.)
Error #5: RoleImportAPI: exception raised while getting serializer. Hint: Is get_serializer_class() returning None or is get_queryset() not working without a request? Ignoring the view for now. (Exception: 'RoleImportAPI' should either include a `serializer_class` attribute, or override the `get_serializer_class()` method.)
Error #6: UserExportAPI: exception raised while getting serializer. Hint: Is get_serializer_class() returning None or is get_queryset() not working without a request? Ignoring the view for now. (Exception: 'UserExportAPI' should either include a `serializer_class` attribute, or override the `get_serializer_class()` method.)
Error #7: UserImportAPI: exception raised while getting serializer. Hint: Is get_serializer_class() returning None or is get_queryset() not working without a request? Ignoring the view for now. (Exception: 'UserImportAPI' should either include a `serializer_class` attribute, or override the `get_serializer_class()` method.)

Schema generation summary:
Warnings: 0 (0 unique)
Errors:   32 (8 unique)
```