### PR TITLE
Fixed celery trace log not output

### DIFF
--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -366,6 +366,11 @@ class Common(Configuration):
                 "level": "INFO",
                 "propagate": False,
             },
+            "celery": {
+                "handlers": ["console"],
+                "level": "INFO",
+                "propagate": True,
+            },
         },
     }
     # If log dir is not exists create it.


### PR DESCRIPTION
Worker logs were not output.
```
[2023-05-02 10:33:28,163: INFO/MainProcess] Task entry.tasks.notify_update_entry[0fd6d48b-39f0-415c-8916-1eeedca153f8] received
[2023-05-02 10:33:28,287: INFO/ForkPoolWorker-1] Task entry.tasks.notify_update_entry[0fd6d48b-39f0-415c-8916-1eeedca153f8] succeeded in 0.12122674379497766s: None
```