### PR TITLE
Add a link to entry details page

### DIFF
--- a/frontend/src/components/entry/EntryControlMenu.tsx
+++ b/frontend/src/components/entry/EntryControlMenu.tsx
@@ -18,6 +18,7 @@ import {
   copyEntryPath,
   entityEntriesPath,
   topPath,
+  entryDetailsPath,
 } from "Routes";
 import { aironeApiClientV2 } from "apiclient/AironeApiClientV2";
 import { Confirmable } from "components/common/Confirmable";
@@ -70,6 +71,9 @@ export const EntryControlMenu: FC<EntryControlProps> = ({
       disableScrollLock
     >
       <Box sx={{ width: 150 }}>
+        <MenuItem component={Link} to={entryDetailsPath(entityId, entryId)}>
+          <Typography>詳細</Typography>
+        </MenuItem>
         <MenuItem component={Link} to={entryEditPath(entityId, entryId)}>
           <Typography>編集</Typography>
         </MenuItem>

--- a/frontend/src/pages/EntryHistoryListPage.tsx
+++ b/frontend/src/pages/EntryHistoryListPage.tsx
@@ -4,7 +4,7 @@ import React, { FC, useCallback, useMemo, useState } from "react";
 import { Link, useHistory, useLocation } from "react-router-dom";
 import { useAsync } from "react-use";
 
-import { entitiesPath, entityPath, topPath } from "../Routes";
+import { entitiesPath, entityPath, entryDetailsPath, topPath } from "../Routes";
 import { aironeApiClientV2 } from "../apiclient/AironeApiClientV2";
 import { AironeBreadcrumbs } from "../components/common/AironeBreadcrumbs";
 import { Loading } from "../components/common/Loading";
@@ -62,6 +62,14 @@ export const EntryHistoryListPage: FC = () => {
         {!entry.loading && (
           <Typography component={Link} to={entityPath(entry.value.schema.id)}>
             {entry.value.schema.name}
+          </Typography>
+        )}
+        {!entry.loading && (
+          <Typography
+            component={Link}
+            to={entryDetailsPath(entry.value.schema.id, entry.value.id)}
+          >
+            {entry.value.name}
           </Typography>
         )}
         {!entry.loading && (

--- a/frontend/src/pages/__snapshots__/EntryHistoryListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryHistoryListPage.test.tsx.snap
@@ -75,6 +75,22 @@ Object {
                   <li
                     class="MuiBreadcrumbs-li"
                   >
+                    <a
+                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                      href="/ui/entities/2/entries/1/details"
+                    >
+                      aaa
+                    </a>
+                  </li>
+                  <li
+                    aria-hidden="true"
+                    class="MuiBreadcrumbs-separator css-1wuw8dw-MuiBreadcrumbs-separator"
+                  >
+                    /
+                  </li>
+                  <li
+                    class="MuiBreadcrumbs-li"
+                  >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1gqyz35-MuiTypography-root"
                     >
@@ -316,6 +332,22 @@ Object {
                     href="/ui/entities/2"
                   >
                     bbb
+                  </a>
+                </li>
+                <li
+                  aria-hidden="true"
+                  class="MuiBreadcrumbs-separator css-1wuw8dw-MuiBreadcrumbs-separator"
+                >
+                  /
+                </li>
+                <li
+                  class="MuiBreadcrumbs-li"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                    href="/ui/entities/2/entries/1/details"
+                  >
+                    aaa
                   </a>
                 </li>
                 <li


### PR DESCRIPTION
Add a link to entry details page to make entry history page going back to the page easily.

![image](https://user-images.githubusercontent.com/191684/208573853-db551146-0d87-4ada-a178-cef225f8b0a5.png)
