### PR TITLE
Fixed containers filling disk space in logs

### DIFF
--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -362,7 +362,7 @@ class Common(Configuration):
         },
         "loggers": {
             "airone": {
-                "handlers": ["file", "console"],
+                "handlers": ["console"],
                 "level": "INFO",
                 "propagate": False,
             },


### PR DESCRIPTION
In container environments such as k8s, logs should be output only to the console.