### PR TITLE
Fixed exact match search results were excluded in simple search

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -296,7 +296,7 @@ def make_query_for_simple(
         "from": offset,
     }
 
-    hint_query: Dict = {"bool": {"should": []}}
+    hint_query: Dict = {"bool": {"should": [{"match": {"name": hint_string}}]}}
     hint_query["bool"]["should"].append(_make_entry_name_query(hint_string))
     hint_query["bool"]["should"].append(_make_attr_query_for_simple(hint_string))
     query["query"]["bool"]["must"].append(hint_query)

--- a/airone/tests/test_elasticsearch.py
+++ b/airone/tests/test_elasticsearch.py
@@ -211,6 +211,7 @@ class ElasticSearchTest(TestCase):
                             {
                                 "bool": {
                                     "should": [
+                                        {"match": {"name": "hoge|fuga&1"}},
                                         {
                                             "bool": {
                                                 "should": [

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -4390,6 +4390,31 @@ class ModelTest(AironeTestCase):
         self.assertEqual(ret["ret_count"], 0)
         self.assertEqual(ret["ret_values"], [])
 
+    def test_search_entries_for_simple_with_sort(self):
+        entry = Entry.objects.create(name="[entry]", schema=self._entity, created_user=self._user)
+        entry.register_es()
+        self._entry.register_es()
+
+        ret = Entry.search_entries_for_simple("entry")
+        self.assertEqual(
+            ret,
+            {
+                "ret_count": 2,
+                "ret_values": [
+                    {
+                        "id": str(self._entry.id),
+                        "name": "entry",
+                        "schema": {"id": self._entity.id, "name": "entity"},
+                    },
+                    {
+                        "id": str(entry.id),
+                        "name": "[entry]",
+                        "schema": {"id": self._entity.id, "name": "entity"},
+                    },
+                ],
+            },
+        )
+
     def test_get_es_document(self):
         user = User.objects.create(username="hoge")
         test_group = Group.objects.create(name="test-group")


### PR DESCRIPTION
In search on TOP page, the entries are sorted by entry name.
Since the target entry may be excluded from the results,
Change to prioritize entries that exactly match entry name.