### PR TITLE
/api/v1/entry の string 型属性値で int と float を許容するように変更

### DIFF
--- a/api_v1/serializers.py
+++ b/api_v1/serializers.py
@@ -129,9 +129,12 @@ class PostEntrySerializer(serializers.Serializer):
                 return None
 
             if attr.type & AttrTypeValue["string"]:
-                if not all([isinstance(v, str)
-                            or isinstance(v, int)
-                            or isinstance(v, float) for v in value]):
+                if not all(
+                    [
+                        isinstance(v, str) or isinstance(v, int) or isinstance(v, float)
+                        for v in value
+                    ]
+                ):
                     return None
                 return value
 

--- a/api_v1/serializers.py
+++ b/api_v1/serializers.py
@@ -129,7 +129,9 @@ class PostEntrySerializer(serializers.Serializer):
                 return None
 
             if attr.type & AttrTypeValue["string"]:
-                if not all([isinstance(v, str) for v in value]):
+                if not all([isinstance(v, str)
+                            or isinstance(v, int)
+                            or isinstance(v, float) for v in value]):
                     return None
                 return value
 
@@ -155,7 +157,7 @@ class PostEntrySerializer(serializers.Serializer):
                 return [x for x in [AttributeValue.uniform_storable(v, Role) for v in value] if x]
 
         elif attr.type & AttrTypeValue["string"] or attr.type & AttrTypeValue["text"]:
-            if not isinstance(value, str):
+            if not (isinstance(value, str) or isinstance(value, int) or isinstance(value, float)):
                 return None
             return value
 

--- a/api_v1/tests/test_api.py
+++ b/api_v1/tests/test_api.py
@@ -563,9 +563,7 @@ class APITest(AironeViewTest):
         params = {
             "name": "Entry",
             "entity": entity.name,
-            "attrs": {
-                "string": 10
-            },
+            "attrs": {"string": 10},
         }
 
         resp = self.client.post("/api/v1/entry", json.dumps(params), "application/json")


### PR DESCRIPTION
/api/v1/entry API のバリデーションで string 型の属性値に数値を許容するように変更