### PR TITLE
Refine props passed in advanced search params

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   python311:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11.5
       - image: rabbitmq:3.8.19-management
       - image: docker.elastic.co/elasticsearch/elasticsearch:7.17.6
         environment:

--- a/frontend/src/components/entry/AdvancedSearchModal.tsx
+++ b/frontend/src/components/entry/AdvancedSearchModal.tsx
@@ -58,7 +58,7 @@ export const AdvancedSearchModal: FC<Props> = ({
 
   const handleUpdatePageURL = () => {
     const params = formatAdvancedSearchParams({
-      attrFilter: Object.fromEntries(
+      attrsFilter: Object.fromEntries(
         selectedAttrNames.map((attrName) => {
           const attrInfo = attrInfos.find((info) => info.name === attrName);
           return [

--- a/frontend/src/components/entry/SearchResultControlMenu.tsx
+++ b/frontend/src/components/entry/SearchResultControlMenu.tsx
@@ -13,7 +13,7 @@ import {
 import { styled } from "@mui/material/styles";
 import React, { ChangeEvent, FC } from "react";
 
-import { AttrsFilter } from "../../services/entry/AdvancedSearch";
+import { AttrFilter } from "../../services/entry/AdvancedSearch";
 
 const StyledTextField = styled(TextField)({
   margin: "8px",
@@ -24,42 +24,33 @@ const StyledBox = styled(Box)({
 });
 
 interface Props {
-  attrName: string;
-  attrsFilter: AttrsFilter;
+  attrFilter: AttrFilter;
   anchorElem: HTMLButtonElement | null;
-  handleClose: (name: string) => void;
-  setAttrsFilter: (filter: AttrsFilter) => void;
-  handleSelectFilterConditions: (
-    attrfilter?: AttrsFilter,
-    overwriteEntryName?: string | undefined,
-    overwriteReferral?: string | undefined
-  ) => void;
+  handleUpdateAttrFilter: (filter: AttrFilter) => void;
+  handleSelectFilterConditions: (attrFilter: AttrFilter) => void;
+  handleClose: () => void;
 }
 
 export const SearchResultControlMenu: FC<Props> = ({
-  attrName,
-  attrsFilter,
+  attrFilter,
   anchorElem,
-  handleClose,
-  setAttrsFilter,
+  handleUpdateAttrFilter,
   handleSelectFilterConditions,
+  handleClose,
 }) => {
   const handleClick = (key: AdvancedSearchResultAttrInfoFilterKeyEnum) => {
     // If the selected filter is the same, remove the filter.
-    if (attrsFilter[attrName].filterKey === key) {
+    if (attrFilter.filterKey === key) {
       handleSelectFilterConditions({
-        ...attrsFilter,
-        [attrName]: {
-          ...attrsFilter[attrName],
-          filterKey: AdvancedSearchResultAttrInfoFilterKeyEnum.CLEARED,
-        },
+        ...attrFilter,
+        filterKey: AdvancedSearchResultAttrInfoFilterKeyEnum.CLEARED,
       });
       return;
     }
 
-    setAttrsFilter({
-      ...attrsFilter,
-      [attrName]: { ...attrsFilter[attrName], filterKey: key },
+    handleUpdateAttrFilter({
+      ...attrFilter,
+      filterKey: key,
     });
 
     switch (key) {
@@ -67,32 +58,27 @@ export const SearchResultControlMenu: FC<Props> = ({
       case AdvancedSearchResultAttrInfoFilterKeyEnum.EMPTY:
       case AdvancedSearchResultAttrInfoFilterKeyEnum.NON_EMPTY:
         handleSelectFilterConditions({
-          ...attrsFilter,
-          [attrName]: { ...attrsFilter[attrName], filterKey: key },
+          ...attrFilter,
+          filterKey: key,
         });
-
+        break;
       case AdvancedSearchResultAttrInfoFilterKeyEnum.CLEARED:
         handleSelectFilterConditions({
-          ...attrsFilter,
-          [attrName]: {
-            ...attrsFilter[attrName],
-            filterKey: key,
-            keyword: "",
-          },
+          ...attrFilter,
+          filterKey: key,
+          keyword: "",
         });
+        break;
     }
   };
 
   const handleChangeKeyword =
     (filterKey: AdvancedSearchResultAttrInfoFilterKeyEnum) =>
     (e: ChangeEvent<HTMLInputElement>) => {
-      setAttrsFilter({
-        ...attrsFilter,
-        [attrName]: {
-          ...attrsFilter[attrName],
-          keyword: e.target.value,
-          filterKey,
-        },
+      handleUpdateAttrFilter({
+        ...attrFilter,
+        keyword: e.target.value,
+        filterKey,
       });
     };
 
@@ -101,25 +87,20 @@ export const SearchResultControlMenu: FC<Props> = ({
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (e.key === "Enter") {
         handleSelectFilterConditions({
-          ...attrsFilter,
-          [attrName]: {
-            ...attrsFilter[attrName],
-            filterKey,
-          },
+          ...attrFilter,
+          filterKey,
         });
       }
     };
 
   const filterKey =
-    attrsFilter[attrName].filterKey ??
-    AdvancedSearchResultAttrInfoFilterKeyEnum.CLEARED;
-  const keyword = attrsFilter[attrName].keyword ?? "";
+    attrFilter.filterKey ?? AdvancedSearchResultAttrInfoFilterKeyEnum.CLEARED;
+  const keyword = attrFilter.keyword ?? "";
 
   return (
     <Menu
-      id={attrName}
       open={Boolean(anchorElem)}
-      onClose={() => handleClose(attrName)}
+      onClose={handleClose}
       anchorEl={anchorElem}
     >
       <Box pl="16px" py="8px">

--- a/frontend/src/components/entry/SearchResultControlMenuForEntry.tsx
+++ b/frontend/src/components/entry/SearchResultControlMenuForEntry.tsx
@@ -7,9 +7,7 @@ import {
   Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import React, { FC } from "react";
-
-import { AttrsFilter } from "../../services/entry/AdvancedSearch";
+import React, { ChangeEvent, Dispatch, FC, KeyboardEvent } from "react";
 
 const StyledTextField = styled(TextField)({
   margin: "8px",
@@ -23,12 +21,10 @@ interface Props {
   entryFilter: string;
   anchorElem: HTMLButtonElement | null;
   handleClose: () => void;
-  entryFilterDispatcher: any;
-  handleSelectFilterConditions: (
-    attrfilter?: AttrsFilter,
-    overwriteEntryName?: string | undefined,
-    overwriteReferral?: string | undefined
-  ) => void;
+  entryFilterDispatcher: Dispatch<
+    ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  >;
+  handleSelectFilterConditions: () => void;
   handleClear: () => void;
 }
 
@@ -40,7 +36,7 @@ export const SearchResultControlMenuForEntry: FC<Props> = ({
   handleSelectFilterConditions,
   handleClear,
 }) => {
-  const handleKeyPressKeyword = (e: any) => {
+  const handleKeyPressKeyword = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Enter") {
       handleSelectFilterConditions();
     }

--- a/frontend/src/components/entry/SearchResultControlMenuForReferral.tsx
+++ b/frontend/src/components/entry/SearchResultControlMenuForReferral.tsx
@@ -11,9 +11,9 @@ import {
   Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import React, { FC, useState } from "react";
+import React, { ChangeEvent, Dispatch, FC, useState } from "react";
 
-import { AttrsFilter } from "../../services/entry/AdvancedSearch";
+import { AttrFilter } from "../../services/entry/AdvancedSearch";
 
 const StyledTextField = styled(TextField)({
   margin: "8px",
@@ -27,9 +27,11 @@ interface Props {
   referralFilter: string;
   anchorElem: HTMLButtonElement | null;
   handleClose: () => void;
-  referralFilterDispatcher: any;
+  referralFilterDispatcher: Dispatch<
+    ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  >;
   handleSelectFilterConditions: (
-    attrfilter?: AttrsFilter,
+    attrFilter?: AttrFilter,
     overwriteEntryName?: string | undefined,
     overwriteReferral?: string | undefined
   ) => void;

--- a/frontend/src/components/entry/SearchResults.tsx
+++ b/frontend/src/components/entry/SearchResults.tsx
@@ -1,13 +1,7 @@
-import {
-  AdvancedSearchResultAttrInfoFilterKeyEnum,
-  AdvancedSearchResultValue,
-} from "@dmm-com/airone-apiclient-typescript-fetch";
-import FilterAltIcon from "@mui/icons-material/FilterAlt";
-import FilterListIcon from "@mui/icons-material/FilterList";
+import { AdvancedSearchResultValue } from "@dmm-com/airone-apiclient-typescript-fetch";
 import {
   Box,
   Checkbox,
-  IconButton,
   List,
   ListItem,
   Pagination,
@@ -17,46 +11,24 @@ import {
   TableBody,
   TableCell,
   TableContainer,
-  TableHead,
   TableRow,
   Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import React, { ChangeEvent, FC, useState, useReducer } from "react";
-import { useHistory, useLocation, Link } from "react-router-dom";
+import React, { FC, useMemo } from "react";
+import { Link } from "react-router-dom";
 
-import { SearchResultControlMenuForEntry } from "./SearchResultControlMenuForEntry";
-import { SearchResultControlMenuForReferral } from "./SearchResultControlMenuForReferral";
+import { SearchResultsTableHead } from "./SearchResultsTableHead";
 
 import { entryDetailsPath } from "Routes";
 import { AttributeValue } from "components/entry/AttributeValue";
-import { SearchResultControlMenu } from "components/entry/SearchResultControlMenu";
-import {
-  AttrFilter,
-  AttrsFilter,
-  formatAdvancedSearchParams,
-} from "services/entry/AdvancedSearch";
+import { AttrsFilter } from "services/entry/AdvancedSearch";
 
 const StyledBox = styled(Box)({
   display: "table",
   overflowX: "inherit",
   padding: "24px",
 });
-
-const HeaderBox = styled(Box)({
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "center",
-});
-
-const StyledIconButton = styled(IconButton)(({ theme }) => ({
-  color: theme.palette.primary.contrastText,
-}));
-
-const StyledTableCell = styled(TableCell)(({ theme }) => ({
-  color: theme.palette.primary.contrastText,
-  minWidth: "300px",
-}));
 
 const StyledTableRow = styled(TableRow)({
   "&:nth-of-type(odd)": {
@@ -98,193 +70,21 @@ export const SearchResults: FC<Props> = ({
   bulkOperationEntryIds,
   handleChangeBulkOperationEntryId,
 }) => {
-  const location = useLocation();
-  const history = useHistory();
-
-  const isFiltered: Record<string, boolean> = Object.fromEntries(
-    Object.keys(defaultAttrsFilter ?? {}).map((attrName: string) => {
-      const attrFilter = defaultAttrsFilter[attrName];
-      switch (attrFilter.filterKey) {
-        case AdvancedSearchResultAttrInfoFilterKeyEnum.EMPTY:
-        case AdvancedSearchResultAttrInfoFilterKeyEnum.NON_EMPTY:
-        case AdvancedSearchResultAttrInfoFilterKeyEnum.DUPLICATED:
-          return [attrName, true];
-        case AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_CONTAINED:
-          return [attrName, attrFilter.keyword !== ""];
-        case AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_NOT_CONTAINED:
-          return [attrName, attrFilter.keyword !== ""];
-      }
-      return [attrName, false];
-    })
-  );
-
-  const [entryFilter, entryFilterDispatcher] = useReducer(
-    (
-      _state: string,
-      event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-    ) => event.target.value,
-    defaultEntryFilter ?? ""
-  );
-  const [referralFilter, referralFilterDispatcher] = useReducer(
-    (
-      _state: string,
-      event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-    ) => event.target.value,
-    defaultReferralFilter ?? ""
-  );
-  const [attrsFilter, setAttrsFilter] = useState<AttrsFilter>(
-    defaultAttrsFilter ?? {}
-  );
-
-  const [attributeMenuEls, setAttributeMenuEls] = useState<{
-    [key: string]: HTMLButtonElement | null;
-  }>({});
-  const [entryMenuEls, setEntryMenuEls] = useState<HTMLButtonElement | null>(
-    null
-  );
-  const [referralMenuEls, setReferralMenuEls] =
-    useState<HTMLButtonElement | null>(null);
-
-  const handleSelectFilterConditions =
-    (attrName?: string) =>
-    (
-      attrFilter?: AttrFilter,
-      overwriteEntryName?: string,
-      overwriteReferral?: string
-    ) => {
-      const _attrsFilter =
-        attrName != null && attrFilter != null
-          ? { ...attrsFilter, [attrName]: attrFilter }
-          : attrsFilter;
-
-      const newParams = formatAdvancedSearchParams({
-        attrsFilter: _attrsFilter,
-        entryName: overwriteEntryName ?? entryFilter,
-        referralName: overwriteReferral ?? referralFilter,
-        baseParams: new URLSearchParams(location.search),
-      });
-
-      // simply reload with the new params
-      history.push({
-        pathname: location.pathname,
-        search: "?" + newParams.toString(),
-      });
-      history.go(0);
-    };
-
-  const handleUpdateAttrFilter =
-    (attrName: string) => (attrFilter: AttrFilter) => {
-      setAttrsFilter((attrsFilter) => ({
-        ...attrsFilter,
-        [attrName]: attrFilter,
-      }));
-    };
+  const attrNames = useMemo(() => {
+    return Object.keys(defaultAttrsFilter);
+  }, [defaultAttrsFilter]);
 
   return (
     <Box display="flex" flexDirection="column">
       <StyledBox>
         <TableContainer component={Paper}>
           <Table id="table_result_list">
-            <TableHead>
-              <TableRow sx={{ backgroundColor: "primary.dark" }}>
-                <TableCell sx={{ witdh: "80px" }} />
-                <StyledTableCell sx={{ outline: "1px solid #FFFFFF" }}>
-                  <HeaderBox>
-                    <Typography>エントリ名</Typography>
-                    <StyledIconButton
-                      onClick={(e) => {
-                        setEntryMenuEls(e.currentTarget);
-                      }}
-                    >
-                      {defaultEntryFilter ? (
-                        <FilterAltIcon />
-                      ) : (
-                        <FilterListIcon />
-                      )}
-                    </StyledIconButton>
-                    <SearchResultControlMenuForEntry
-                      entryFilter={entryFilter}
-                      anchorElem={entryMenuEls}
-                      handleClose={() => setEntryMenuEls(null)}
-                      entryFilterDispatcher={entryFilterDispatcher}
-                      handleSelectFilterConditions={handleSelectFilterConditions()}
-                      handleClear={() =>
-                        handleSelectFilterConditions()(undefined, "")
-                      }
-                    />
-                  </HeaderBox>
-                </StyledTableCell>
-                {Object.keys(attrsFilter).map((attrName) => (
-                  <StyledTableCell key={attrName}>
-                    <HeaderBox>
-                      <Typography>{attrName}</Typography>
-                      <StyledIconButton
-                        onClick={(e) => {
-                          setAttributeMenuEls({
-                            ...attributeMenuEls,
-                            [attrName]: e.currentTarget,
-                          });
-                        }}
-                      >
-                        {isFiltered[attrName] ?? false ? (
-                          <FilterAltIcon />
-                        ) : (
-                          <FilterListIcon />
-                        )}
-                      </StyledIconButton>
-                      <SearchResultControlMenu
-                        attrFilter={attrsFilter[attrName]}
-                        anchorElem={attributeMenuEls[attrName]}
-                        handleClose={() =>
-                          setAttributeMenuEls({
-                            ...attributeMenuEls,
-                            [attrName]: null,
-                          })
-                        }
-                        handleSelectFilterConditions={handleSelectFilterConditions(
-                          attrName
-                        )}
-                        handleUpdateAttrFilter={handleUpdateAttrFilter(
-                          attrName
-                        )}
-                      />
-                    </HeaderBox>
-                  </StyledTableCell>
-                ))}
-                {hasReferral && (
-                  <StyledTableCell sx={{ outline: "1px solid #FFFFFF" }}>
-                    <HeaderBox>
-                      <Typography>参照エントリ</Typography>
-                      <StyledIconButton
-                        onClick={(e) => {
-                          setReferralMenuEls(e.currentTarget);
-                        }}
-                      >
-                        {defaultReferralFilter ? (
-                          <FilterAltIcon />
-                        ) : (
-                          <FilterListIcon />
-                        )}
-                      </StyledIconButton>
-                      <SearchResultControlMenuForReferral
-                        referralFilter={referralFilter}
-                        anchorElem={referralMenuEls}
-                        handleClose={() => setReferralMenuEls(null)}
-                        referralFilterDispatcher={referralFilterDispatcher}
-                        handleSelectFilterConditions={handleSelectFilterConditions()}
-                        handleClear={() =>
-                          handleSelectFilterConditions()(
-                            undefined,
-                            undefined,
-                            ""
-                          )
-                        }
-                      />
-                    </HeaderBox>
-                  </StyledTableCell>
-                )}
-              </TableRow>
-            </TableHead>
+            <SearchResultsTableHead
+              hasReferral={hasReferral}
+              defaultEntryFilter={defaultEntryFilter}
+              defaultReferralFilter={defaultReferralFilter}
+              defaultAttrsFilter={defaultAttrsFilter}
+            />
             <TableBody>
               {results.map((result) => (
                 <StyledTableRow key={result.entry.id}>
@@ -307,7 +107,7 @@ export const SearchResults: FC<Props> = ({
                       {result.entry.name}
                     </Box>
                   </TableCell>
-                  {Object.keys(attrsFilter).map((attrName) => (
+                  {attrNames.map((attrName) => (
                     <TableCell key={attrName}>
                       {(() => {
                         const info = result.attrs[attrName];

--- a/frontend/src/components/entry/SearchResultsTableHead.tsx
+++ b/frontend/src/components/entry/SearchResultsTableHead.tsx
@@ -1,0 +1,230 @@
+import { AdvancedSearchResultAttrInfoFilterKeyEnum } from "@dmm-com/airone-apiclient-typescript-fetch";
+import FilterAltIcon from "@mui/icons-material/FilterAlt";
+import FilterListIcon from "@mui/icons-material/FilterList";
+import {
+  Box,
+  IconButton,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { styled } from "@mui/material/styles";
+import React, { ChangeEvent, FC, useMemo, useReducer, useState } from "react";
+import { useHistory, useLocation } from "react-router-dom";
+
+import {
+  AttrFilter,
+  AttrsFilter,
+  formatAdvancedSearchParams,
+} from "../../services/entry/AdvancedSearch";
+
+import { SearchResultControlMenu } from "./SearchResultControlMenu";
+import { SearchResultControlMenuForEntry } from "./SearchResultControlMenuForEntry";
+import { SearchResultControlMenuForReferral } from "./SearchResultControlMenuForReferral";
+
+const HeaderBox = styled(Box)({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+});
+
+const StyledIconButton = styled(IconButton)(({ theme }) => ({
+  color: theme.palette.primary.contrastText,
+}));
+
+const StyledTableCell = styled(TableCell)(({ theme }) => ({
+  color: theme.palette.primary.contrastText,
+  minWidth: "300px",
+}));
+
+interface Props {
+  hasReferral: boolean;
+  defaultEntryFilter?: string;
+  defaultReferralFilter?: string;
+  defaultAttrsFilter?: AttrsFilter;
+}
+
+export const SearchResultsTableHead: FC<Props> = ({
+  hasReferral,
+  defaultEntryFilter,
+  defaultReferralFilter,
+  defaultAttrsFilter = {},
+}) => {
+  const location = useLocation();
+  const history = useHistory();
+
+  const [entryFilter, entryFilterDispatcher] = useReducer(
+    (
+      _state: string,
+      event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+    ) => event.target.value,
+    defaultEntryFilter ?? ""
+  );
+  const [referralFilter, referralFilterDispatcher] = useReducer(
+    (
+      _state: string,
+      event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+    ) => event.target.value,
+    defaultReferralFilter ?? ""
+  );
+  const [attrsFilter, setAttrsFilter] = useState<AttrsFilter>(
+    defaultAttrsFilter ?? {}
+  );
+
+  const [attributeMenuEls, setAttributeMenuEls] = useState<{
+    [key: string]: HTMLButtonElement | null;
+  }>({});
+  const [entryMenuEls, setEntryMenuEls] = useState<HTMLButtonElement | null>(
+    null
+  );
+  const [referralMenuEls, setReferralMenuEls] =
+    useState<HTMLButtonElement | null>(null);
+
+  const attrNames = useMemo(() => {
+    return Object.keys(defaultAttrsFilter);
+  }, [defaultAttrsFilter]);
+
+  const isFiltered = useMemo(
+    (): Record<string, boolean> =>
+      Object.fromEntries(
+        Object.keys(defaultAttrsFilter ?? {}).map((attrName: string) => {
+          const attrFilter = defaultAttrsFilter[attrName];
+          switch (attrFilter.filterKey) {
+            case AdvancedSearchResultAttrInfoFilterKeyEnum.EMPTY:
+            case AdvancedSearchResultAttrInfoFilterKeyEnum.NON_EMPTY:
+            case AdvancedSearchResultAttrInfoFilterKeyEnum.DUPLICATED:
+              return [attrName, true];
+            case AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_CONTAINED:
+              return [attrName, attrFilter.keyword !== ""];
+            case AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_NOT_CONTAINED:
+              return [attrName, attrFilter.keyword !== ""];
+          }
+          return [attrName, false];
+        })
+      ),
+    [defaultAttrsFilter]
+  );
+
+  const handleSelectFilterConditions =
+    (attrName?: string) =>
+    (
+      attrFilter?: AttrFilter,
+      overwriteEntryName?: string,
+      overwriteReferral?: string
+    ) => {
+      const _attrsFilter =
+        attrName != null && attrFilter != null
+          ? { ...attrsFilter, [attrName]: attrFilter }
+          : attrsFilter;
+
+      const newParams = formatAdvancedSearchParams({
+        attrsFilter: _attrsFilter,
+        entryName: overwriteEntryName ?? entryFilter,
+        referralName: overwriteReferral ?? referralFilter,
+        baseParams: new URLSearchParams(location.search),
+      });
+
+      // simply reload with the new params
+      history.push({
+        pathname: location.pathname,
+        search: "?" + newParams.toString(),
+      });
+      history.go(0);
+    };
+
+  const handleUpdateAttrFilter =
+    (attrName: string) => (attrFilter: AttrFilter) => {
+      setAttrsFilter((attrsFilter) => ({
+        ...attrsFilter,
+        [attrName]: attrFilter,
+      }));
+    };
+
+  return (
+    <TableHead>
+      <TableRow sx={{ backgroundColor: "primary.dark" }}>
+        <TableCell sx={{ witdh: "80px" }} />
+        <StyledTableCell sx={{ outline: "1px solid #FFFFFF" }}>
+          <HeaderBox>
+            <Typography>エントリ名</Typography>
+            <StyledIconButton
+              onClick={(e) => {
+                setEntryMenuEls(e.currentTarget);
+              }}
+            >
+              {defaultEntryFilter ? <FilterAltIcon /> : <FilterListIcon />}
+            </StyledIconButton>
+            <SearchResultControlMenuForEntry
+              entryFilter={entryFilter}
+              anchorElem={entryMenuEls}
+              handleClose={() => setEntryMenuEls(null)}
+              entryFilterDispatcher={entryFilterDispatcher}
+              handleSelectFilterConditions={handleSelectFilterConditions()}
+              handleClear={() => handleSelectFilterConditions()(undefined, "")}
+            />
+          </HeaderBox>
+        </StyledTableCell>
+        {attrNames.map((attrName) => (
+          <StyledTableCell key={attrName}>
+            <HeaderBox>
+              <Typography>{attrName}</Typography>
+              <StyledIconButton
+                onClick={(e) => {
+                  setAttributeMenuEls({
+                    ...attributeMenuEls,
+                    [attrName]: e.currentTarget,
+                  });
+                }}
+              >
+                {isFiltered[attrName] ?? false ? (
+                  <FilterAltIcon />
+                ) : (
+                  <FilterListIcon />
+                )}
+              </StyledIconButton>
+              <SearchResultControlMenu
+                attrFilter={attrsFilter[attrName]}
+                anchorElem={attributeMenuEls[attrName]}
+                handleClose={() =>
+                  setAttributeMenuEls({
+                    ...attributeMenuEls,
+                    [attrName]: null,
+                  })
+                }
+                handleSelectFilterConditions={handleSelectFilterConditions(
+                  attrName
+                )}
+                handleUpdateAttrFilter={handleUpdateAttrFilter(attrName)}
+              />
+            </HeaderBox>
+          </StyledTableCell>
+        ))}
+        {hasReferral && (
+          <StyledTableCell sx={{ outline: "1px solid #FFFFFF" }}>
+            <HeaderBox>
+              <Typography>参照エントリ</Typography>
+              <StyledIconButton
+                onClick={(e) => {
+                  setReferralMenuEls(e.currentTarget);
+                }}
+              >
+                {defaultReferralFilter ? <FilterAltIcon /> : <FilterListIcon />}
+              </StyledIconButton>
+              <SearchResultControlMenuForReferral
+                referralFilter={referralFilter}
+                anchorElem={referralMenuEls}
+                handleClose={() => setReferralMenuEls(null)}
+                referralFilterDispatcher={referralFilterDispatcher}
+                handleSelectFilterConditions={handleSelectFilterConditions()}
+                handleClear={() =>
+                  handleSelectFilterConditions()(undefined, undefined, "")
+                }
+              />
+            </HeaderBox>
+          </StyledTableCell>
+        )}
+      </TableRow>
+    </TableHead>
+  );
+};

--- a/frontend/src/pages/AdvancedSearchPage.tsx
+++ b/frontend/src/pages/AdvancedSearchPage.tsx
@@ -68,7 +68,7 @@ export const AdvancedSearchPage: FC = () => {
 
   const searchParams = useMemo(() => {
     return formatAdvancedSearchParams({
-      attrFilter: Object.fromEntries(
+      attrsFilter: Object.fromEntries(
         selectedAttrs.map((attr) => [
           attr,
           {

--- a/frontend/src/services/entry/AdvancedSearch.test.ts
+++ b/frontend/src/services/entry/AdvancedSearch.test.ts
@@ -36,7 +36,7 @@ describe("formatAdvancedSearchParams", () => {
       searchAllEntities: true,
       hasReferral: true,
       referralName: "referral_name",
-      attrFilter: {
+      attrsFilter: {
         attr1: {
           filterKey: AdvancedSearchResultAttrInfoFilterKeyEnum.CLEARED,
           keyword: "",

--- a/frontend/src/services/entry/AdvancedSearch.ts
+++ b/frontend/src/services/entry/AdvancedSearch.ts
@@ -3,10 +3,12 @@ import {
   AdvancedSearchResultAttrInfoFilterKeyEnum,
 } from "@dmm-com/airone-apiclient-typescript-fetch";
 
-export type AttrsFilter = Record<
-  string,
-  { filterKey: AdvancedSearchResultAttrInfoFilterKeyEnum; keyword: string }
->;
+export type AttrFilter = {
+  filterKey: AdvancedSearchResultAttrInfoFilterKeyEnum;
+  keyword: string;
+};
+
+export type AttrsFilter = Record<string, AttrFilter>;
 
 interface AdvancedSearchParams {
   entityIds: number[];
@@ -65,7 +67,7 @@ class AdvancedSearchParamsInner {
 }
 
 export function formatAdvancedSearchParams({
-  attrFilter,
+  attrsFilter,
   entityIds,
   searchAllEntities,
   entryName,
@@ -73,7 +75,7 @@ export function formatAdvancedSearchParams({
   referralName,
   baseParams,
 }: {
-  attrFilter?: AttrsFilter;
+  attrsFilter?: AttrsFilter;
   entityIds?: string[];
   searchAllEntities?: boolean;
   entryName?: string;
@@ -106,15 +108,15 @@ export function formatAdvancedSearchParams({
     params.set("referral_name", referralName);
   }
 
-  if (attrFilter != null) {
+  if (attrsFilter != null) {
     params.set(
       "attrinfo",
       JSON.stringify(
-        Object.keys(attrFilter).map(
+        Object.keys(attrsFilter).map(
           (key): AdvancedSearchResultAttrInfo => ({
             name: key,
-            filterKey: attrFilter[key].filterKey,
-            keyword: attrFilter[key].keyword,
+            filterKey: attrsFilter[key].filterKey,
+            keyword: attrsFilter[key].keyword,
           })
         )
       )


### PR DESCRIPTION
`SearchResultControlMenu` accepts filter conditions for **all** attributes but each component needs condition for specific attribute. I guess it occurs unnecessary re-rendering. So I refine props to get only necessary values.