### PR TITLE
Fixed edit entries when special characters are used in attribute names

### DIFF
--- a/frontend/src/components/entry/EntryForm.tsx
+++ b/frontend/src/components/entry/EntryForm.tsx
@@ -82,14 +82,14 @@ export const EntryForm: FC<EntryFormProps> = ({
             <ArrowDropDownIcon sx={{ color: "black", padding: "0 4px" }} />
           </AnchorLinkButton>
         </Box>
-        {Object.keys(entryInfo.attrs).map((attributeName) => (
-          <Box key={attributeName} m="8px">
+        {Object.entries(entryInfo.attrs).map(([attrId, attrValue]) => (
+          <Box key={attrId} m="8px">
             <AnchorLinkButton
-              href={`#attrs-${attributeName}`}
+              href={`#attrs-${attrValue.schema.name}`}
               onClick={() => setIsAnchorLink(true)}
             >
               <Typography sx={{ color: "black", padding: "0 4px" }}>
-                {attributeName}
+                {attrValue.schema.name}
               </Typography>
               <ArrowDropDownIcon sx={{ color: "black" }} />
             </AnchorLinkButton>
@@ -134,27 +134,25 @@ export const EntryForm: FC<EntryFormProps> = ({
               />
             </TableCell>
           </TableRow>
-          {Object.keys(entryInfo.attrs).map((attributeName, index) => (
-            <TableRow key={index}>
+          {Object.entries(entryInfo.attrs).map(([attrId, attrValue]) => (
+            <TableRow key={attrId}>
               <TableCell>
                 <Box display="flex" alignItems="center">
                   {/* an anchor link adjusted fixed headers etc. */}
                   <Link
-                    id={`attrs-${attributeName}`}
+                    id={`attrs-${attrValue.schema.name}`}
                     sx={{ marginTop: "-500px", paddingTop: "500px" }}
                   />
-                  <Typography flexGrow={1}>{attributeName}</Typography>
-                  {entryInfo.attrs[attributeName]?.isMandatory && (
-                    <RequiredLabel>必須</RequiredLabel>
-                  )}
+                  <Typography flexGrow={1}>{attrValue.schema.name}</Typography>
+                  {attrValue.isMandatory && <RequiredLabel>必須</RequiredLabel>}
                 </Box>
               </TableCell>
               <TableCell>
                 <AttributeValueField
                   control={control}
                   setValue={setValue}
-                  attrName={attributeName}
-                  attrInfo={entryInfo.attrs[attributeName]}
+                  attrName={attrId}
+                  attrInfo={attrValue}
                 />
               </TableCell>
             </TableRow>

--- a/frontend/src/services/entry/Edit.test.ts
+++ b/frontend/src/services/entry/Edit.test.ts
@@ -56,7 +56,7 @@ test("initializeEntryInfo should return expect value", () => {
       name: "TestEntity",
     },
     attrs: {
-      attr: {
+      2: {
         isMandatory: true,
         schema: {
           id: 2,

--- a/frontend/src/services/entry/Edit.ts
+++ b/frontend/src/services/entry/Edit.ts
@@ -1,5 +1,3 @@
-import { Schema } from "../../components/entry/entryForm/EntryFormSchema";
-
 import {
   AttributeData,
   EntityDetail,
@@ -11,6 +9,7 @@ import {
   EditableEntry,
   EditableEntryAttrs,
 } from "components/entry/entryForm/EditableEntry";
+import { Schema } from "components/entry/entryForm/EntryFormSchema";
 import { DjangoContext } from "services/DjangoContext";
 
 const djangoContext = DjangoContext.getInstance();
@@ -47,7 +46,7 @@ export function formalizeEntryInfo(
         }
 
         return [
-          attr.schema.name,
+          String(attr.schema.id),
           {
             id: attr.id,
             type: attr.type,
@@ -75,7 +74,7 @@ export function initializeEntryInfo(entity: EntityDetail): Schema {
     },
     attrs: entity.attrs
       .map((attr): [string, EditableEntryAttrs] => [
-        attr.name,
+        String(attr.id),
         {
           type: attr.type,
           isMandatory: attr.isMandatory,


### PR DESCRIPTION
There is a problem that the value cannot be updated with ReactHookForm if the EntityAttr name contains "|".
https://github.com/react-hook-form/react-hook-form/issues/5441

Changed key in ReactHookForm to id of EntityAttr.