### PR TITLE
Enable to switch legacy UI

### DIFF
--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -200,6 +200,9 @@ def render(request, template, context={}):
     # set Version
     context["version"] = settings.AIRONE["VERSION"]
 
+    # set AirOne context to templates
+    context["airone"] = settings.AIRONE
+
     return django_render(request, template, context)
 
 

--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -206,7 +206,7 @@ class Common(Configuration):
 
     LOGIN_REDIRECT_URL = "/dashboard/"
 
-    # global settins for AirOne
+    # global settings for AirOne
     AIRONE: dict[str, Any] = {
         "CONCURRENCY": 1,
         "VERSION": "unknown",
@@ -217,6 +217,7 @@ class Common(Configuration):
         "NOTE_DESC": env.str("AIRONE_NOTE_DESC", "Description, Please change it"),
         "NOTE_LINK": env.str("AIRONE_NOTE_LINK", ""),
         "SSO_DESC": env.str("AIRONE_SSO_DESC", "SSO"),
+        "LEGACY_UI_DISABLED": env.bool("AIRONE_LEGACY_UI_DISABLED", False),
     }
 
     try:

--- a/airone/urls.py
+++ b/airone/urls.py
@@ -1,13 +1,13 @@
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib.auth import views as auth_views
-from django.views.generic import RedirectView
 
+from airone import views
 from airone.auth import view as auth_view
 from api_v1.urls import urlpatterns as api_v1_urlpatterns
 
 urlpatterns = [
-    url(r"^$", RedirectView.as_view(url="dashboard/")),
+    url(r"^$", views.index, name="index"),
     url(r"^acl/", include(("acl.urls", "acl"))),
     url(r"^user/", include(("user.urls", "user"))),
     url(r"^group/", include(("group.urls", "group"))),

--- a/airone/views.py
+++ b/airone/views.py
@@ -1,0 +1,9 @@
+from django.shortcuts import redirect
+
+from airone import settings
+
+
+def index(request):
+    if "LEGACY_UI_DISABLED" in settings.AIRONE and settings.AIRONE["LEGACY_UI_DISABLED"]:
+        return redirect("ui/")
+    return redirect("dashboard/")

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -188,7 +188,9 @@ export const Header: FC = () => {
             </MenuBox>
 
             <MenuBox justifyContent="flex-end">
-              <Button href="/dashboard/">旧デザイン</Button>
+              {djangoContext?.legacyUiDisabled === false && (
+                <Button href="/dashboard/">旧デザイン</Button>
+              )}
               <IconButton
                 aria-controls="user-menu"
                 aria-haspopup="true"

--- a/frontend/src/services/DjangoContext.ts
+++ b/frontend/src/services/DjangoContext.ts
@@ -20,6 +20,7 @@ export class DjangoContext {
   noteLink: string;
   user?: User;
   singleSignOnLoginUrl?: string;
+  legacyUiDisabled?: boolean;
 
   private static _instance: DjangoContext | undefined;
 
@@ -32,6 +33,7 @@ export class DjangoContext {
     this.version = context.version;
     this.user = context.user ? new User(context.user) : undefined;
     this.singleSignOnLoginUrl = context.singleSignOnLoginUrl;
+    this.legacyUiDisabled = context.legacyUiDisabled;
   }
 
   static getInstance() {

--- a/templates/frontend/index.html
+++ b/templates/frontend/index.html
@@ -30,6 +30,7 @@
               username: "{{user.username}}",
               isSuperuser: {{user.is_superuser|yesno:"true,false"}},
           },
+          legacyUiDisabled: {{airone.LEGACY_UI_DISABLED|yesno:"true,false"}},
       };
     </script>
     <script src="/static/js/ui.js"></script>


### PR DESCRIPTION
The new ui will be standard UI for AirOne, and the legacy( current ) UI will be deprecated. Keeping to support the legacy UI can be costly for administrators. So I'd like to switch the path to legacy UI. It can be performed via `AIRONE_LEGACY_UI_DISABLED` environment variable on this PR.