### PR TITLE
Do not crash if refreshing jobs failed

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -124,7 +124,11 @@ export const Header: FC = () => {
   const djangoContext = DjangoContext.getInstance();
 
   useInterval(async () => {
-    setRecentJobs(await aironeApiClientV2.getRecentJobs());
+    try {
+      setRecentJobs(await aironeApiClientV2.getRecentJobs());
+    } catch (e) {
+      console.warn("failed to get recent jobs. will auto retried ...");
+    }
   }, JobRefreshIntervalMilliSec);
 
   const uncheckedJobsCount = useMemo(() => {


### PR DESCRIPTION
The recent jobs are automatically, periodically updated on background. Currently if the update failed, the new UI will crash. But I think the update process is not so critical, should keep to serve. (And I think it will occur frequently in development environment...)

After this modification, the update failures ignored:

<img width="1677" alt="image" src="https://github.com/dmm-com/airone/assets/191684/659eaf71-b566-41eb-b1b7-dfd1c9b01942">
