### PR TITLE
Fixed a bug to be able to edit Entry, Attribute and EntityAttr's ACL without Full permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Changed
 
 ### Fixed
+* Fixed a bug to be able to edit Entry, Attribute and EntityAttr's ACL without Full permission
+  Contributed by @userlocalhost
 
 ## v3.43.0
 

--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -48,41 +48,14 @@ def get_obj_with_check_perm(user, model, object_id, permission_level):
         return (None, HttpResponse("Failed to get entity of specified id", status=400))
 
     # only requests that have correct permission are executed
-    if not user.has_permission(target_obj, permission_level):
+    airone_instance = target_obj.get_subclass_object()
+    if not user.has_permission(airone_instance, permission_level):
         return (
             None,
             HttpResponse("You don't have permission to access this object", status=400),
         )
 
-    # This also checks parent permission if object is Entry, Attribute or EntityAttr
-    airone_instance = target_obj.get_subclass_object()
-    if isinstance(airone_instance, entry_models.Entry):
-        if not user.has_permission(airone_instance.schema, permission_level):
-            return (
-                None,
-                HttpResponse("You don't have permission to access this object", status=400),
-            )
-
-    elif isinstance(airone_instance, entity_models.EntityAttr):
-        if not user.has_permission(airone_instance.parent_entity, permission_level):
-            return (
-                None,
-                HttpResponse("You don't have permission to access this object", status=400),
-            )
-
-    elif isinstance(airone_instance, entry_models.Attribute):
-        if (
-            not user.has_permission(airone_instance.parent_entry, permission_level)
-            or not user.has_permission(airone_instance.parent_entry.schema, permission_level)
-            or not user.has_permission(airone_instance.schema, permission_level)
-            or not user.has_permission(airone_instance.schema.parent_entity, permission_level)
-        ):
-            return (
-                None,
-                HttpResponse("You don't have permission to access this object", status=400),
-            )
-
-    return (target_obj, None)
+    return (airone_instance, None)
 
 
 def check_superuser(func):

--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -72,10 +72,12 @@ def get_obj_with_check_perm(user, model, object_id, permission_level):
             )
 
     elif isinstance(airone_instance, entry_models.Attribute):
