### PR TITLE
Fixed connection error when rabbitmq is scaled

### DIFF
--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -31,7 +31,7 @@ class Common(Configuration):
     #: from unwanted access (see userguide/security.html)
     CELERY_ACCEPT_CONTENT = ["json"]
     CELERY_TASK_SERIALIZER = "json"
-    CELERY_BROKER_HEARTBEAT = 0
+    CELERY_BROKER_HEARTBEAT = 10
 
     ALLOWED_HOSTS = ["*"]
 


### PR DESCRIPTION
https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-broker_heartbeat

If there is no heartbeat, reconnection will not be performed and a connection error will occur.