### PR TITLE
Fixed error in advanced search for all entities

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -858,7 +858,7 @@ def make_search_results(
     hit_entries = Entry.objects.filter(id__in=hit_entry_ids, is_active=True)
 
     hit_infos: Dict = {}
-    for entry in hit_entries[offset : offset + limit]:
+    for entry in hit_entries[offset : max(0, offset + limit)]:
         hit_infos[entry] = [x["_source"] for x in res["hits"]["hits"] if int(x["_id"]) == entry.id][
             0
         ]

--- a/airone/tests/test_elasticsearch.py
+++ b/airone/tests/test_elasticsearch.py
@@ -528,3 +528,8 @@ class ElasticSearchTest(TestCase):
                 key=lambda x: x["entry"]["id"],
             ),
         )
+
+        # Specify -1 for limit
+        results = elasticsearch.make_search_results(self._user, res, [], "", limit=-1, offset=0)
+        self.assertEqual(results["ret_count"], len(entries))
+        self.assertEqual(results["ret_values"], [])


### PR DESCRIPTION
If specify multiple entities in advanced search,
Limit parameters can be negative.
`Negative indexing is not supported`