### PR TITLE
Disallow blank string as entry name

### DIFF
--- a/entry/views.py
+++ b/entry/views.py
@@ -194,7 +194,11 @@ def create(request, entity_id):
 
 @http_post(
     [
-        {"name": "entry_name", "type": str, "checker": lambda x: x["entry_name"]},
+        {
+            "name": "entry_name",
+            "type": str,
+            "checker": lambda x: (x["entry_name"] and len(x["entry_name"].strip()) > 0),
+        },
         {
             "name": "attrs",
             "type": list,
@@ -281,7 +285,11 @@ def edit(request, entry_id):
 
 @http_post(
     [
-        {"name": "entry_name", "type": str, "checker": lambda x: (x["entry_name"])},
+        {
+            "name": "entry_name",
+            "type": str,
+            "checker": lambda x: (x["entry_name"] and len(x["entry_name"].strip()) > 0),
+        },
         {
             "name": "attrs",
             "type": list,

--- a/frontend/src/components/entry/entryForm/EntryFormSchema.test.ts
+++ b/frontend/src/components/entry/entryForm/EntryFormSchema.test.ts
@@ -193,6 +193,15 @@ describe("schema", () => {
     expect(() => schema.parse(value)).toThrow();
   });
 
+  test("validation fails if name has only whitespaces", () => {
+    const value = {
+      ...baseValue,
+      name: "   ",
+    };
+
+    expect(() => schema.parse(value)).toThrow();
+  });
+
   test("validation fails if string attr value is mandatory and empty", () => {
     const value = {
       ...baseValue,

--- a/frontend/src/components/entry/entryForm/EntryFormSchema.ts
+++ b/frontend/src/components/entry/entryForm/EntryFormSchema.ts
@@ -9,7 +9,7 @@ import { schemaForType } from "services/ZodSchemaUtil";
 // TODO rethink it, e.g. consider to use union as a type of value
 export const schema = schemaForType<EditableEntry>()(
   z.object({
-    name: z.string().min(1, "エントリ名は必須です").default(""),
+    name: z.string().trim().min(1, "エントリ名は必須です").default(""),
     schema: z.object({
       id: z.number(),
       name: z.string(),

--- a/templates/edit_entry/content.html
+++ b/templates/edit_entry/content.html
@@ -9,7 +9,7 @@
         <tr>
           <td>エントリ名</td>
           <td>
-            <input type="text" class="form-control" name="entry_name" value="{{ entry.name }}"/>
+            <input type="text" class="form-control" name="entry_name" pattern="^(?!\s*$).+" title="有効なエントリ名(空白のみは不許可)" value="{{ entry.name }}" required />
           {% if entry.is_deleted %}
             [削除済]
           {% elif entry.status|bitwise_and:STATUS_ENTRY.EDITING %}

--- a/templates/edit_entry/js.html
+++ b/templates/edit_entry/js.html
@@ -26,6 +26,12 @@ var get_register_attrs = function(base) {
 
 AirOneButtonUtil.initialize($('#submit-button'), gettext('button_save'),
                             gettext('button_communicating'), true, true, function(e) {
+  // ensure to pass form validation
+  if(! $('#edit-form')[0].reportValidity()) {
+    $("#submit-button").trigger('enableButton');
+    return false;
+  }
+
   $('#edit-form').submit();
 });
   


### PR DESCRIPTION
fix https://github.com/dmm-com/airone/issues/627

Deny blank as entry name on both the current UI and the new UI.

<img width="1437" alt="image" src="https://github.com/dmm-com/airone/assets/191684/19fcfe4e-9432-4fb0-8578-df38fc72f5da">

<img width="1182" alt="image" src="https://github.com/dmm-com/airone/assets/191684/b30b07a7-18fd-42a5-bf6a-8930f59f2853">
