### PR TITLE
Make advanced search result export v2 compatible with entry import v2

### DIFF
--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -168,6 +168,7 @@ def render(request, template, context={}):
             "EXPORT_V2": JobOperation.EXPORT_ENTRY_V2.value,
             "RESTORE": JobOperation.RESTORE_ENTRY.value,
             "EXPORT_SEARCH_RESULT": JobOperation.EXPORT_SEARCH_RESULT.value,
+            "EXPORT_SEARCH_RESULT_V2": JobOperation.EXPORT_SEARCH_RESULT_V2.value,
             "CREATE_ENTITY": JobOperation.CREATE_ENTITY.value,
             "EDIT_ENTITY": JobOperation.EDIT_ENTITY.value,
             "DELETE_ENTITY": JobOperation.DELETE_ENTITY.value,

--- a/api_v1/job/views.py
+++ b/api_v1/job/views.py
@@ -34,6 +34,7 @@ class JobAPI(APIView):
                 "export": JobOperation.EXPORT_ENTRY.value,
                 "export_v2": JobOperation.EXPORT_ENTRY_V2.value,
                 "export_search_result": JobOperation.EXPORT_SEARCH_RESULT.value,
+                "export_search_result_v2": JobOperation.EXPORT_SEARCH_RESULT_V2.value,
                 "restore": JobOperation.RESTORE_ENTRY.value,
                 "create_entity": JobOperation.CREATE_ENTITY.value,
                 "edit_entity": JobOperation.EDIT_ENTITY.value,

--- a/api_v1/tests/job/test_api.py
+++ b/api_v1/tests/job/test_api.py
@@ -54,6 +54,7 @@ class APITest(AironeViewTest):
                 "export": JobOperation.EXPORT_ENTRY.value,
                 "export_search_result": JobOperation.EXPORT_SEARCH_RESULT.value,
                 "export_v2": JobOperation.EXPORT_ENTRY_V2.value,
+                "export_search_result_v2": JobOperation.EXPORT_SEARCH_RESULT_V2.value,
                 "restore": JobOperation.RESTORE_ENTRY.value,
                 "create_entity": JobOperation.CREATE_ENTITY.value,
                 "edit_entity": JobOperation.EDIT_ENTITY.value,

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -1,7 +1,7 @@
 import csv
 import io
 import json
-from typing import Optional
+from typing import Any, Optional
 
 import yaml
 from django.conf import settings
@@ -13,7 +13,7 @@ from entry.models import Entry
 from job.models import Job
 
 
-def _csv_export(job, values, recv_data, has_referral):
+def _csv_export(job: Job, values, recv_data: dict, has_referral: bool) -> Optional[io.StringIO]:
     output = io.StringIO(newline="")
     writer = csv.writer(output)
 
@@ -30,7 +30,7 @@ def _csv_export(job, values, recv_data, has_referral):
 
         # Abort processing when job is canceled
         if index % Job.STATUS_CHECK_FREQUENCY == 0 and job.is_canceled():
-            return
+            return None
 
         # Append the data which specifies Entity name to which target Entry belongs
         line_data.append(entry_info["entity"]["name"])
@@ -48,7 +48,7 @@ def _csv_export(job, values, recv_data, has_referral):
             if (value is not None) and ("type" in value):
                 vtype = value["type"]
 
-            vval = None
+            vval: Any = None
             if (value is not None) and ("value" in value):
                 vval = value["value"]
 
@@ -102,9 +102,7 @@ def _csv_export(job, values, recv_data, has_referral):
     return output
 
 
-def _yaml_export(
-    job: Job, values: list[dict], recv_data: dict, has_referral: bool
-) -> Optional[io.StringIO]:
+def _yaml_export(job: Job, values, recv_data: dict, has_referral: bool) -> Optional[io.StringIO]:
     output = io.StringIO()
 
     def _get_attr_value(atype: int, value: dict):
@@ -179,9 +177,8 @@ def export_search_result(self, job_id):
 
     # Do not care whether the "has_referral" value is
     has_referral: bool = recv_data.get("has_referral", False)
-    referral_name = recv_data.get("referral_name")
-    entry_name = recv_data.get("entry_name")
-
+    referral_name: Optional[str] = recv_data.get("referral_name")
+    entry_name: Optional[str] = recv_data.get("entry_name")
     if has_referral and referral_name is None:
         referral_name = ""
 
