### PR TITLE
Show empty string for jobs doesn't have target

### DIFF
--- a/frontend/src/utils/JobUtil.ts
+++ b/frontend/src/utils/JobUtil.ts
@@ -52,7 +52,7 @@ export const jobOperationLabel = (jobOperation: number): string => {
 
 export const jobTargetLabel = (job: JobSerializers): string => {
   return `[${jobStatusLabel(job.status)}/${jobOperationLabel(job.operation)}] ${
-    job.target.name
+    job.target?.name ?? ""
   }`;
 };
 


### PR DESCRIPTION
To avoid failing to resolve target name, like:

<img width="599" alt="image" src="https://user-images.githubusercontent.com/191684/212464490-2b7997cc-8e78-4249-a192-8c3d1532f1e5.png">
