### PR TITLE
Hide entry attribute if user isn't allowed to show it

### DIFF
--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -87,6 +87,7 @@ class EntryAttributeType(TypedDict):
     id: Optional[int]
     type: int
     is_mandatory: bool
+    is_readable: bool
     value: EntryAttributeValue
     schema: EntityAttributeType
 
@@ -142,6 +143,7 @@ class EntryAttributeTypeSerializer(serializers.Serializer):
     id = serializers.IntegerField(allow_null=True)
     type = serializers.IntegerField()
     is_mandatory = serializers.BooleanField()
+    is_readable = serializers.BooleanField()
     value = EntryAttributeValueSerializer()
     schema = EntityAttributeTypeSerializer()
 
@@ -590,15 +592,23 @@ class EntryRetrieveSerializer(EntryBaseSerializer):
             .order_by("index")
         )
 
+        user: User = self.context["request"].user
+
         attrinfo: List[EntryAttributeType] = []
         for entity_attr in entity_attrs:
             attr = entity_attr.attr_list[0] if entity_attr.attr_list else None
-            value = get_attr_value(attr) if attr else get_default_attr_value(entity_attr.type)
+            is_readable = user.has_permission(entity_attr, ACLType.Readable)
+            value = (
+                get_attr_value(attr)
+                if attr and is_readable
+                else get_default_attr_value(entity_attr.type)
+            )
             attrinfo.append(
                 {
                     "id": attr.id if attr else None,
                     "type": entity_attr.type,
                     "is_mandatory": entity_attr.is_mandatory,
+                    "is_readable": is_readable,
                     "value": value,
                     "schema": {
                         "id": entity_attr.id,

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -129,6 +129,7 @@ class ViewTest(AironeViewTest):
                 "value": {"as_string": "hoge"},
                 "id": entry.attrs.get(schema__name="val").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="val").schema.id,
                     "name": "val",
@@ -151,6 +152,7 @@ class ViewTest(AironeViewTest):
                 },
                 "id": entry.attrs.get(schema__name="ref").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="ref").schema.id,
                     "name": "ref",
@@ -175,6 +177,7 @@ class ViewTest(AironeViewTest):
                 },
                 "id": entry.attrs.get(schema__name="name").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="name").schema.id,
                     "name": "name",
@@ -188,6 +191,7 @@ class ViewTest(AironeViewTest):
                 "value": {"as_boolean": False},
                 "id": entry.attrs.get(schema__name="bool").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="bool").schema.id,
                     "name": "bool",
@@ -201,6 +205,7 @@ class ViewTest(AironeViewTest):
                 "value": {"as_string": "2018-12-31"},
                 "id": entry.attrs.get(schema__name="date").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="date").schema.id,
                     "name": "date",
@@ -219,6 +224,7 @@ class ViewTest(AironeViewTest):
                 },
                 "id": entry.attrs.get(schema__name="group").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="group").schema.id,
                     "name": "group",
@@ -239,6 +245,7 @@ class ViewTest(AironeViewTest):
                 },
                 "id": entry.attrs.get(schema__name="groups").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="groups").schema.id,
                     "name": "groups",
@@ -257,6 +264,7 @@ class ViewTest(AironeViewTest):
                 },
                 "id": entry.attrs.get(schema__name="role").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="role").schema.id,
                     "name": "role",
@@ -277,6 +285,7 @@ class ViewTest(AironeViewTest):
                 },
                 "id": entry.attrs.get(schema__name="roles").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="roles").schema.id,
                     "name": "roles",
@@ -290,6 +299,7 @@ class ViewTest(AironeViewTest):
                 "value": {"as_string": "fuga"},
                 "id": entry.attrs.get(schema__name="text").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="text").schema.id,
                     "name": "text",
@@ -303,6 +313,7 @@ class ViewTest(AironeViewTest):
                 "value": {"as_array_string": ["foo", "bar"]},
                 "id": entry.attrs.get(schema__name="vals").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="vals").schema.id,
                     "name": "vals",
@@ -327,6 +338,7 @@ class ViewTest(AironeViewTest):
                 },
                 "id": entry.attrs.get(schema__name="refs").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="refs").schema.id,
                     "name": "refs",
@@ -363,6 +375,7 @@ class ViewTest(AironeViewTest):
                 },
                 "id": entry.attrs.get(schema__name="names").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="names").schema.id,
                     "name": "names",
@@ -376,6 +389,7 @@ class ViewTest(AironeViewTest):
                 "value": {"as_string": AttrTypeStr.DEFAULT_VALUE},
                 "id": None,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": self.entity.attrs.get(name="opt").id,
                     "name": "opt",
@@ -422,6 +436,46 @@ class ViewTest(AironeViewTest):
         entry.readable.roles.add(self.role)
         resp = self.client.get("/entry/api/v2/%d/" % entry.id)
         self.assertEqual(resp.status_code, 200)