@@ -194,10 +191,9 @@ def export_search_result(self, job_id):
         referral_name,
     )
 
-    io_stream = None
+    io_stream: Optional[io.StringIO] = None
     if recv_data["export_style"] == "yaml":
         io_stream = _yaml_export(job, resp["ret_values"], recv_data, has_referral)
-
     elif recv_data["export_style"] == "csv":
         io_stream = _csv_export(job, resp["ret_values"], recv_data, has_referral)
 

--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -1126,11 +1126,9 @@ class AdvancedSearchResultExportSerializer(serializers.Serializer):
             raise ValidationError("Same export processing is under execution")
 
         # create a job to export search result and run it
-        job = Job.new_export_search_result(
-            user,
-            **{
-                "text": "search_results.%s" % self.validated_data["export_style"],
-                "params": self.validated_data,
-            },
+        job = Job.new_export_search_result_v2(
+            user=user,
+            text="search_results.%s" % self.validated_data["export_style"],
+            params=self.validated_data,
         )
         job.run()

--- a/entry/models.py
+++ b/entry/models.py
@@ -1739,7 +1739,7 @@ class Entry(ACLBase):
 
         return {"name": self.name, "attrs": attrinfo}
 
-    def export_v2(self, user, with_entity: bool = False):
+    def export_v2(self, user, with_entity: bool = False) -> dict:
         attrinfo = []
 
         # This calling of complement_attrs is needed to take into account the case of the Attributes

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -2,7 +2,7 @@ import csv
 import io
 import json
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
 import yaml
 from django.conf import settings
@@ -281,7 +281,7 @@ def _yaml_export_v2(job: Job, values, recv_data: dict, has_referral: bool) -> Op
         else:
             return value
 
-    resp_data: list[dict] = []
+    resp_data: List[dict] = []
     for index, entry_info in enumerate(values):
         data: dict = {
             "name": entry_info["entry"]["name"],

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -21,10 +21,8 @@ from airone.lib.types import (
     AttrTypeText,
     AttrTypeValue,
 )
-from dashboard import tasks as dashboard_tasks
 from entity.models import Entity, EntityAttr
 from entry import tasks
-from entry import tasks as entry_tasks
 from entry.models import Attribute, AttributeValue, Entry
 from entry.settings import CONFIG
 from group.models import Group
@@ -3104,8 +3102,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(attrv.value, prev_attrv.value)
 
     @patch(
-        "dashboard.tasks.export_search_result.delay",
-        Mock(side_effect=dashboard_tasks.export_search_result),
+        "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)
     )
     def test_export_advanced_search_result(self):
         user = self._create_user("admin", is_superuser=True)
@@ -3485,8 +3482,7 @@ class ViewTest(AironeViewTest):
         )
 
     @patch(
-        "dashboard.tasks.export_search_result.delay",
-        Mock(side_effect=dashboard_tasks.export_search_result),
+        "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)
     )
     def test_export_advanced_search_result_with_referral(self):
         user = self._create_user("admin", is_superuser=True)
@@ -3553,8 +3549,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(len(csv_contents), 1)
 
     @patch(
-        "dashboard.tasks.export_search_result.delay",
-        Mock(side_effect=dashboard_tasks.export_search_result),
+        "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)
     )
     def test_export_advanced_search_result_with_no_permission(self):
         admin = self._create_user("admin", is_superuser=True)
@@ -3577,12 +3572,12 @@ class ViewTest(AironeViewTest):
         )
 
         csv_contents = [x for x in Job.objects.last().get_cache().splitlines() if x]
+        self.assertEqual(len(csv_contents), 1)
         self.assertEqual(csv_contents[0], "Name,Entity,text")
-        self.assertEqual(csv_contents[1], "private,test-entity,")
+        # csv_contents[1] is omitted because of lack of permissions
 
     @patch(
-        "dashboard.tasks.export_search_result.delay",
-        Mock(side_effect=dashboard_tasks.export_search_result),
+        "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)
     )
     def test_show_advanced_search_results_csv_escape(self):
         user = self._create_user("admin", is_superuser=True)
