### PR TITLE
Install ruff as an alternative of flake8, autoflake and isort

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,11 +66,11 @@ jobs:
             chmod +x codecov
             ./codecov -t ${CODECOV_TOKEN}
 
-  pep8:
+  staticchecks:
     docker:
       - image: cimg/python:3.8.10
     environment:
-      TOXENV: "pep8"
+      TOXENV: "staticchecks"
     steps:
       - checkout
       - run:
@@ -86,31 +86,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y libldap2-dev libsasl2-dev libxmlsec1-dev
       - run:
-          name: flake8
-          command: |
-            . virtualenv/bin/activate
-            tox
-
-  mypy:
-    docker:
-      - image: cimg/python:3.8.10
-    environment:
-      TOXENV: "mypy"
-    steps:
-      - checkout
-      - run:
-          name: Install tox tox-pyenv
-          command: |
-            python3 -m venv virtualenv
-            . virtualenv/bin/activate
-            pip install tox
-      - run:
-          name: Install additional dependencies
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y libldap2-dev libsasl2-dev libxmlsec1-dev
-      - run:
-          name: mypy
+          name: staticchecks
           command: |
             . virtualenv/bin/activate
             tox
@@ -156,9 +132,8 @@ workflows:
   build_and_test:
     jobs:
       - python38
-      - pep8
+      - staticchecks
       - frontend
-      - mypy
       - build_gh_page:
           filters:
             branches:

--- a/README.md
+++ b/README.md
@@ -302,9 +302,8 @@ user@hostname:~/airone$ npm run build:custom
 ```
 user@hostname:~$ cd airone
 user@hostname:~/airone$ source virtualenv/bin/activate
-(virtualenv) user@hostname:~/airone$ autoflake .
 (virtualenv) user@hostname:~/airone$ black .
-(virtualenv) user@hostname:~/airone$ isort .
+(virtualenv) user@hostname:~/airone$ ruff check --fix .
 
 user@hostname:~/airone$ npm run fix
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,21 @@
 [tool.black]
 line-length = 100
 
-[tool.isort]
-line_length = 100
-profile = "black"
-skip_glob = "*/migrations/*.py"
-skip = "virtualenv, .tox"
-
 [tool.mypy]
 allow_untyped_globals = true
 follow_imports = "silent"
 ignore_missing_imports = true
 
+[tool.ruff]
+# Pyflakes (F), pycodestyle (E, W), isort (I)
+select = ["E", "F", "I", "W"]
+line-length = 100
+extend-exclude = ["./*/migrations", "manage.py", "./node_modules"]
+
+[tool.ruff.per-file-ignores]
+"./airone/tests/test_elasticsearch.py" = ["E501"]
+
+# TODO remove it if ruff works well
 [tool.autoflake]
 in_place = true
 recursive = true
@@ -20,3 +24,10 @@ exclude = ["node_modules", "venv", "virtualenv"]
 remove_all_unused_imports = true
 ignore_init_module_imports = true
 ignore_pass_after_docstring = true
+
+# TODO remove it if ruff works well
+[tool.isort]
+line_length = 100
+profile = "black"
+skip_glob = "*/migrations/*.py"
+skip = "virtualenv, .tox"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ types-requests
 types-PyYAML
 types-pytz
 types-mock
+ruff

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py38, pep8, mypy
+envlist = py38, staticchecks
 skipsdist = TRUE
 
 [testenv:py38]
@@ -19,14 +19,12 @@ commands =
   coverage report
 whitelist_externals = rm
 
-[testenv:pep8]
+# TODO remove flake8, isort if ruff works well
+[testenv:staticchecks]
 commands =
   pip install -r requirements-dev.txt
   flake8
   black --check .
   isort --check .
-
-[testenv:mypy]
-commands =
-  pip install -r requirements-dev.txt
   mypy ./
+  ruff check .


### PR DESCRIPTION
There're many devtools around Python. And actually we use `flake8`, `autoflake`, `isort`, ... It helps but sometimes confuses us.

Recently a new tool `Ruff` looks great as a replacement for these tools. Its so fast, supports auto-fix feature.
https://gihyo.jp/article/2023/03/monthly-python-2303

For now I'd like to just introduce it, doesn't replace existing tools. It it works well, I will remove flake8, autoflake and isort.