### PR TITLE
Fixed for header width would change depending on the presence or absence of a scroll bar

### DIFF
--- a/frontend/src/Theme.tsx
+++ b/frontend/src/Theme.tsx
@@ -32,4 +32,16 @@ export const theme = createTheme({
   typography: {
     fontFamily: "Noto Sans JP",
   },
+  components: {
+    MuiMenu: {
+      defaultProps: {
+        disableScrollLock: true,
+      },
+    },
+    MuiModal: {
+      defaultProps: {
+        disableScrollLock: true,
+      },
+    },
+  },
 });

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -202,7 +202,6 @@ export const Header: FC = () => {
                 open={Boolean(userAnchorEl)}
                 onClose={() => setUserAnchorEl(null)}
                 keepMounted
-                disableScrollLock
               >
                 <MenuItem>
                   {djangoContext?.user?.username ?? "不明なユーザ"}{" "}
@@ -231,7 +230,6 @@ export const Header: FC = () => {
                 open={Boolean(jobAnchorEl)}
                 onClose={() => setJobAnchorEl(null)}
                 keepMounted
-                disableScrollLock
               >
                 {recentJobs.length > 0 ? (
                   recentJobs.map((job) => (

--- a/frontend/src/components/acl/ACLForm.tsx
+++ b/frontend/src/components/acl/ACLForm.tsx
@@ -83,7 +83,6 @@ export const ACLForm: FC<Props> = ({ control, watch }) => {
                     fullWidth
                     value={field.value ? 1 : 0}
                     onChange={(e) => field.onChange(e.target.value === 1)}
-                    MenuProps={{ disableScrollLock: true }}
                   >
                     <MenuItem value={1}>公開</MenuItem>
                     <MenuItem value={0}>限定公開</MenuItem>
@@ -125,7 +124,6 @@ export const ACLForm: FC<Props> = ({ control, watch }) => {
                       size="small"
                       fullWidth
                       disabled={watch("isPublic")}
-                      MenuProps={{ disableScrollLock: true }}
                     >
                       {Object.values(ACLType).map((value) => (
                         <MenuItem key={value} value={value}>
@@ -153,7 +151,6 @@ export const ACLForm: FC<Props> = ({ control, watch }) => {
                           size="small"
                           fullWidth
                           disabled={watch("isPublic")}
-                          MenuProps={{ disableScrollLock: true }}
                         >
                           {Object.values(ACLType).map((value) => (
                             <MenuItem key={value} value={value}>

--- a/frontend/src/components/entity/EntityControlMenu.tsx
+++ b/frontend/src/components/entity/EntityControlMenu.tsx
@@ -90,7 +90,6 @@ export const EntityControlMenu: FC<Props> = ({
         vertical: "top",
         horizontal: "right",
       }}
-      disableScrollLock
     >
       <MenuItem component={Link} to={entityEntriesPath(entityId)}>
         <Typography>エントリ一覧</Typography>

--- a/frontend/src/components/entry/EntryControlMenu.tsx
+++ b/frontend/src/components/entry/EntryControlMenu.tsx
@@ -72,7 +72,6 @@ export const EntryControlMenu: FC<EntryControlProps> = ({
         vertical: "top",
         horizontal: "right",
       }}
-      disableScrollLock
     >
       <Box sx={{ width: 150 }}>
         <MenuItem component={Link} to={entryDetailsPath(entityId, entryId)}>

--- a/frontend/src/components/group/GroupControlMenu.tsx
+++ b/frontend/src/components/group/GroupControlMenu.tsx
@@ -64,7 +64,6 @@ export const GroupControlMenu: FC<Props> = ({
         vertical: "top",
         horizontal: "right",
       }}
-      disableScrollLock
     >
       <Box sx={{ width: 150 }}>
         <MenuItem onClick={handleEdit}>

--- a/frontend/src/components/user/UserControlMenu.tsx
+++ b/frontend/src/components/user/UserControlMenu.tsx
@@ -75,7 +75,6 @@ export const UserControlMenu: FC<UserControlProps> = ({
         vertical: "top",
         horizontal: "right",
       }}
-      disableScrollLock
     >
       <Box sx={{ width: 150 }}>
         <MenuItem onClick={handleOpenModal}>

--- a/templates/frontend/index.html
+++ b/templates/frontend/index.html
@@ -1,19 +1,28 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <!-- custom script head -->
-  {% include 'custom_view/custom_script_head.html' %}
-  <meta charset="utf-8">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;700&display=swap" />
-  <link rel="shortcut icon" href="/static/favicon.ico" />
-  <title>AirOne(NewUI)</title>
-</head>
-<body style="margin: 0px">
-  <!-- custom script body -->
-  {% include 'custom_view/custom_script_body.html' %}
-  <div id="app" class="columns" style="min-height: 100vh; display: flex; flex-direction: column"><!-- React --></div>
+  <head>
+    <!-- custom script head -->
+    {% include 'custom_view/custom_script_head.html' %}
+    <meta charset="utf-8" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;700&display=swap"
+    />
+    <link rel="shortcut icon" href="/static/favicon.ico" />
+    <title>AirOne(NewUI)</title>
+  </head>
+  <body style="margin: 0px; overflow-y: scroll">
+    <!-- custom script body -->
+    {% include 'custom_view/custom_script_body.html' %}
+    <div
+      id="app"
+      class="columns"
+      style="min-height: 100vh; display: flex; flex-direction: column"
+    >
+      <!-- React -->
+    </div>
 
-  <script type="text/javascript">
+    <script type="text/javascript">
       window.django_context = {
           version: "{{version}}",
           user: {
@@ -22,8 +31,7 @@
               isSuperuser: {{user.is_superuser|yesno:"true,false"}},
           },
       };
-  </script>
-  <script src="/static/js/ui.js"></script>
-
-</body>
+    </script>
+    <script src="/static/js/ui.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
There was an issue where the header was shifted when opening the select box.
(e.g. Edit Entity page)
Fixed it by taking the width of the scrollbar into account.