@@ -3692,10 +3687,9 @@ class ViewTest(AironeViewTest):
             data = content.replace(header, "", 1).strip()
             self.assertEqual(data, '"%s,""ENTRY""",%s,%s' % (type_name, test_entity.name, case[2]))
 
-    @patch("entry.tasks.import_entries.delay", Mock(side_effect=entry_tasks.import_entries))
+    @patch("entry.tasks.import_entries_v2.delay", Mock(side_effect=tasks.import_entries_v2))
     @patch(
-        "dashboard.tasks.export_search_result.delay",
-        Mock(side_effect=dashboard_tasks.export_search_result),
+        "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)
     )
     def test_yaml_export(self):
         user = self.admin_login()
@@ -3912,8 +3906,7 @@ class ViewTest(AironeViewTest):
                 self.assertEqual(attrv.date, date(1999, 1, 1))
 
     @patch(
-        "dashboard.tasks.export_search_result.delay",
-        Mock(side_effect=dashboard_tasks.export_search_result),
+        "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)
     )
     def test_duplicate_export(self):
         user = self.admin_login()
@@ -3957,8 +3950,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
 
     @patch(
-        "dashboard.tasks.export_search_result.delay",
-        Mock(side_effect=dashboard_tasks.export_search_result),
+        "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)
     )
     def test_export_with_hint_entry_name(self):
         admin = self._create_user("admin", is_superuser=True)
@@ -3986,8 +3978,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual([x["name"] for x in resp_data["Entity"]], ["bar", "baz"])
 
     @patch(
-        "dashboard.tasks.export_search_result.delay",
-        Mock(side_effect=dashboard_tasks.export_search_result),
+        "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)
     )
     def test_yaml_export_with_referral(self):
         user = self._create_user("admin", is_superuser=True)
@@ -4035,8 +4026,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(referrals[0]["entry"], "entry")
 
     @patch(
-        "dashboard.tasks.export_search_result.delay",
-        Mock(side_effect=dashboard_tasks.export_search_result),
+        "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)
     )
     def test_export_advanced_search_result_with_no_value(self):
         admin = self._create_user("admin", is_superuser=True)
@@ -4116,8 +4106,7 @@ class ViewTest(AironeViewTest):
         )
 
     @patch(
-        "dashboard.tasks.export_search_result.delay",
-        Mock(side_effect=dashboard_tasks.export_search_result),
+        "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)
     )
     def test_export_with_all_entities(self):
         self.add_entry(self.user, "Entry", self.entity, values={"val": "hoge"})

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -3812,7 +3812,7 @@ class ViewTest(AironeViewTest):
                     "name": "arr_name",
                     "value": [
                         {"hoge": {"entity": "RefEntity", "name": "ref"}},
-                        {"fuga": {"entity": None, "name": ""}},
+                        {"fuga": None},
                     ],
                 },
                 {"name": "group", "value": "group"},
@@ -4062,16 +4062,16 @@ class ViewTest(AironeViewTest):
         results = [
             {"column": "val", "csv": "", "yaml": ""},
             {"column": "vals", "csv": "", "yaml": []},
-            {"column": "ref", "csv": "", "yaml": {"entity": None, "name": ""}},
+            {"column": "ref", "csv": "", "yaml": None},
             {"column": "refs", "csv": "", "yaml": []},
-            {"column": "name", "csv": ": ", "yaml": {"": {"entity": None, "name": ""}}},
+            {"column": "name", "csv": ": ", "yaml": {}},
             {"column": "names", "csv": "", "yaml": []},
-            {"column": "group", "csv": "", "yaml": ""},
+            {"column": "group", "csv": "", "yaml": None},
             {"column": "groups", "csv": "", "yaml": []},
             {"column": "bool", "csv": "False", "yaml": False},
             {"column": "text", "csv": "", "yaml": ""},
             {"column": "date", "csv": "", "yaml": None},
-            {"column": "role", "csv": "", "yaml": ""},
+            {"column": "role", "csv": "", "yaml": None},
             {"column": "roles", "csv": "", "yaml": []},
         ]
 

