### PR TITLE
Filter only ancestors and others not to break group tree

### DIFF
--- a/frontend/src/components/group/GroupForm.test.tsx
+++ b/frontend/src/components/group/GroupForm.test.tsx
@@ -66,7 +66,7 @@ test("should render a component with essential props", function () {
   /* eslint-enable */
 
   expect(() =>
-    render(<GroupForm group={group} setGroup={setGroup} />, {
+    render(<GroupForm group={group} setGroup={setGroup} groupId={1} />, {
       wrapper: TestWrapper,
     })
   ).not.toThrow();

--- a/frontend/src/components/group/GroupForm.tsx
+++ b/frontend/src/components/group/GroupForm.tsx
@@ -14,6 +14,8 @@ import {
 import React, { FC, useState } from "react";
 import { useAsync } from "react-use";
 
+import { filterAncestorsAndOthers } from "../../services/group/Edit";
+
 import { GroupTreeRoot } from "./GroupTreeRoot";
 
 import { aironeApiClientV2 } from "apiclient/AironeApiClientV2";
@@ -23,9 +25,10 @@ import { Loading } from "components/common/Loading";
 interface Props {
   group: Group;
   setGroup: (group: Group) => void;
+  groupId?: number;
 }
 
-export const GroupForm: FC<Props> = ({ group, setGroup }) => {
+export const GroupForm: FC<Props> = ({ group, setGroup, groupId }) => {
   const [userKeyword, setUserKeyword] = useState("");
 
   const users = useAsync(async () => {
@@ -36,9 +39,13 @@ export const GroupForm: FC<Props> = ({ group, setGroup }) => {
   }, [userKeyword]);
 
   const groupTrees = useAsync(async () => {
-    return await aironeApiClientV2.getGroupTrees();
+    const _groupTrees = await aironeApiClientV2.getGroupTrees();
+    return groupId != null
+      ? filterAncestorsAndOthers(_groupTrees, groupId)
+      : _groupTrees;
   });
 
+  console.log(groupTrees);
   return (
     <Box>
       <Table className="table table-bordered">

--- a/frontend/src/pages/EditGroupPage.tsx
+++ b/frontend/src/pages/EditGroupPage.tsx
@@ -118,7 +118,11 @@ export const EditGroupPage: FC = () => {
       </PageHeader>
 
       <Container>
-        <GroupForm group={group} setGroup={setGroup} />
+        <GroupForm
+          group={group}
+          setGroup={setGroup}
+          groupId={Number(groupId)}
+        />
       </Container>
 
       <Prompt

--- a/frontend/src/services/group/Edit.test.ts
+++ b/frontend/src/services/group/Edit.test.ts
@@ -1,0 +1,116 @@
+import { GroupTree } from "../../apiclient/AironeApiClientV2";
+
+import { filterAncestorsAndOthers } from "./Edit";
+
+test("filterAncestorsAndOthers returns group trees without specific group and their descendants", () => {
+  const groupTrees: GroupTree[] = [
+    {
+      id: 1,
+      name: "group1",
+      children: [
+        {
+          id: 11,
+          name: "group11",
+          children: [
+            {
+              id: 111,
+              name: "group111",
+              children: [],
+            },
+          ],
+        },
+        {
+          id: 12,
+          name: "group12",
+          children: [
+            {
+              id: 121,
+              name: "group121",
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 2,
+      name: "group2",
+      children: [
+        {
+          id: 21,
+          name: "group21",
+          children: [
+            {
+              id: 211,
+              name: "group211",
+              children: [],
+            },
+          ],
+        },
+        {
+          id: 22,
+          name: "group22",
+          children: [
+            {
+              id: 221,
+              name: "group221",
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+  ];
+  const targetGroupId = 11;
+
+  const actual = filterAncestorsAndOthers(groupTrees, targetGroupId);
+
+  expect(actual).toStrictEqual([
+    {
+      id: 1,
+      name: "group1",
+      children: [
+        // group(id=11) and their descendants are filtered
+        {
+          id: 12,
+          name: "group12",
+          children: [
+            {
+              id: 121,
+              name: "group121",
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 2,
+      name: "group2",
+      children: [
+        {
+          id: 21,
+          name: "group21",
+          children: [
+            {
+              id: 211,
+              name: "group211",
+              children: [],
+            },
+          ],
+        },
+        {
+          id: 22,
+          name: "group22",
+          children: [
+            {
+              id: 221,
+              name: "group221",
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+  ]);
+});

--- a/frontend/src/services/group/Edit.ts
+++ b/frontend/src/services/group/Edit.ts
@@ -1,0 +1,13 @@
+import { GroupTree } from "../../apiclient/AironeApiClientV2";
+
+export const filterAncestorsAndOthers = (
+  groupTrees: GroupTree[],
+  targetGroupId: number
+): GroupTree[] => {
+  return groupTrees
+    .filter((t) => t.id !== targetGroupId)
+    .map((t) => ({
+      ...t,
+      children: filterAncestorsAndOthers(t.children, targetGroupId),
+    }));
+};


### PR DESCRIPTION
Filter ancestors and others as selectable groups for parent group on group form because specifying such groups as a parent breaks group tree structure.

In this PR, if we have such a group tree:

<img width="469" alt="image" src="https://user-images.githubusercontent.com/191684/218262127-1612c179-07a1-4238-bbb6-8d7523540716.png">

`group100` can select only `group1` as a parent (`group100`, itself and `group1000`, a descendant are not selectable).

<img width="1194" alt="image" src="https://user-images.githubusercontent.com/191684/218262147-a3333eb0-7bd3-4c49-8bc3-a79207e56288.png">
