### PR TITLE
Paginate on ES query, not the application side

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -877,11 +877,12 @@ def _make_an_attribute_filter(hint: AttrHint, keyword: str) -> Dict[str, Dict]:
     return {"nested": {"path": "attr", "query": {"bool": {"filter": cond_attr}}}}
 
 
-def execute_query(query: Dict[str, str], size: int = 0) -> Dict[str, Any]:
+def execute_query(query: Dict[str, str], size: Optional[int] = None) -> Dict[str, Any]:
     """Run a search query.
 
     Args:
         query (dict[str, str]): Search query
+        size (Optional[int]): Size of search query results
 
     Raises:
         Exception: If query execution fails, output error details.
@@ -891,14 +892,12 @@ def execute_query(query: Dict[str, str], size: int = 0) -> Dict[str, Any]:
 
     """
     kwargs = {
-        "size": settings.ES_CONFIG["MAXIMUM_RESULTS_NUM"],
+        "size": size if size else settings.ES_CONFIG["MAXIMUM_RESULTS_NUM"],
         "body": query,
         "ignore": [404],
         "sort": ["name.keyword:asc"],
         "track_total_hits": True,
     }
-    if size and isinstance(size, int):
-        kwargs["size"] = size
 
     try:
         res = ESS().search(**kwargs)

--- a/airone/tests/test_elasticsearch.py
+++ b/airone/tests/test_elasticsearch.py
@@ -457,7 +457,7 @@ class ElasticSearchTest(TestCase):
             ],
         )
 
-    def test_make_search_results_with_limit_offset(self):
+    def test_make_search_results_with_limit(self):
         entries = [
             Entry.objects.create(name="entry-%d" % i, schema=self._entity, created_user=self._user)
             for i in range(1, 16)
@@ -484,7 +484,7 @@ class ElasticSearchTest(TestCase):
         }
 
         # 1 to 10
-        results = elasticsearch.make_search_results(self._user, res, [], "", limit=10, offset=0)
+        results = elasticsearch.make_search_results(self._user, res, [], "", limit=10)
         self.assertEqual(results["ret_count"], len(entries))
         self.assertEqual(
             sorted(results["ret_values"], key=lambda x: x["entry"]["id"]),
@@ -505,31 +505,3 @@ class ElasticSearchTest(TestCase):
                 key=lambda x: x["entry"]["id"],
             ),
         )
-
-        # 11 to 15
-        results = elasticsearch.make_search_results(self._user, res, [], "", limit=10, offset=10)
-        self.assertEqual(results["ret_count"], len(entries))
-        self.assertEqual(
-            sorted(results["ret_values"], key=lambda x: x["entry"]["id"]),
-            sorted(
-                [
-                    {
-                        "entity": {
-                            "id": self._entity.id,
-                            "name": self._entity.name,
-                        },
-                        "entry": {"id": entry.id, "name": entry.name},
-                        "attrs": {},
-                        "is_readable": True,
-                        "referrals": [],
-                    }
-                    for entry in entries[10:15]
-                ],
-                key=lambda x: x["entry"]["id"],
-            ),
-        )
-
-        # Specify -1 for limit
-        results = elasticsearch.make_search_results(self._user, res, [], "", limit=-1, offset=0)
-        self.assertEqual(results["ret_count"], len(entries))
-        self.assertEqual(results["ret_values"], [])

--- a/entry/models.py
+++ b/entry/models.py
@@ -2112,8 +2112,7 @@ class Entry(ACLBase):
             )
 
             # sending request to elasticsearch with making query
-            # resp = execute_query(query, limit + offset)
-            resp = execute_query(query)
+            resp = execute_query(query, limit, offset)
 
             if "status" in resp and resp["status"] == 404:
                 continue
@@ -2136,7 +2135,11 @@ class Entry(ACLBase):
 
             # retrieve data from database on the basis of the result of elasticsearch
             search_result: AdvancedSearchResults = make_search_results(
-                user, resp, hint_attrs, hint_referral, limit, offset
+                user,
+                resp,
+                hint_attrs,
+                hint_referral,
+                limit,
             )
             results["ret_count"] += search_result["ret_count"]
             results["ret_values"].extend(search_result["ret_values"])

--- a/entry/models.py
+++ b/entry/models.py
@@ -2112,6 +2112,7 @@ class Entry(ACLBase):
             )
 
             # sending request to elasticsearch with making query
+            # resp = execute_query(query, limit + offset)
             resp = execute_query(query)
 
             if "status" in resp and resp["status"] == 404:
@@ -2150,8 +2151,8 @@ class Entry(ACLBase):
         hint_attr_value,
         hint_entity_name=None,
         exclude_entity_names=[],
-        limit=CONFIG.MAX_LIST_ENTRIES,
-        offset=0,
+        limit: int = CONFIG.MAX_LIST_ENTRIES,
+        offset: int = 0,
     ):
         """Method called from simple search.
         Returns the count and values of entries with hint_attr_value.


### PR DESCRIPTION
Currently advanced search can perform pagination, but the control is performed on the application side (mainly `airone/lib/elasticsearch.py`), not on elasticsearch query. So if we have many entries as advanced search result candidates, the performance is so heavy because airone fetches "all the results" as possible, then filter it.
To optimize it, I would switch to ES side pagination with appropriate `size` and `from` parameters. Actually I can get performance improvement as below:

## performance improvement example

### environment

- I have 10000+ entries
- ES runs on docker container with poor machine resource

### before

I set `MAXIMUM_RESULTS_NUM=1000` because the default (too large) value `500000` does not work well on my box.

<img width="824" alt="image" src="https://github.com/dmm-com/airone/assets/191684/6e7ba74c-99c0-45e0-8c73-f575ee228e92">

### after

looks better than 'before''s

<img width="790" alt="image" src="https://github.com/dmm-com/airone/assets/191684/df52fd22-2d33-4f2f-b37b-cc48679b9b7d">
