### PR TITLE
Enable to limit the number of records

### DIFF
--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -2,7 +2,7 @@ import errno
 import logging
 import os
 import subprocess
-from typing import Any
+from typing import Any, Optional
 
 import environ
 from configurations import Configuration
@@ -432,3 +432,11 @@ class Common(Configuration):
                 "dd.span_id:%(dd.span_id)s",
             ]
         )
+
+    # Dynamic record number limitations on model level validation (None means unlimited)
+    MAX_ENTITIES: Optional[int] = env.int("AIRONE_MAX_ENTITIES", None)
+    MAX_ATTRIBUTES_PER_ENTITY: Optional[int] = env.int("AIRONE_MAX_ATTRIBUTES_PER_ENTITY", None)
+    MAX_ENTRIES: Optional[int] = env.int("AIRONE_MAX_ENTRIES", None)
+    MAX_USERS: Optional[int] = env.int("AIRONE_MAX_USERS", None)
+    MAX_GROUPS: Optional[int] = env.int("AIRONE_MAX_GROUPS", None)
+    MAX_ROLES: Optional[int] = env.int("AIRONE_MAX_ROLES", None)

--- a/entry/models.py
+++ b/entry/models.py
@@ -1636,6 +1636,12 @@ class Entry(ACLBase):
             "attrs": returning_attrs,
         }
 
+    def save(self, *args, **kwargs):
+        max_entries: Optional[int] = settings.MAX_ENTRIES
+        if max_entries and Entry.objects.count() >= max_entries:
+            raise RuntimeError("The number of entries is over the limit")
+        return super(Entry, self).save(*args, **kwargs)
+
     def delete(self, *args, **kwargs):
         super(Entry, self).delete(*args, **kwargs)
 

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -5686,3 +5686,21 @@ class ModelTest(AironeTestCase):
         self._entry.register_es()
         ret = Entry.search_entries(self._user, [self._entity.id], [], 99999999)
         self.assertEqual(ret["ret_count"], 1)
+
+    def test_max_entries(self):
+        max_entries = 10
+        for i in range(max_entries):
+            Entry.objects.create(name=f"entry-{i}", created_user=self._user, schema=self._entity)
+
+        # if the limit exceeded, RuntimeError should be raised
+        settings.MAX_ENTRIES = max_entries
+        with self.assertRaises(RuntimeError):
+            Entry.objects.create(
+                name=f"entry-{max_entries}", created_user=self._user, schema=self._entity
+            )
+
+        # if the limit is not set, RuntimeError should not be raised
+        settings.MAX_ENTRIES = None
+        Entry.objects.create(
+            name=f"entry-{max_entries}", created_user=self._user, schema=self._entity
+        )

--- a/group/tests/test_model.py
+++ b/group/tests/test_model.py
@@ -1,3 +1,4 @@
+from airone import settings
 from airone.lib.test import AironeTestCase
 from airone.lib.types import AttrTypeValue
 from entry.models import Entry
@@ -114,3 +115,17 @@ class ModelTest(AironeTestCase):
             self.assertEqual(
                 [e.name for e in group.get_referred_entries(entity_name="Entity1")], ["e-1"]
             )
+
+    def test_max_groups(self):
+        max_groups = 10 - Group.objects.count()
+        for i in range(max_groups):
+            Group.objects.create(name=f"group-{i}")
+
+        # if the limit exceeded, RuntimeError should be raised
+        settings.MAX_GROUPS = max_groups
+        with self.assertRaises(RuntimeError):
+            Group.objects.create(name=f"group-{max_groups}")
+
+        # if the limit is not set, RuntimeError should not be raised
+        settings.MAX_GROUPS = None
+        Group.objects.create(name=f"group-{max_groups}")

--- a/role/tests/test_model.py
+++ b/role/tests/test_model.py
@@ -1,3 +1,4 @@
+from airone import settings
 from airone.lib.acl import ACLType
 from airone.lib.types import AttrTypeValue
 from entity.models import Entity
@@ -187,3 +188,18 @@ class ModelTest(RoleTestBase):
         self.add_entry(user, "e-1", entity, values={"roles": roles})
         for role in roles:
             self.assertEqual([e.name for e in role.get_referred_entries()], ["e-1"])
+
+    def test_max_roles(self):
+        Role.objects.all().delete()
+
+        max_roles = 10
+        Role.objects.bulk_create([Role(name=f"role-{i}") for i in range(max_roles)])
+
+        # if the limit exceeded, RuntimeError should be raised
+        settings.MAX_ROLES = max_roles
+        with self.assertRaises(RuntimeError):
+            Role.objects.create(name=f"role-{max_roles}")
+
+        # if the limit is not set, RuntimeError should not be raised
+        settings.MAX_ROLES = None
+        Role.objects.create(name=f"role-{max_roles}")

--- a/user/models.py
+++ b/user/models.py
@@ -1,10 +1,12 @@
 from datetime import datetime
 from importlib import import_module
+from typing import Optional
 
 from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.db import models
 from rest_framework.authtoken.models import Token
 
+from airone import settings
 from airone.lib.acl import ACLType, ACLTypeBase
 from group.models import Group
 from role.models import Role
@@ -187,6 +189,15 @@ class User(AbstractUser):
             return False
 
         return True
+
+    def save(self, *args, **kwargs):
+        """
+        Override Model.save method of Django
+        """
+        max_users: Optional[int] = settings.MAX_USERS
+        if max_users and User.objects.count() >= max_users:
+            raise RuntimeError("The number of users is over the limit")
+        return super(User, self).save(*args, **kwargs)
 
     def delete(self):
         """


### PR DESCRIPTION
It enables to limit the number of records on:

- entity
- entity attributes per entity
- entry
- user
- group
- role

to prevent a user exhausts server resources.
The limitation is optional (`None`(default) means unlimited ) and we can specify it via settings with environment variables.