### PR TITLE
Show exact total number if the number exceeds 10000

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -895,6 +895,7 @@ def execute_query(query: Dict[str, str], size: int = 0) -> Dict[str, Any]:
         "body": query,
         "ignore": [404],
         "sort": ["name.keyword:asc"],
+        "track_total_hits": True,
     }
     if size and isinstance(size, int):
         kwargs["size"] = size


### PR DESCRIPTION
Current advanced search cannot show search result number 10000+ because of elasticsearch's default behavior.
https://www.elastic.co/guide/en/elasticsearch/reference/7.17/breaking-changes-7.0.html#track-total-hits-10000-default

But we want the exact total number, so it gives `track_total_hits` to get it.
For e.g.
<img width="1002" alt="image" src="https://github.com/dmm-com/airone/assets/191684/a3186a4f-5b9b-4a44-a4b9-c15e58661d03">
<img width="1145" alt="image" src="https://github.com/dmm-com/airone/assets/191684/7c9d3ce5-0049-405e-845c-6bbbb3c6dce1">
