### PR TITLE
Introduce autoflake to auto-format unused imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ user@hostname:~/airone$ npm run build:custom
 ```
 user@hostname:~$ cd airone
 user@hostname:~/airone$ source virtualenv/bin/activate
+(virtualenv) user@hostname:~/airone$ autoflake .
 (virtualenv) user@hostname:~/airone$ black .
 (virtualenv) user@hostname:~/airone$ isort .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,13 @@ skip = "virtualenv, .tox"
 allow_untyped_globals = true
 follow_imports = "silent"
 ignore_missing_imports = true
+
+[tool.autoflake]
+in_place = true
+recursive = true
+imports = ["django", "requests", "urllib3"]
+exclude = ["venv", "virtualenv"]
+remove_all_unused_imports = true
+ignore_init_module_imports = true
+ignore_pass_statements = true
+ignore_pass_after_docstring = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ black
 coverage
 flake8
 isort
+autoflake
 mypy
 requests-html==0.10.0
 types-six


### PR DESCRIPTION
Introducing [autoflake](https://github.com/PyCQA/autoflake) to remove unused imports.
`black` and `isort` don't resolve unused imports. And the imports fail `pep8` CI job. I would like to auto-resolve it before the CI job detects.