### PR TITLE
Enable to import objects have same name safely

### DIFF
--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -694,7 +694,7 @@ class EntryImportEntitySerializer(serializers.Serializer):
         def _convert_value_name_to_id(attr_data, entity_attrs):
             def _object(
                 val: Optional[Union[str, dict]],
-                refs: list[ACLBase],
+                refs,
             ):
                 if val:
                     # for compatibility;

--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -15,6 +15,7 @@ from airone.lib.drf import (
     RequiredParameterError,
 )
 from airone.lib.elasticsearch import FilterKey
+from airone.lib.log import Logger
 from airone.lib.types import AttrDefaultValue, AttrType, AttrTypeValue
 from entity.api_v2.serializers import EntitySerializer
 from entity.models import Entity, EntityAttr
@@ -691,10 +692,27 @@ class EntryImportEntitySerializer(serializers.Serializer):
             return params
 
         def _convert_value_name_to_id(attr_data, entity_attrs):
-            def _object(val, refs):
+            def _object(
+                val: Optional[Union[str, dict]],
+                refs: list[ACLBase],
+            ):
                 if val:
-                    ref_entry = Entry.objects.filter(name=val, schema__in=refs).first()
-                    return ref_entry.id if ref_entry else "0"
+                    # for compatibility;
+                    # it will pick wrong entry if there are multiple entries with same name
+                    if isinstance(val, str):
+                        if len(refs) >= 2:
+                            Logger.warn(
+                                "ambiguous object given: entry name(%s), entity ids(%s)",
+                                (val, refs),
+                            )
+                        ref_entry = Entry.objects.filter(name=val, schema__in=refs).first()
+                        return ref_entry.id if ref_entry else "0"
+                    # fully qualified entry, safer than above
+                    if isinstance(val, dict):
+                        ref_entry = Entry.objects.filter(
+                            name=val["name"], schema__name=val["entity"]
+                        ).first()
+                        return ref_entry.id if ref_entry else "0"
                 return None
 
             def _group(val):

--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -729,13 +729,17 @@ class EntryImportEntitySerializer(serializers.Serializer):
                     if entity_attrs[attr_data["name"]]["type"] & AttrTypeValue["named"]:
                         if not isinstance(attr_data["value"], dict):
                             return
-                        attr_data["value"] = {
-                            "name": list(attr_data["value"].keys())[0],
-                            "id": _object(
-                                list(attr_data["value"].values())[0],
-                                entity_attrs[attr_data["name"]]["refs"],
-                            ),
-                        }
+                        attr_data["value"] = (
+                            {
+                                "name": list(attr_data["value"].keys())[0],
+                                "id": _object(
+                                    list(attr_data["value"].values())[0],
+                                    entity_attrs[attr_data["name"]]["refs"],
+                                ),
+                            }
+                            if len(attr_data["value"].keys()) > 0
+                            else {}
+                        )
                     else:
                         attr_data["value"] = _object(
                             attr_data["value"], entity_attrs[attr_data["name"]]["refs"]

--- a/entry/models.py
+++ b/entry/models.py
@@ -359,16 +359,19 @@ class AttributeValue(models.Model):
 
             if type & AttrTypeValue["object"]:
                 if type & AttrTypeValue["named"]:
-                    if not isinstance(value, dict):
-                        raise Exception("value(%s) is not dict" % value)
-                    if not ("name" in value.keys() and "id" in value.keys()):
-                        raise Exception("value(%s) is not key('name', 'id')" % value)
-                    if not any(
-                        [
-                            _is_validate_attr_str(value["name"]),
-                            _is_validate_attr_object(value["id"]),
-                        ]
-                    ):
+                    if value:
+                        if not isinstance(value, dict):
+                            raise Exception("value(%s) is not dict" % value)
+                        if not ("name" in value.keys() and "id" in value.keys()):
+                            raise Exception("value(%s) is not key('name', 'id')" % value)
+                        if not any(
+                            [
+                                _is_validate_attr_str(value["name"]),
+                                _is_validate_attr_object(value["id"]),
+                            ]
+                        ):
+                            return False
+                    if is_mandatory and not value:
                         return False
                 else:
                     if not _is_validate_attr_object(value):

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -603,6 +603,7 @@ def export_entries_v2(self, job_id):
     user = job.user
     entity = Entity.objects.get(id=job.target.id)
     params = json.loads(job.params)
+    with_entity = params["export_format"] != "csv"
 
     exported_entity = []
     exported_entries = []
@@ -622,7 +623,7 @@ def export_entries_v2(self, job_id):
             return
 
         if user.has_permission(entry, ACLType.Readable):
-            exported_entries.append(entry.export_v2(user))
+            exported_entries.append(entry.export_v2(user, with_entity=with_entity))
 
         # increment loop counter
         export_item_counter += 1

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -225,8 +225,12 @@ def _do_import_entries_v2(job: Job):
         try:
             serializer.is_valid(raise_exception=True)
             serializer.save()
-        except ValidationError:
+        except ValidationError as e:
             err_msg.append(entry_data["name"])
+            Logger.warning(
+                "failed to validate on entry import v2: entry=%s, error=%s"
+                % (entry_data["name"], e)
+            )
 
     if err_msg:
         text = "Imported Entry count: %d, Failed import Entry: %s" % (total_count, err_msg)

--- a/entry/tests/fixtures/import_data_v2_with_entities.yaml
+++ b/entry/tests/fixtures/import_data_v2_with_entities.yaml
@@ -1,0 +1,45 @@
+- entity: test-entity
+  entries:
+  - name: test-entry
+    attrs:
+      - name: val
+        value: foo
+      - name: vals
+        value:
+          - foo
+      - name: ref
+        value:
+          name: r-0
+          entity: ref_entity
+      - name: refs
+        value:
+          - name: r-0
+            entity: ref_entity
+      - name: name
+        value:
+          foo:
+            name: r-0
+            entity: ref_entity
+      - name: names
+        value:
+          - foo:
+              name: r-0
+              entity: ref_entity
+      - name: group
+        value: group0
+      - name: groups
+        value:
+          - group0
+      - name: bool
+        value: True
+      - name: text
+        value: "foo
+
+bar"
+      - name: date
+        value: 2018-12-31 
+      - name: role
+        value: role0
+      - name: roles
+        value:
+          - role0


### PR DESCRIPTION
Currently the import entries by entry names. But the name will conflict with entries under the other entity.

For e.g., if we have an entry has object-like fields referring to `entry1`
```yaml
      - name: referral
        value: entry1
```
and the entity that the parent of the entry has both `entity1` and `entity` as the type of `referral`, and also both an entry under `entity1` named `entry1` and an entry under `entity1` named `entry1`. The name `entry1` in the yaml file is ambiguous, importing result of the yaml file is unstable.

To resolve the problem, I fix the yaml export format  a little to have an entity name explicitly. For e.g.
```yaml
      - name: referral
        value: 
          name: entry1
          entity: entity1
```
The yaml file specifies `entity1` as the parent of `entry1` so the importing result should be deterministic.