### PR TITLE
Fix clear_and_initdb script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 *.pyc
 __pycache__/
 local_settings.py
-db.sqlite3
 
 ### Python ###
 # Byte-compiled / optimized / DLL files
@@ -150,10 +149,6 @@ custom_view/*
 custom_view/__init__.py
 !custom_view/background
 templates/custom_view
-
-# ignores db-files for sqlite
-db.sqlite*
-*.db
 
 # ignores screenlogs
 screenlog*

--- a/tools/clear_and_initdb.sh
+++ b/tools/clear_and_initdb.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # clear the database
-for dir in `find ./ -name "migrations"`
+for dir in `find ./ -name "migrations" -maxdepth 2`
 do
   rm ${dir}/0*.py || true
 done

--- a/tools/clear_and_initdb.sh
+++ b/tools/clear_and_initdb.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 # clear the database
-rm db.sqlite3
 for dir in `find ./ -name "migrations"`
 do
   rm ${dir}/0*.py || true


### PR DESCRIPTION
- Remove sqlite3 related settings. It looks no longer used
- Focus on necessary directories on removing old migration files