+
+        # permission nothing entity attr
+        entity_attr = entry.attrs.get(schema__name="val").schema
+        entity_attr.is_public = False
+        entity_attr.save()
+        resp = self.client.get("/entry/api/v2/%d/" % entry.id)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            next(filter(lambda x: x["schema"]["name"] == "val", resp.json()["attrs"])),
+            {
+                "type": AttrTypeValue["string"],
+                "value": {"as_string": ""},
+                "id": entry.attrs.get(schema__name="val").id,
+                "is_mandatory": False,
+                "is_readable": False,
+                "schema": {
+                    "id": entry.attrs.get(schema__name="val").schema.id,
+                    "name": "val",
+                },
+            },
+        )
+
+        # permission readable entity attr
+        entity_attr.readable.roles.add(self.role)
+        resp = self.client.get("/entry/api/v2/%d/" % entry.id)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            next(filter(lambda x: x["schema"]["name"] == "val", resp.json()["attrs"])),
+            {
+                "type": AttrTypeValue["string"],
+                "value": {"as_string": ""},
+                "id": entry.attrs.get(schema__name="val").id,
+                "is_mandatory": False,
+                "is_readable": True,
+                "schema": {
+                    "id": entry.attrs.get(schema__name="val").schema.id,
+                    "name": "val",
+                },
+            },
+        )
 
     def test_retrieve_entry_with_invalid_param(self):
         resp = self.client.get("/entry/api/v2/%s/" % "hoge")
@@ -516,6 +570,7 @@ class ViewTest(AironeViewTest):
                 },
                 "id": entry.attrs.get(schema__name="ref").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="ref").schema.id,
                     "name": "ref",
@@ -533,6 +588,7 @@ class ViewTest(AironeViewTest):
                 },
                 "id": entry.attrs.get(schema__name="name").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="name").schema.id,
                     "name": "name",
@@ -546,6 +602,7 @@ class ViewTest(AironeViewTest):
                 "value": {"as_array_object": []},
                 "id": entry.attrs.get(schema__name="refs").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="refs").schema.id,
                     "name": "refs",
@@ -568,6 +625,7 @@ class ViewTest(AironeViewTest):
                 },
                 "id": entry.attrs.get(schema__name="names").id,
                 "is_mandatory": False,
+                "is_readable": True,
                 "schema": {
                     "id": entry.attrs.get(schema__name="names").schema.id,
                     "name": "names",

--- a/frontend/src/apiclient/autogenerated/models/EntryAttributeType.ts
+++ b/frontend/src/apiclient/autogenerated/models/EntryAttributeType.ts
@@ -52,6 +52,12 @@ export interface EntryAttributeType {
   isMandatory: boolean;
   /**
    *
+   * @type {boolean}
+   * @memberof EntryAttributeType
+   */
+  isReadable: boolean;
+  /**
+   *
    * @type {EntryAttributeValue}
    * @memberof EntryAttributeType
    */
@@ -79,6 +85,7 @@ export function EntryAttributeTypeFromJSONTyped(
     id: json["id"],
     type: json["type"],
     isMandatory: json["is_mandatory"],
+    isReadable: json["is_readable"],
     value: EntryAttributeValueFromJSON(json["value"]),
     schema: EntityAttributeTypeFromJSON(json["schema"]),
   };
@@ -97,6 +104,7 @@ export function EntryAttributeTypeToJSON(
     id: value.id,
     type: value.type,
     is_mandatory: value.isMandatory,
+    is_readable: value.isReadable,
     value: EntryAttributeValueToJSON(value.value),
     schema: EntityAttributeTypeToJSON(value.schema),
   };

--- a/frontend/src/components/entry/EntryAttributes.tsx
+++ b/frontend/src/components/entry/EntryAttributes.tsx
@@ -6,6 +6,7 @@ import {
   TableCell,
   TableRow,
   Paper,
+  Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import React, { FC } from "react";
@@ -56,9 +57,13 @@ export const EntryAttributes: FC<Props> = ({ attributes }) => {
             <StyledTableRow key={attr.schema.name}>
               <AttrNameTableCell>{attr.schema.name}</AttrNameTableCell>
               <AttrValueTableCell sx={{ p: "0px" }}>
-                <AttributeValue
-                  attrInfo={{ type: attr.type, value: attr.value }}
-                />
+                {attr.isReadable ? (
+                  <AttributeValue
+                    attrInfo={{ type: attr.type, value: attr.value }}
+                  />
+                ) : (
+                  <Typography>Permission denied.</Typography>
+                )}
               </AttrValueTableCell>
             </StyledTableRow>
           ))}

--- a/frontend/src/services/entry/Edit.test.ts
+++ b/frontend/src/services/entry/Edit.test.ts
@@ -162,6 +162,7 @@ test("formalizeEntryInfo should return expect value", () => {
         },
         type: djangoContext?.attrTypeValue.string,
         isMandatory: true,
+        isReadable: true,
         value: {
           asString: "",
         },
@@ -176,6 +177,7 @@ test("formalizeEntryInfo should return expect value", () => {
         },
         type: djangoContext?.attrTypeValue.array_string,
         isMandatory: false,
+        isReadable: true,
         value: {
           asArrayString: [],
         },
@@ -190,6 +192,7 @@ test("formalizeEntryInfo should return expect value", () => {
         },
         type: djangoContext?.attrTypeValue.array_named_object,
         isMandatory: true,
+        isReadable: true,
         value: {
           asArrayNamedObject: [],
         },


### PR DESCRIPTION
A similar change to https://github.com/dmm-com/airone/pull/794, for only entry page. Check `isReadable` that indicates user can read an attribute to determine if showing the value on the frontend.

<img width="409" alt="image" src="https://user-images.githubusercontent.com/191684/236662083-e9680cd2-43c9-4a00-95fb-beb726955cb2.png">
