### PR TITLE
Fixed a bug of Entry.search_entries() when None is passed at the user parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Fixed
 
+* Fixed a bug of Entry.search_entries() when None is passed at the user parameter.
+  Contributed by @userlocalhost
+
 ## v3.34.0
 
 ### Changed

--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -874,8 +874,12 @@ def make_search_results(
         if hint_referral is not None:
             ret_info["referrals"] = entry_info.get("referrals", [])
 
-        # Check for has permission to Entry
-        if entry_info["is_readable"] or user.has_permission(entry, ACLType.Readable):
+        # Check for has permission to Entry. But it will be omitted when user is None.
+        if (
+            entry_info["is_readable"]
+            or user is None
+            or user.has_permission(entry, ACLType.Readable)
+        ):
             ret_info["is_readable"] = True
         else:
             ret_info["is_readable"] = False

--- a/airone/lib/test.py
+++ b/airone/lib/test.py
@@ -106,8 +106,10 @@ class AironeTestCase(TestCase):
 
         return entity
 
-    def add_entry(self, user, name, schema, values={}):
-        entry = Entry.objects.create(name=name, schema=schema, created_user=user)
+    def add_entry(self, user, name, schema, values={}, is_public=True):
+        entry = Entry.objects.create(
+            name=name, schema=schema, created_user=user, is_public=is_public
+        )
         entry.complement_attrs(user)
 
         for (attrname, value) in values.items():

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -5552,3 +5552,29 @@ class ModelTest(AironeTestCase):
         attr.add_value(user, [e0])
         self.assertEqual(list(entry.get_refers_objects()), [e0])
         self.assertEqual(list(entry.get_prev_refers_objects()), [e1, e2])
+
+    def test_search_entries_without_user(self):
+        entity = self.create_entity(
+            self._user,
+            "Test Another Entity",
+            attrs=[{"name": "attr", "type": AttrTypeValue["string"]}],
+        )
+        entry = self.add_entry(
+            self._user, "Test Entry", entity, is_public=False, values={"attr": "value"}
+        )
+
+        # set permission for creating user to read
+        role = Role.objects.create(name="role")
+        role.permissions.add(entry.full)
+        role.users.add(self._user)
+
+        # Check the result of Entry.search_entries() when the 1st argument of user is None,
+        # that returns all data regardless of the permission settings.
+        search_params = {
+            "hint_entity_ids": [entity.id],
+            "hint_attrs": [{"name": "attr", "keyword": ""}],
+        }
+        self.assertEqual(
+            Entry.search_entries(self._user, **search_params),
+            Entry.search_entries(None, **search_params),
+        )


### PR DESCRIPTION
It raise an exception when None is passed to the 1st argument (user). It expects to return result that is equivalent with the case when user who is deserved with readable permission.