### PR TITLE
Changed exclued field for history records

### DIFF
--- a/entity/models.py
+++ b/entity/models.py
@@ -25,7 +25,7 @@ class EntityAttr(ACLBase):
     # if this parameter set.
     is_delete_in_chain = models.BooleanField(default=False)
 
-    history = HistoricalRecords(m2m_fields=[referral])
+    history = HistoricalRecords(m2m_fields=[referral], excluded_fields=["status", "updated_time"])
 
     def __init__(self, *args, **kwargs):
         super(ACLBase, self).__init__(*args, **kwargs)
@@ -86,7 +86,7 @@ class Entity(ACLBase):
     # This indicates informatoin where to send request for notification
     webhooks = models.ManyToManyField(Webhook, default=[], related_name="registered_entity")
 
-    history = HistoricalRecords(m2m_fields=[attrs], excluded_fields=["status"])
+    history = HistoricalRecords(m2m_fields=[attrs], excluded_fields=["status", "updated_time"])
 
     def __init__(self, *args, **kwargs):
         super(Entity, self).__init__(*args, **kwargs)

--- a/entry/models.py
+++ b/entry/models.py
@@ -1294,7 +1294,7 @@ class Entry(ACLBase):
     attrs = models.ManyToManyField(Attribute)
     schema = models.ForeignKey(Entity, on_delete=models.DO_NOTHING)
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(excluded_fields=["status", "updated_time"])
 
     def __init__(self, *args, **kwargs):
         super(Entry, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Excluded attributes not needed for history.
Execute the following SQL.

```
ALTER TABLE `entity_historicalentity` DROP COLUMN `updated_time`;
ALTER TABLE `entity_historicalentityattr` DROP COLUMN `status`;
ALTER TABLE `entity_historicalentityattr` DROP COLUMN `updated_time`;
ALTER TABLE `entry_historicalentry` DROP COLUMN `status`;
ALTER TABLE `entry_historicalentry` DROP COLUMN `updated_time`;
```
