### PR TITLE
Fixed an error when POST parameter is incorrect format

### DIFF
--- a/api_v1/entry/views.py
+++ b/api_v1/entry/views.py
@@ -54,6 +54,11 @@ class EntrySearchChainAPI(APIView):
 
 class EntrySearchAPI(APIView):
     def post(self, request, format=None):
+        if not isinstance(request.data, dict):
+            return Response(
+                "parameter must be in dictionary format", status=status.HTTP_400_BAD_REQUEST
+            )
+
         hint_entities = request.data.get("entities")
         hint_entry_name = request.data.get("entry_name", "")
         hint_attrs = request.data.get("attrinfo")

--- a/api_v1/tests/entry/test_api.py
+++ b/api_v1/tests/entry/test_api.py
@@ -21,6 +21,10 @@ class APITest(AironeViewTest):
             {"referral": ["hoge"]},
             {"entry_limit": "hoge"},
         ]
+        resp = self.client.post("/api/v1/entry/search", [], "application/json")
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.content, b'"parameter must be in dictionary format"')
+
         for invalid_param in invalid_params:
             params = {**valid_params, **invalid_param}
             resp = self.client.post("/api/v1/entry/search", json.dumps(params), "application/json")


### PR DESCRIPTION
There was a problem that an exception error occurred if the POST parameter was anything other than dictionary format.