### PR TITLE
Fixed failed frontend build

### DIFF
--- a/frontend/src/components/common/AutocompleteWithAllSelector.tsx
+++ b/frontend/src/components/common/AutocompleteWithAllSelector.tsx
@@ -104,7 +104,7 @@ export const AutocompleteWithAllSelector = <
           </li>
         );
       default:
-        return <li {...props}>{option}</li>;
+        return <li {...props}>{option as string}</li>;
     }
   };
 


### PR DESCRIPTION
Fixed the following error.
```
ERROR in ./frontend/src/components/common/AutocompleteWithAllSelector.tsx:107:31
TS2322: Type 'T' is not assignable to type 'ReactNode'.
  Type 'T' is not assignable to type 'ReactPortal'.
    105 |         );
    106 |       default:
  > 107 |         return <li {...props}>{option}</li>;
        |                               ^^^^^^^^
    108 |     }
    109 |   };
```