### PR TITLE
Disable security feature of Elasticsearch for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,7 @@ services:
     container_name: elasticsearch
     hostname: elasticsearch
     environment:
-      transport.host: localhost
-      xpack.security.enabled: "true"
+      discovery.type: "single-node"
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
In Elasticsearch 8.0 and later, security is enabled automatically. It's necessary for production environments, but it prevents to run tests on some CI environments or development environments.

When "single-node" is specified at the "discovery.type", it ensures not to connect to other clusters. So Elasticsearch eases security when this parameter is set.
(c.f. https://www.elastic.co/guide/en/elasticsearch/reference/current/security-minimal-setup.html)

An environemnt that is created by this docker-compose.yaml assumes to be for development or test. It's reasonable to ease security on there.