### PR TITLE
Improve validation rules on RoleForm

### DIFF
--- a/frontend/src/components/role/RoleFormSchema.test.ts
+++ b/frontend/src/components/role/RoleFormSchema.test.ts
@@ -63,6 +63,16 @@ describe("schema", () => {
     expect(() => schema.parse(value)).toThrow();
   });
 
+  test("validation fails if both adminUsers and adminGroups are empty", () => {
+    const value = {
+      ...baseValue,
+      adminUsers: [],
+      adminGroups: [],
+    };
+
+    expect(() => schema.parse(value)).toThrow();
+  });
+
   test("validation fails if some users are also belonging to adminUsers", () => {
     const value = {
       ...baseValue,

--- a/frontend/src/components/role/RoleFormSchema.ts
+++ b/frontend/src/components/role/RoleFormSchema.ts
@@ -41,6 +41,21 @@ export const schema = schemaForType<Role>()(
       const adminUserIds = adminUsers.map((u) => u.id);
       const adminGroupIds = adminGroups.map((g) => g.id);
 
+      if (adminUserIds.length === 0 && adminGroupIds.length === 0) {
+        ctx.addIssue({
+          path: ["adminUsers"],
+          code: z.ZodIssueCode.custom,
+          message:
+            "管理者ユーザーか管理者グループのどちらかは必ずメンバーを指定してください",
+        });
+        ctx.addIssue({
+          path: ["adminGroups"],
+          code: z.ZodIssueCode.custom,
+          message:
+            "管理者ユーザーか管理者グループのどちらかは必ずメンバーを指定してください",
+        });
+      }
+
       userIds
         .flatMap((id, index) => (adminUserIds.includes(id) ? [index] : []))
         .forEach((index) => {


### PR DESCRIPTION
Add a validation rule that requires either `adminUsers` or `adminGroups` because its able to do on FE side.

<img width="1203" alt="image" src="https://user-images.githubusercontent.com/191684/220891076-53660f35-5f93-4594-ac4a-9fbfaee7a507.png">
