### PR TITLE
Hide disallowed value explicitly on advanced search result

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -891,6 +891,9 @@ def make_search_results(
             else:
                 ret_attrinfo = ret_info["attrs"][attrinfo["name"]] = {}
 
+            ret_attrinfo["is_readable"] = True
+            ret_attrinfo["type"] = attrinfo["type"]
+
             # if target attribute is array type, then values would be stored in array
             if attrinfo["name"] not in ret_info["attrs"]:
                 if attrinfo["type"] & AttrTypeValue["array"]:
@@ -917,9 +920,6 @@ def make_search_results(
                     ret_attrinfo["is_readable"] = False
                     continue
 
-            ret_attrinfo["is_readable"] = True
-
-            ret_attrinfo["type"] = attrinfo["type"]
             if (
                 attrinfo["type"] == AttrTypeValue["string"]
                 or attrinfo["type"] == AttrTypeValue["text"]

--- a/frontend/src/components/entry/SearchResults.tsx
+++ b/frontend/src/components/entry/SearchResults.tsx
@@ -48,7 +48,13 @@ const StyledTableRow = styled(TableRow)({
 
 interface Props {
   results: {
-    attrs: { [key: string]: { type: number; value: EntryAttributeValue } };
+    attrs: {
+      [key: string]: {
+        type: number;
+        value: EntryAttributeValue;
+        is_readable: boolean;
+      };
+    };
     entry: {
       id: number;
       name: string;
@@ -272,7 +278,15 @@ export const SearchResults: FC<Props> = ({
                     {(() => {
                       const info = result.attrs[attrName];
                       if (info != null) {
-                        return <AttributeValue attrInfo={info} />;
+                        return (
+                          <>
+                            {info.is_readable ? (
+                              <AttributeValue attrInfo={info} />
+                            ) : (
+                              <Typography>Permission denied.</Typography>
+                            )}
+                          </>
+                        );
                       }
                     })()}
                   </TableCell>

--- a/frontend/src/pages/AdvancedSearchResultsPage.tsx
+++ b/frontend/src/pages/AdvancedSearchResultsPage.tsx
@@ -60,7 +60,7 @@ export const AdvancedSearchResultsPage: FC = () => {
       return 0;
     }
     return Math.ceil(
-      results.value.ret_count / AdvancedSerarchResultList.MAX_ROW_COUNT
+      results.value?.ret_count ?? 0 / AdvancedSerarchResultList.MAX_ROW_COUNT
     );
   }, [results.loading, results.value?.ret_count]);
 


### PR DESCRIPTION
Hide disallowed value by entity attr explicitly on advanced search result page.
<img width="1470" alt="image" src="https://github.com/dmm-com/airone/assets/191684/90961c58-25c6-43bf-8562-c2005cf1357e">