-        if (not user.has_permission(airone_instance.parent_entry, permission_level) or
-            not user.has_permission(airone_instance.parent_entry.schema, permission_level) or
-            not user.has_permission(airone_instance.schema, permission_level) or
-            not user.has_permission(airone_instance.schema.parent_entity, permission_level)):
+        if (
+            not user.has_permission(airone_instance.parent_entry, permission_level)
+            or not user.has_permission(airone_instance.parent_entry.schema, permission_level)
+            or not user.has_permission(airone_instance.schema, permission_level)
+            or not user.has_permission(airone_instance.schema.parent_entity, permission_level)
+        ):
             return (
                 None,
                 HttpResponse("You don't have permission to access this object", status=400),

--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -11,7 +11,6 @@ from django.utils.encoding import smart_str
 
 from airone.lib.acl import ACLObjType
 from airone.lib.types import AttrTypes, AttrTypeValue
-from airone.lib.log import Logger
 from entity import models as entity_models
 from entry import models as entry_models
 from job.models import Job, JobOperation

--- a/airone/lib/test.py
+++ b/airone/lib/test.py
@@ -64,7 +64,15 @@ class AironeTestCase(TestCase):
 
         self._settings.disable()
 
-    def create_entity(self, user, name, attrs=[], webhooks=[], is_public=True, default_permission=ACLType.Nothing.id):
+    def create_entity(
+        self,
+        user,
+        name,
+        attrs=[],
+        webhooks=[],
+        is_public=True,
+        default_permission=ACLType.Nothing.id,
+    ):
         """
         This is a helper method to create Entity for test. This method has following parameters.
         * user      : describes user instance which will be registered on creating Entity
@@ -78,7 +86,9 @@ class AironeTestCase(TestCase):
           - ref : Entity that Entry can refer to
         """
 
-        entity: Entity = Entity.objects.create(name=name, created_user=user, is_public=is_public, default_permission=default_permission)
+        entity: Entity = Entity.objects.create(
+            name=name, created_user=user, is_public=is_public, default_permission=default_permission
+        )
         for index, attr_info in enumerate(attrs):
             entity_attr: EntityAttr = EntityAttr.objects.create(
                 **{

--- a/airone/lib/test.py
+++ b/airone/lib/test.py
@@ -84,7 +84,8 @@ class AironeTestCase(TestCase):
           - type : indicates type of creating EntityAttr [string by default]
           - is_mandatory : same parameter of EntityAttr [False by default]
           - is_public: same parameter of creating EntityAttr [True by default]
-          - default_permission: same parameter of creating EntityAttr [ACLType.Nothing.id by default]
+          - default_permission: same parameter of creating EntityAttr
+                                [ACLType.Nothing.id by default]
           - ref : Entity that Entry can refer to
         """
 

--- a/airone/lib/test.py
+++ b/airone/lib/test.py
@@ -83,6 +83,8 @@ class AironeTestCase(TestCase):
           - name : indicates name of creating EntityAttr
           - type : indicates type of creating EntityAttr [string by default]
           - is_mandatory : same parameter of EntityAttr [False by default]
+          - is_public: same parameter of creating EntityAttr [True by default]
+          - default_permission: same parameter of creating EntityAttr [ACLType.Nothing.id by default]
           - ref : Entity that Entry can refer to
         """
 
@@ -96,6 +98,8 @@ class AironeTestCase(TestCase):
                     "name": attr_info["name"],
                     "type": attr_info.get("type", AttrTypeValue["string"]),
                     "is_mandatory": attr_info.get("is_mandatory", False),
+                    "is_public": attr_info.get("is_public", True),
+                    "default_permission": attr_info.get("default_permission", ACLType.Nothing.id),
                     "parent_entity": entity,
                     "created_user": user,
                 }

--- a/airone/lib/test.py
+++ b/airone/lib/test.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.test import Client, TestCase, override_settings
 from pytz import timezone
 
+from airone.lib.acl import ACLType
 from airone.lib.types import AttrTypeValue
 from entity.models import Entity, EntityAttr
 from entry.models import Entry
@@ -63,7 +64,7 @@ class AironeTestCase(TestCase):
 
         self._settings.disable()
 
-    def create_entity(self, user, name, attrs=[], webhooks=[], is_public=True):
+    def create_entity(self, user, name, attrs=[], webhooks=[], is_public=True, default_permission=ACLType.Nothing.id):
         """
         This is a helper method to create Entity for test. This method has following parameters.
         * user      : describes user instance which will be registered on creating Entity
@@ -77,7 +78,7 @@ class AironeTestCase(TestCase):
           - ref : Entity that Entry can refer to
         """
 
-        entity: Entity = Entity.objects.create(name=name, created_user=user, is_public=is_public)
+        entity: Entity = Entity.objects.create(name=name, created_user=user, is_public=is_public, default_permission=default_permission)
         for index, attr_info in enumerate(attrs):
             entity_attr: EntityAttr = EntityAttr.objects.create(
                 **{

--- a/airone/tests/test_http.py
+++ b/airone/tests/test_http.py
@@ -84,7 +84,9 @@ class ViewTest(AironeViewTest):
         self.entity.save()
 
         for co_instance in [self.entityattr, self.entry, self.attr]:
-            target_obj, error = get_obj_with_check_perm(self.user, ACLBase, co_instance.id, ACLType.Full)
+            target_obj, error = get_obj_with_check_perm(
+                self.user, ACLBase, co_instance.id, ACLType.Full
+            )
             self.assertIsNone(target_obj)
             self.assertEqual(error.content, b"You don't have permission to access this object")
             self.assertEqual(error.status_code, 400)

--- a/airone/tests/test_http.py
+++ b/airone/tests/test_http.py
@@ -3,6 +3,7 @@ import unittest
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 
+from acl.models import ACLBase
 from airone.lib.acl import ACLType
 from airone.lib.http import get_obj_with_check_perm, http_get
 from airone.lib.test import AironeViewTest
@@ -76,3 +77,14 @@ class ViewTest(AironeViewTest):
         self.assertIsNone(target_obj)
         self.assertEqual(error.content, b"You don't have permission to access this object")
         self.assertEqual(error.status_code, 400)
+
+    def test_get_obj_with_check_perm_without_parent_permission(self):
+        self.entity.default_permission = ACLType.Writable.id
+        self.entity.is_public = False
+        self.entity.save()
+
+        for co_instance in [self.entityattr, self.entry, self.attr]:
+            target_obj, error = get_obj_with_check_perm(self.user, ACLBase, co_instance.id, ACLType.Full)
+            self.assertIsNone(target_obj)
+            self.assertEqual(error.content, b"You don't have permission to access this object")
+            self.assertEqual(error.status_code, 400)

--- a/entity/tests/test_model.py
+++ b/entity/tests/test_model.py
@@ -161,7 +161,7 @@ class ModelTest(TestCase):
         This checks the attribute type wouldn't be changed by specifying type.
         """
         user = self._test_user
-        entity = Entity.objects.create(name="Entity", created_user=user, is_public=False)
+        entity = Entity.objects.create(name="Entity", created_user=user)
         entity_attr = EntityAttr.objects.create(
             **{
                 "name": "attr",
@@ -192,7 +192,7 @@ class ModelTest(TestCase):
         This import EntityAttr without specifying type parameter.
         """
         user = self._test_user
-        entity = Entity.objects.create(name="Entity", created_user=user, is_public=False)
+        entity = Entity.objects.create(name="Entity", created_user=user)
         entity_attr = EntityAttr.objects.create(
             **{
                 "name": "attr",
@@ -222,7 +222,7 @@ class ModelTest(TestCase):
         This checks an attribute would be created by importing.
         """
         user = self._test_user
-        entity = Entity.objects.create(name="Entity", created_user=user, is_public=False)
+        entity = Entity.objects.create(name="Entity", created_user=user)
 
         EntityAttrResource.import_data_from_request(
             {
@@ -245,7 +245,7 @@ class ModelTest(TestCase):
         This checks an attribute wouldn't be created by importing because of luck of parameters
         """
         user = self._test_user
-        entity = Entity.objects.create(name="Entity", created_user=user, is_public=False)
+        entity = Entity.objects.create(name="Entity", created_user=user)
 
         # This processing would be failed because 'type' parameter is necessary for creating
         # a new EntityAttr instance by importing processing.

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -5219,7 +5219,14 @@ class ViewTest(AironeViewTest):
             entity = self.create_entity(
                 user,
                 "Test Another Entity %d" % index,
-                attrs=[{"name": "attr", "type": AttrTypeValue["string"], "is_public": False, "default_permission": acltype.id}],
+                attrs=[
+                    {
+                        "name": "attr",
+                        "type": AttrTypeValue["string"],
+                        "is_public": False,
+                        "default_permission": acltype.id,
+                    }
+                ],
                 is_public=True,
                 default_permission=acltype.id,
             )

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -5181,7 +5181,7 @@ class ViewTest(AironeViewTest):
 
     def test_acl_is_not_editable_when_entity_has_not_full_permission(self):
         user = self.guest_login()
-        for (index, acltype) in enumerate([ACLType.Readable, ACLType.Writable, ACLType.Nothing]):
+        for index, acltype in enumerate([ACLType.Readable, ACLType.Writable, ACLType.Nothing]):
             entity = self.create_entity(
                 user,
                 "Test Another Entity %d" % index,
@@ -5193,7 +5193,9 @@ class ViewTest(AironeViewTest):
             entry = self.add_entry(user, "TestEntry", entity)
             resp = self.client.get(reverse("entry:acl", args=[entry.id]))
             self.assertEqual(resp.status_code, 400)
-            self.assertEqual(resp.content.decode("utf-8"), "You don't have permission to access this object")
+            self.assertEqual(
+                resp.content.decode("utf-8"), "You don't have permission to access this object"
+            )
 
             # check Attribute's and EntityAttr's ACL couldn't editable
             attr = entry.attrs.last()
@@ -5201,4 +5203,6 @@ class ViewTest(AironeViewTest):
             for instance in [attr, attr.schema]:
                 resp = self.client.get(reverse("acl:index", args=[instance.id]))
                 self.assertEqual(resp.status_code, 400)
-                self.assertEqual(resp.content.decode("utf-8"), "You don't have permission to access this object")
+                self.assertEqual(
+                    resp.content.decode("utf-8"), "You don't have permission to access this object"
+                )

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -5181,7 +5181,7 @@ class ViewTest(AironeViewTest):
 
     def test_acl_is_not_editable_when_entity_has_not_full_permission(self):
         user = self.guest_login()
-        for index, acltype in enumerate([ACLType.Readable, ACLType.Writable, ACLType.Nothing]):
+        for index, acltype in enumerate([ACLType.Readable, ACLType.Writable]):
             entity = self.create_entity(
                 user,
                 "Test Another Entity %d" % index,

--- a/user/models.py
+++ b/user/models.py
@@ -92,6 +92,12 @@ class User(AbstractUser):
         ) and not self.has_permission(target_obj.schema, permission_level):
             return False
 
+        # This also checks Entity permission if object is EntityAttr
+        if (
+            isinstance(target_obj, import_module("entity.models").EntityAttr)
+        ) and not self.has_permission(target_obj.parent_entity, permission_level):
+            return False
+
         # This check processing must be set after checking superior data structure's check
         if target_obj.is_public:
             return True

--- a/user/models.py
+++ b/user/models.py
@@ -98,12 +98,10 @@ class User(AbstractUser):
             return False
 
         # Check all superior object's permission if object is Attribute
-        if (
-            isinstance(target_obj, import_module("entry.models").Attribute)
-        ) and (
-            not self.has_permission(target_obj.schema, permission_level) or
-            not self.has_permission(target_obj.schema.parent_entity, permission_level) or
-            not self.has_permission(target_obj.parent_entry, permission_level)
+        if (isinstance(target_obj, import_module("entry.models").Attribute)) and (
+            not self.has_permission(target_obj.schema, permission_level)
+            or not self.has_permission(target_obj.schema.parent_entity, permission_level)
+            or not self.has_permission(target_obj.parent_entry, permission_level)
         ):
             return False
 

--- a/user/models.py
+++ b/user/models.py
@@ -88,7 +88,6 @@ class User(AbstractUser):
         # doesn't permit, access to the children's objects are also not permitted.
         if (
             isinstance(target_obj, import_module("entry.models").Entry)
-            or isinstance(target_obj, import_module("entry.models").Attribute)
         ) and not self.has_permission(target_obj.schema, permission_level):
             return False
 
@@ -96,6 +95,16 @@ class User(AbstractUser):
         if (
             isinstance(target_obj, import_module("entity.models").EntityAttr)
         ) and not self.has_permission(target_obj.parent_entity, permission_level):
+            return False
+
+        # Check all superior object's permission if object is Attribute
+        if (
+            isinstance(target_obj, import_module("entry.models").Attribute)
+        ) and (
+            not self.has_permission(target_obj.schema, permission_level) or
+            not self.has_permission(target_obj.schema.parent_entity, permission_level) or
+            not self.has_permission(target_obj.parent_entry, permission_level)
+        ):
             return False
 
         # This check processing must be set after checking superior data structure's check


### PR DESCRIPTION
Previously there is a bug that following AirOne instance could be editable by user how doesn't have Full control permission for an Entity (e.g. Readable permission)
* Entry
* Attribute
* EntityAttr

That is because `get_obj_with_check_perm()` doesn't care about Entity's permission, but only checks specified ACLBase object's permission.

This PR fixed it by caring about hierarchical structure's permission.