### PR TITLE
Use head commits on release workflow

### DIFF
--- a/.github/workflows/release-apiv2-client.yml
+++ b/.github/workflows/release-apiv2-client.yml
@@ -18,6 +18,9 @@ jobs:
     if: ${{ github.event.label.name == 'release-apiv2-client' }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: apt-get
         run: |
           sudo apt-get update


### PR DESCRIPTION
To resolve the error on https://github.com/dmm-com/airone/pull/902

> npm ERR! publish fail Update the 'version' field in package.json and try again.

https://github.com/dmm-com/airone/actions/runs/5792125637/job/15697953389?pr=902

The point indicates the workflow uses the latest code on `master` on `dmm-com/airone`, not pullreq code. So I force this workflow to refer the pullreq's on checkout step.