### PR TITLE
Fixed not being able to add array_string in entry edit

### DIFF
--- a/frontend/src/components/entry/entryForm/EditableEntry.ts
+++ b/frontend/src/components/entry/entryForm/EditableEntry.ts
@@ -15,7 +15,7 @@ export type EditableEntryAttrValue = {
   asString?: string;
   asNamedObject?: Record<string, EditableEntryAttrValueObject | null>;
   asArrayObject?: Array<EditableEntryAttrValueObject>;
-  asArrayString?: Array<string>;
+  asArrayString?: Array<{ value: string }>;
   asArrayNamedObject?: Array<
     Record<string, EditableEntryAttrValueObject | null>
   >;

--- a/frontend/src/components/entry/entryForm/EntryFormSchema.test.ts
+++ b/frontend/src/components/entry/entryForm/EntryFormSchema.test.ts
@@ -35,7 +35,7 @@ describe("schema", () => {
           name: "array_string",
         },
         value: {
-          asArrayString: ["string"],
+          asArrayString: [{ value: "string" }],
         },
       },
       object: {

--- a/frontend/src/components/entry/entryForm/EntryFormSchema.ts
+++ b/frontend/src/components/entry/entryForm/EntryFormSchema.ts
@@ -30,7 +30,13 @@ export const schema = schemaForType<EditableEntry>()(
             value: z.object({
               asBoolean: z.boolean().default(false).optional(),
               asString: z.string().default("").optional(),
-              asArrayString: z.array(z.string()).default([""]).optional(),
+              asArrayString: z
+                .array(
+                  z.object({
+                    value: z.string(),
+                  })
+                )
+                .optional(),
               asObject: z
                 .object({
                   id: z.number(),
@@ -118,7 +124,8 @@ export const schema = schemaForType<EditableEntry>()(
                   return value.value.asString !== "";
                 case AttributeTypes.array_string.type:
                   return (
-                    value.value.asArrayString?.some((v) => v !== "") ?? false
+                    value.value.asArrayString?.some((v) => v.value !== "") ??
+                    false
                   );
                 case AttributeTypes.object.type:
                   return value.value.asObject != null;

--- a/frontend/src/components/entry/entryForm/StringAttributeValueField.tsx
+++ b/frontend/src/components/entry/entryForm/StringAttributeValueField.tsx
@@ -2,13 +2,14 @@ import AddIcon from "@mui/icons-material/Add";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import { Box, IconButton, List, ListItem, TextField } from "@mui/material";
 import React, { FC } from "react";
-import { Control, useFieldArray, useWatch, Controller } from "react-hook-form";
+import { Control, useFieldArray, Controller } from "react-hook-form";
 
 import { Schema } from "./EntryFormSchema";
 
 interface CommonProps {
   attrId: number;
   index?: number;
+  control: Control<Schema>;
 }
 
 export const StringAttributeValueField: FC<
@@ -16,32 +17,21 @@ export const StringAttributeValueField: FC<
     handleClickDeleteListItem?: (index: number) => void;
     handleClickAddListItem?: (index: number) => void;
     multiline?: boolean;
-    control: Control<Schema>;
   }
 > = ({
   attrId,
   index,
+  control,
   handleClickDeleteListItem,
   handleClickAddListItem,
   multiline,
-  control,
 }) => {
-  const value = useWatch({
-    control,
-    name:
-      index != null
-        ? `attrs.${attrId}.value.asArrayString.${index}`
-        : `attrs.${attrId}.value.asString`,
-  });
-
-  const disabledToAppend = index === 0 && value === "";
-
   return (
     <Box display="flex" width="100%">
       <Controller
         name={
           index != null
-            ? `attrs.${attrId}.value.asArrayString.${index}`
+            ? `attrs.${attrId}.value.asArrayString.${index}.value`
             : `attrs.${attrId}.value.asString`
         }
         control={control}
@@ -69,10 +59,7 @@ export const StringAttributeValueField: FC<
             </IconButton>
           )}
           {handleClickAddListItem != null && (
-            <IconButton
-              disabled={disabledToAppend}
-              onClick={() => handleClickAddListItem(index)}
-            >
+            <IconButton onClick={() => handleClickAddListItem(index)}>
               <AddIcon />
             </IconButton>
           )}
@@ -82,12 +69,10 @@ export const StringAttributeValueField: FC<
   );
 };
 
-export const ArrayStringAttributeValueField: FC<
-  CommonProps & {
-    attrValue?: Array<string>;
-    control: Control<Schema>;
-  }
-> = ({ attrId, control }) => {
+export const ArrayStringAttributeValueField: FC<CommonProps> = ({
+  attrId,
+  control,
+}) => {
   const { fields, insert, remove } = useFieldArray({
     control,
     // @ts-ignore
@@ -97,7 +82,7 @@ export const ArrayStringAttributeValueField: FC<
   const handleClickAddListItem = (index: number) => {
     // TODO fix the type error; its misrecognizing the type of fields as object-like type
     // @ts-ignore
-    insert(index + 1, "");
+    insert(index + 1, { value: "" });
   };
 
   const handleClickDeleteListItem = (index: number) => {
@@ -109,7 +94,7 @@ export const ArrayStringAttributeValueField: FC<
     <Box>
       <List>
         {fields.map((field, index) => (
-          <ListItem key={field.id}>
+          <ListItem key={field.id} disablePadding={true}>
             <StringAttributeValueField
               control={control}
               attrId={attrId}

--- a/frontend/src/services/entry/Edit.test.ts
+++ b/frontend/src/services/entry/Edit.test.ts
@@ -575,7 +575,7 @@ test("convertAttrsFormatCtoS() returns expected value", () => {
           asArrayString: [{ value: "value" }],
         },
       },
-      expected_data: [{ value: "value" }],
+      expected_data: ["value"],
     },
     // array_object
     {

--- a/frontend/src/services/entry/Edit.test.ts
+++ b/frontend/src/services/entry/Edit.test.ts
@@ -86,7 +86,7 @@ test("formalizeEntryInfo should return expect value", () => {
           asArrayNamedObject: [{}],
           asArrayObject: [],
           asArrayRole: [],
-          asArrayString: [""],
+          asArrayString: [{ value: "" }],
           asBoolean: false,
           asGroup: undefined,
           asNamedObject: {},
@@ -108,7 +108,7 @@ test("formalizeEntryInfo should return expect value", () => {
           asArrayNamedObject: [{}],
           asArrayObject: [],
           asArrayRole: [],
-          asArrayString: [""],
+          asArrayString: [{ value: "" }],
           asBoolean: false,
           asGroup: undefined,
           asNamedObject: {},
@@ -130,7 +130,7 @@ test("formalizeEntryInfo should return expect value", () => {
           asArrayNamedObject: [{}],
           asArrayObject: [],
           asArrayRole: [],
-          asArrayString: [""],
+          asArrayString: [{ value: "" }],
           asBoolean: false,
           asGroup: undefined,
           asNamedObject: {},
@@ -228,7 +228,7 @@ test("formalizeEntryInfo should return expect value", () => {
         },
         type: 1026,
         value: {
-          asArrayString: [""],
+          asArrayString: [{ value: "" }],
         },
       },
       4: {
@@ -301,7 +301,7 @@ test("isSubmittable() returns true when entryInfo.attrs is changed", () => {
     {
       type: djangoContext?.attrTypeValue.array_string,
       value: {
-        asArrayString: ["value"],
+        asArrayString: [{ value: "value" }],
       },
     },
     // array_object
@@ -572,10 +572,10 @@ test("convertAttrsFormatCtoS() returns expected value", () => {
       client_data: {
         type: djangoContext?.attrTypeValue.array_string,
         value: {
-          asArrayString: ["value"],
+          asArrayString: [{ value: "value" }],
         },
       },
-      expected_data: ["value"],
+      expected_data: [{ value: "value" }],
     },
     // array_object
     {

--- a/frontend/src/services/entry/Edit.ts
+++ b/frontend/src/services/entry/Edit.ts
@@ -44,7 +44,7 @@ export function formalizeEntryInfo(
               asGroup: undefined,
               asRole: undefined,
               asNamedObject: {},
-              asArrayString: [""],
+              asArrayString: [{ value: "" }],
               asArrayObject: [],
               asArrayGroup: [],
               asArrayRole: [],
@@ -55,8 +55,12 @@ export function formalizeEntryInfo(
           switch (attrType) {
             case djangoContext?.attrTypeValue.array_string:
               return value?.asArrayString?.length ?? 0 > 0
-                ? value
-                : { asArrayString: [""] };
+                ? {
+                    asArrayString: value.asArrayString?.map((value) => {
+                      return { value: value };
+                    }),
+                  }
+                : { asArrayString: [{ value: "" }] };
             case djangoContext?.attrTypeValue.array_named_object:
               return value?.asArrayNamedObject?.length ?? 0 > 0
                 ? value

--- a/frontend/src/services/entry/Edit.ts
+++ b/frontend/src/services/entry/Edit.ts
@@ -142,7 +142,7 @@ export function convertAttrsFormatCtoS(
           };
 
         case djangoContext?.attrTypeValue.array_string:
-          return attrValue.asArrayString;
+          return attrValue.asArrayString?.map((x) => x.value);
 
         case djangoContext?.attrTypeValue.array_object:
           return attrValue.asArrayObject?.map((x) => x.id);


### PR DESCRIPTION
Changed to an object because useFieldArray cannot add "" as a value.

```
AsIs: ArrayString: ["aaa", "bbb"]
ToBe: ArrayString: [{value: "aaa"}, {value: "bbb"}]
```
