### PR TITLE
Notify entry submit result, and make notification logic as a reusable custom hook

### DIFF
--- a/frontend/src/hooks/useFormNotification.tsx
+++ b/frontend/src/hooks/useFormNotification.tsx
@@ -1,0 +1,34 @@
+import { SnackbarKey, useSnackbar } from "notistack";
+
+interface formNotification {
+  enqueueSubmitResult: (
+    finished: boolean,
+    additionalMessage?: string
+  ) => SnackbarKey;
+}
+
+/**
+ * A hook enqueues common notification message on form page to snackbar.
+ *
+ */
+export const useFormNotification = (
+  targetName: string,
+  willCreate: boolean
+): formNotification => {
+  const { enqueueSnackbar } = useSnackbar();
+
+  const operationName = willCreate ? "作成" : "更新";
+
+  return {
+    enqueueSubmitResult: (finished: boolean, additionalMessage?: string) => {
+      return enqueueSnackbar(
+        `${targetName}の${operationName}が${
+          finished ? "完了" : "失敗"
+        }しました。${additionalMessage ?? ""}`,
+        {
+          variant: finished ? "success" : "error",
+        }
+      );
+    },
+  };
+};


### PR DESCRIPTION
- Notify errors on EntryForm via snackbar
- Make common `enqueueSnarkbar` usage a reusable custom hook `useFormNotification` to simplify `Edit*Page`'s 