### PR TITLE
Fixed entry history API for openapi generator

### DIFF
--- a/entry/api_v2/urls.py
+++ b/entry/api_v2/urls.py
@@ -41,7 +41,7 @@ urlpatterns = [
         "<int:pk>/histories/",
         views.EntryAPI.as_view(
             {
-                "get": "histories",
+                "get": "list",
             }
         ),
     ),

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -51,7 +51,7 @@ class EntryPermission(BasePermission):
             "destroy": ACLType.Writable,
             "restore": ACLType.Writable,
             "copy": ACLType.Writable,
-            "histories": ACLType.Readable,
+            "list": ACLType.Readable,  # histories
         }
 
         if not user.has_permission(obj, permisson.get(view.action)):
@@ -70,7 +70,7 @@ class EntryAPI(viewsets.ModelViewSet):
             "retrieve": EntryRetrieveSerializer,
             "update": EntryUpdateSerializer,
             "copy": EntryCopySerializer,
-            "histories": EntryHistoryAttributeValueSerializer,
+            "list": EntryHistoryAttributeValueSerializer,
         }
         return serializer.get(self.action, EntryBaseSerializer)
 
@@ -155,7 +155,8 @@ class EntryAPI(viewsets.ModelViewSet):
 
         return Response({}, status=status.HTTP_200_OK)
 
-    def histories(self, request, pk):
+    # histories view
+    def list(self, request, pk):
         user: User = self.request.user
         entry: Entry = self.get_object()
 
@@ -174,7 +175,7 @@ class EntryAPI(viewsets.ModelViewSet):
             .select_related("parent_attr")
         )
 
-        return self.list(request, pk)
+        return super(EntryAPI, self).list(request, pk)
 
 
 @extend_schema(

--- a/frontend/src/apiclient/autogenerated/.openapi-generator/FILES
+++ b/frontend/src/apiclient/autogenerated/.openapi-generator/FILES
@@ -1,4 +1,3 @@
-.openapi-generator-ignore
 apis/AclApi.ts
 apis/EntityApi.ts
 apis/EntryApi.ts


### PR DESCRIPTION
The build fails when you run generate:client.
Changed the function name because OpenAPI generator does not handle pagination unless the View function name is list.