### PR TITLE
Fixed failed generate_client

### DIFF
--- a/.github/workflows/release-apiv2-client.yml
+++ b/.github/workflows/release-apiv2-client.yml
@@ -36,11 +36,6 @@ jobs:
           source virtualenv/bin/activate
           pip install pip --upgrade
           pip install -r requirements.txt
-      # NOTE why is it needed? if missing, spectacular fails because of "no module named custom_view.api_v2"
-      - name: dummy custom_view
-        run: |
-          mkdir -p custom_view/api_v2
-          echo "urlpatterns = []" > custom_view/api_v2/urls.py
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/api_v2/urls.py
+++ b/api_v2/urls.py
@@ -7,4 +7,4 @@ urlpatterns = []
 try:
     urlpatterns.append(path("custom/", include("custom_view.api_v2.urls")))
 except ImportError as e:
-    Logger.error(e)
+    Logger.warn(e)


### PR DESCRIPTION
There was an issue where npm run generate:client would fail if a custom view was not set.
https://github.com/dmm-com/airone/blob/f3a575df9506d49418de1184135cce684edf2192/tools/generate_client.sh#L8