### PR TITLE
Autofocus at simple search box on dashboard page

### DIFF
--- a/frontend/src/components/common/SearchBox.tsx
+++ b/frontend/src/components/common/SearchBox.tsx
@@ -9,6 +9,7 @@ interface Props {
   value?: string;
   defaultValue?: string;
   inputSx?: SxProps<Theme>;
+  autoFocus?: boolean;
 }
 
 export const SearchBox: FC<Props> = ({
@@ -18,6 +19,7 @@ export const SearchBox: FC<Props> = ({
   value,
   defaultValue,
   inputSx,
+  autoFocus,
 }) => {
   return (
     <TextField
@@ -41,6 +43,7 @@ export const SearchBox: FC<Props> = ({
       value={value}
       onChange={onChange}
       onKeyPress={onKeyPress}
+      autoFocus={autoFocus}
     />
   );
 };

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -78,6 +78,7 @@ export const DashboardPage: FC = () => {
             onKeyPress={(e) => {
               e.key === "Enter" && submitQuery(e.target.value);
             }}
+            autoFocus
           />
           {entries.loading ? (
             <Loading />

--- a/frontend/src/pages/__snapshots__/DashboardPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/DashboardPage.test.tsx.snap
@@ -48,7 +48,7 @@ Object {
               class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1mw4b3-MuiFormControl-root-MuiTextField-root"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart css-8j6b76-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-adornedStart css-8j6b76-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
                   class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-ittuaa-MuiInputAdornment-root"
@@ -165,7 +165,7 @@ Object {
             class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1mw4b3-MuiFormControl-root-MuiTextField-root"
           >
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart css-8j6b76-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-adornedStart css-8j6b76-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <div
                 class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-ittuaa-MuiInputAdornment-root"


### PR DESCRIPTION
The dashboard page mainly provides simple-search feature, so `autofocus` at the text field makes usability better.
ref. https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus