### PR TITLE
Make attribute name field shorter

### DIFF
--- a/frontend/src/components/entry/EntryAttributes.tsx
+++ b/frontend/src/components/entry/EntryAttributes.tsx
@@ -40,11 +40,11 @@ export const EntryAttributes: FC<Props> = ({ attributes }) => {
         <TableBody>
           {attributes.map((attr) => (
             <StyledTableRow key={attr.schema.name}>
-              <TableCell sx={{ width: "400px", wordBreak: "break-word" }}>
+              <TableCell sx={{ width: "200px", wordBreak: "break-word" }}>
                 {attr.schema.name}
               </TableCell>
               <TableCell
-                sx={{ width: "750px", p: "0px", wordBreak: "break-word" }}
+                sx={{ width: "950px", p: "0px", wordBreak: "break-word" }}
               >
                 <AttributeValue
                   attrInfo={{ type: attr.type, value: attr.value }}


### PR DESCRIPTION
The entry attribute name field looks too long. I believe its better to see.

- before

<img width="1708" alt="image" src="https://user-images.githubusercontent.com/191684/209545650-7c28afc3-593a-499b-bcac-aefdcf482e7a.png">

- after

<img width="1713" alt="image" src="https://user-images.githubusercontent.com/191684/209545662-d5503f0f-6716-42f0-ad74-3182fce7789e.png">