--- a/frontend/src/components/job/JobList.tsx
+++ b/frontend/src/components/job/JobList.tsx
@@ -229,7 +229,8 @@ export const JobList: FC<Props> = ({ jobs }) => {
             <TableCell>
               {(job.operation == JobOperations.EXPORT_ENTRY ||
                 job.operation == JobOperations.EXPORT_SEARCH_RESULT ||
-                job.operation == JobOperations.EXPORT_ENTRY_V2) &&
+                job.operation == JobOperations.EXPORT_ENTRY_V2 ||
+                job.operation == JobOperations.EXPORT_SEARCH_RESULT_V2) &&
               job.status == JobStatuses.DONE ? (
                 <MuiLink href={`/job/download/${job.id}`}>Download</MuiLink>
               ) : (

--- a/frontend/src/services/Constants.ts
+++ b/frontend/src/services/Constants.ts
@@ -124,6 +124,7 @@ export const JobStatuses = {
   CANCELED: 6,
 };
 
+// TODO manage it in the API side
 export const JobOperations = {
   CREATE_ENTRY: 1,
   EDIT_ENTRY: 2,
@@ -145,6 +146,8 @@ export const JobOperations = {
   GROUP_REGISTER_REFERRAL: 18,
   ROLE_REGISTER_REFERRAL: 19,
   EXPORT_ENTRY_V2: 20,
+  UPDATE_DOCUMENT: 21,
+  EXPORT_SEARCH_RESULT_V2: 22,
 };
 
 export const JobRefreshIntervalMilliSec = 60 * 1000;

--- a/job/api_v2/views.py
+++ b/job/api_v2/views.py
@@ -44,7 +44,9 @@ class JobListAPI(viewsets.ModelViewSet):
 
         export_operations = [
             JobOperation.EXPORT_ENTRY.value,
+            JobOperation.EXPORT_ENTRY_V2.value,
             JobOperation.EXPORT_SEARCH_RESULT.value,
+            JobOperation.EXPORT_SEARCH_RESULT_V2.value,
         ]
         query = Q(
             Q(user=user),

--- a/job/models.py
+++ b/job/models.py
@@ -48,6 +48,7 @@ class JobOperation(Enum):
     ROLE_REGISTER_REFERRAL = 19
     EXPORT_ENTRY_V2 = 20
     UPDATE_DOCUMENT = 21
+    EXPORT_SEARCH_RESULT_V2 = 22
 
 
 class Job(models.Model):
@@ -107,6 +108,7 @@ class Job(models.Model):
         JobOperation.EXPORT_ENTRY_V2.value,
         JobOperation.REGISTER_REFERRALS.value,
         JobOperation.EXPORT_SEARCH_RESULT.value,
+        JobOperation.EXPORT_SEARCH_RESULT_V2.value,
     ]
 
     PARALLELIZABLE_OPERATIONS = [
@@ -321,6 +323,7 @@ class Job(models.Model):
                 JobOperation.GROUP_REGISTER_REFERRAL.value: group_task.edit_group_referrals,
                 JobOperation.ROLE_REGISTER_REFERRAL.value: role_task.edit_role_referrals,
                 JobOperation.UPDATE_DOCUMENT.value: entry_task.update_es_documents,
+                JobOperation.EXPORT_SEARCH_RESULT_V2.value: entry_task.export_search_result_v2,
             }
 
         return kls._METHOD_TABLE
@@ -431,6 +434,16 @@ class Job(models.Model):
             user,
             target,
             JobOperation.EXPORT_SEARCH_RESULT.value,
+            text,
+            json.dumps(params, default=_support_time_default, sort_keys=True),
+        )
+
+    @classmethod
+    def new_export_search_result_v2(kls, user, target=None, text="", params={}):
+        return kls._create_new_job(
+            user,
+            target,
+            JobOperation.EXPORT_SEARCH_RESULT_V2.value,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )

--- a/job/views.py
+++ b/job/views.py
@@ -67,6 +67,7 @@ def download(request, job_id):
         JobOperation.EXPORT_ENTRY.value,
         JobOperation.EXPORT_ENTRY_V2.value,
         JobOperation.EXPORT_SEARCH_RESULT.value,
+        JobOperation.EXPORT_SEARCH_RESULT_V2.value,
     ]
     if job.operation not in export_operations:
         return HttpResponse("Target Job has no value to return", status=400)


### PR DESCRIPTION
The advanced search result export v1 outputs entry import v1 compatible data format, but v2 is not so. Its because the v2 export data format is same as v1's ...