### PR TITLE
Enable to install dependencies with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-apiv2-client.yml
+++ b/.github/workflows/release-apiv2-client.yml
@@ -45,10 +45,12 @@ jobs:
           node-version: 16
           registry-url: https://npm.pkg.github.com/
           scope: '@dmm-com'
+      - name: install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: generate client
-        run: |
-          npm ci
-          npm run generate:client:new
+        run: npm run generate:client:new
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
It will resolve the npm-ci error on https://github.com/dmm-com/airone/pull/918.
I guess that the action runs workflows defined at `master` branch, not the feature's because of `pull_request_target` trigger. So at first we'll need to modify the workflow definition.