### PR TITLE
Allow to submit if any fields are dirty

### DIFF
--- a/frontend/src/pages/EditEntityPage.tsx
+++ b/frontend/src/pages/EditEntityPage.tsx
@@ -203,7 +203,7 @@ export const EditEntityPage: FC = () => {
       >
         <SubmitButton
           name="保存"
-          disabled={!isValid || isSubmitting || isSubmitSuccessful}
+          disabled={!isDirty || !isValid || isSubmitting || isSubmitSuccessful}
           isSubmitting={isSubmitting}
           handleSubmit={handleSubmit(handleSubmitOnValid)}
           handleCancel={handleCancel}

--- a/frontend/src/pages/EditGroupPage.tsx
+++ b/frontend/src/pages/EditGroupPage.tsx
@@ -108,7 +108,7 @@ export const EditGroupPage: FC = () => {
       >
         <SubmitButton
           name="保存"
-          disabled={!isValid || isSubmitting || isSubmitSuccessful}
+          disabled={!isDirty || !isValid || isSubmitting || isSubmitSuccessful}
           isSubmitting={isSubmitting}
           handleSubmit={handleSubmit(handleSubmitOnValid)}
           handleCancel={handleCancel}

--- a/frontend/src/pages/EditRolePage.tsx
+++ b/frontend/src/pages/EditRolePage.tsx
@@ -112,6 +112,7 @@ export const EditRolePage: FC = () => {
         <SubmitButton
           name="保存"
           disabled={
+            !isDirty ||
             !isValid ||
             isSubmitting ||
             isSubmitSuccessful ||

--- a/frontend/src/pages/EditUserPage.tsx
+++ b/frontend/src/pages/EditUserPage.tsx
@@ -198,7 +198,9 @@ export const EditUserPage: FC = () => {
             isCreateMode={isCreateMode}
             isSuperuser={isSuperuser}
             isMyself={isMyself}
-            isSubmittable={isValid && !isSubmitting && !isSubmitSuccessful}
+            isSubmittable={
+              isDirty && isValid && !isSubmitting && !isSubmitSuccessful
+            }
             handleSubmit={handleSubmit(handleSubmitOnValid)}
             handleCancel={handleCancel}
           />

--- a/frontend/src/pages/EntryEditPage.tsx
+++ b/frontend/src/pages/EntryEditPage.tsx
@@ -169,7 +169,7 @@ export const EntryEditPage: FC<Props> = ({
       >
         <SubmitButton
           name="保存"
-          disabled={!isValid || isSubmitting || isSubmitSuccessful}
+          disabled={!isDirty || !isValid || isSubmitting || isSubmitSuccessful}
           isSubmitting={isSubmitting}
           handleSubmit={handleSubmit(handleSubmitOnValid, (errors) => {
             console.log(errors);


### PR DESCRIPTION
Current the new UI allows to submit data that doesn't have any changes. Its unnecessary, and will cause redundant history record ( see also https://github.com/dmm-com/airone/pull/987 ).
So I enforce forms to have any changed fields on submit. Its easy to recognize it, just with `isDirty` from RHF.

https://github.com/dmm-com/airone/assets/191684/052fd8a5-cf59-47f8-b8d5-39543115fd21

