### PR TITLE
Add date/boolean type specific attr filter selector

### DIFF
--- a/frontend/src/components/entry/SearchResultControlMenu.tsx
+++ b/frontend/src/components/entry/SearchResultControlMenu.tsx
@@ -1,4 +1,7 @@
-import { AdvancedSearchResultAttrInfoFilterKeyEnum } from "@dmm-com/airone-apiclient-typescript-fetch";
+import {
+  AdvancedSearchResultAttrInfoFilterKeyEnum,
+  EntryAttributeTypeTypeEnum,
+} from "@dmm-com/airone-apiclient-typescript-fetch";
 import Check from "@mui/icons-material/Check";
 import {
   Box,
@@ -11,6 +14,9 @@ import {
   Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { DesktopDatePicker } from "@mui/x-date-pickers/DesktopDatePicker";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import React, { ChangeEvent, FC } from "react";
 
 import { AttrFilter } from "../../services/entry/AdvancedSearch";
@@ -23,12 +29,17 @@ const StyledBox = styled(Box)({
   margin: "8px",
 });
 
+const StyledTypography = styled(Typography)(({}) => ({
+  color: "rgba(0, 0, 0, 0.6)",
+}));
+
 interface Props {
   attrFilter: AttrFilter;
   anchorElem: HTMLButtonElement | null;
   handleUpdateAttrFilter: (filter: AttrFilter) => void;
   handleSelectFilterConditions: (attrFilter: AttrFilter) => void;
   handleClose: () => void;
+  attrType?: number;
 }
 
 export const SearchResultControlMenu: FC<Props> = ({
@@ -37,6 +48,7 @@ export const SearchResultControlMenu: FC<Props> = ({
   handleUpdateAttrFilter,
   handleSelectFilterConditions,
   handleClose,
+  attrType,
 }) => {
   const handleClick = (key: AdvancedSearchResultAttrInfoFilterKeyEnum) => {
     // If the selected filter is the same, remove the filter.
@@ -154,42 +166,161 @@ export const SearchResultControlMenu: FC<Props> = ({
         )}
         <Typography>重複</Typography>
       </MenuItem>
-      <Box>
-        <StyledTextField
-          size="small"
-          placeholder="次を含むテキスト"
-          value={
-            filterKey ===
-            AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_CONTAINED
-              ? keyword
-              : ""
-          }
-          onChange={handleChangeKeyword(
-            AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_CONTAINED
-          )}
-          onKeyPress={handleKeyPressKeyword(
-            AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_CONTAINED
-          )}
-        />
-      </Box>
-      <Box>
-        <StyledTextField
-          size="small"
-          placeholder="次を含まないテキスト"
-          value={
-            filterKey ===
-            AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_NOT_CONTAINED
-              ? keyword
-              : ""
-          }
-          onChange={handleChangeKeyword(
-            AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_NOT_CONTAINED
-          )}
-          onKeyPress={handleKeyPressKeyword(
-            AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_NOT_CONTAINED
-          )}
-        />
-      </Box>
+
+      {/* date-type specific text selector */}
+      {attrType === EntryAttributeTypeTypeEnum.DATE && (
+        <>
+          <StyledBox display="flex" flexDirection="column">
+            <StyledTypography variant="caption">次を含む日付</StyledTypography>
+            <LocalizationProvider dateAdapter={AdapterDateFns}>
+              <DesktopDatePicker
+                inputFormat="yyyy/MM/dd"
+                value={
+                  filterKey ===
+                  AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_CONTAINED
+                    ? keyword
+                    : null
+                }
+                onChange={(date: Date | null) => {
+                  let settingDateValue = "";
+                  if (date !== null) {
+                    settingDateValue = `${date.getFullYear()}-${
+                      date.getMonth() + 1
+                    }-${date.getDate()}`;
+                  }
+                  handleSelectFilterConditions({
+                    ...attrFilter,
+                    filterKey:
+                      AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_CONTAINED,
+                    keyword: settingDateValue,
+                  });
+                }}
+                renderInput={(params) => (
+                  <StyledTextField size="small" {...params} />
+                )}
+              />
+            </LocalizationProvider>
+          </StyledBox>
+          <StyledBox display="flex" flexDirection="column">
+            <StyledTypography variant="caption">
+              次を含まない日付
+            </StyledTypography>
+            <LocalizationProvider dateAdapter={AdapterDateFns}>
+              <DesktopDatePicker
+                inputFormat="yyyy/MM/dd"
+                value={
+                  filterKey ===
+                  AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_NOT_CONTAINED
+                    ? keyword
+                    : null
+                }
+                onChange={(date: Date | null) => {
+                  let settingDateValue = "";
+                  if (date !== null) {
+                    settingDateValue = `${date.getFullYear()}-${
+                      date.getMonth() + 1
+                    }-${date.getDate()}`;
+                  }
+                  handleSelectFilterConditions({
+                    ...attrFilter,
+                    filterKey:
+                      AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_NOT_CONTAINED,
+                    keyword: settingDateValue,
+                  });
+                }}
+                renderInput={(params) => (
+                  <StyledTextField size="small" {...params} />
+                )}
+              />
+            </LocalizationProvider>
+          </StyledBox>
+        </>
+      )}
+
+      {/* date-type specific text selector */}
+      {attrType === EntryAttributeTypeTypeEnum.BOOLEAN && (
+        <>
+          <MenuItem
+            onClick={() =>
+              handleSelectFilterConditions({
+                ...attrFilter,
+                filterKey:
+                  AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_CONTAINED,
+                keyword: "true",
+              })
+            }
+          >
+            {filterKey ===
+              AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_CONTAINED && (
+              <ListItemIcon>
+                <Check />
+              </ListItemIcon>
+            )}
+            <Typography>true のみ</Typography>
+          </MenuItem>
+          <MenuItem
+            onClick={() =>
+              handleSelectFilterConditions({
+                ...attrFilter,
+                filterKey:
+                  AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_NOT_CONTAINED,
+                keyword: "true",
+              })
+            }
+          >
+            {filterKey ===
+              AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_NOT_CONTAINED && (
+              <ListItemIcon>
+                <Check />
+              </ListItemIcon>
+            )}
+            <Typography>false のみ</Typography>
+          </MenuItem>
+        </>
+      )}
+
+      {/* default text selector */}
+      {attrType !== EntryAttributeTypeTypeEnum.DATE &&
+        attrType !== EntryAttributeTypeTypeEnum.BOOLEAN && (
+          <>
+            <Box>
+              <StyledTextField
+                size="small"
+                placeholder="次を含むテキスト"
+                value={
+                  filterKey ===
+                  AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_CONTAINED
+                    ? keyword
+                    : ""
+                }
+                onChange={handleChangeKeyword(
+                  AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_CONTAINED
+                )}
+                onKeyPress={handleKeyPressKeyword(
+                  AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_CONTAINED
+                )}
+              />
+            </Box>
+            <Box>
+              <StyledTextField
+                size="small"
+                placeholder="次を含まないテキスト"
+                value={
+                  filterKey ===
+                  AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_NOT_CONTAINED
+                    ? keyword
+                    : ""
+                }
+                onChange={handleChangeKeyword(
+                  AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_NOT_CONTAINED
+                )}
+                onKeyPress={handleKeyPressKeyword(
+                  AdvancedSearchResultAttrInfoFilterKeyEnum.TEXT_NOT_CONTAINED
+                )}
+              />
+            </Box>
+          </>
+        )}
     </Menu>
   );
 };

--- a/frontend/src/components/entry/SearchResults.tsx
+++ b/frontend/src/components/entry/SearchResults.tsx
@@ -70,9 +70,18 @@ export const SearchResults: FC<Props> = ({
   bulkOperationEntryIds,
   handleChangeBulkOperationEntryId,
 }) => {
-  const attrNames = useMemo(() => {
-    return Object.keys(defaultAttrsFilter);
-  }, [defaultAttrsFilter]);
+  // NOTE attrTypes are guessed by the first element on the results. So if it has no appropriate attr,
+  // the type guess doesn't work well. We should improve attr type API if more accurate type is needed.
+  const [attrNames, attrTypes] = useMemo(() => {
+    const _attrNames = Object.keys(defaultAttrsFilter);
+    const _attrTypes = Object.fromEntries(
+      _attrNames.map((attrName) => [
+        attrName,
+        results[0]?.attrs[attrName]?.type,
+      ])
+    );
+    return [_attrNames, _attrTypes];
+  }, [defaultAttrsFilter, results]);
 
   return (
     <Box display="flex" flexDirection="column">
@@ -81,6 +90,7 @@ export const SearchResults: FC<Props> = ({
           <Table id="table_result_list">
             <SearchResultsTableHead
               hasReferral={hasReferral}
+              attrTypes={attrTypes}
               defaultEntryFilter={defaultEntryFilter}
               defaultReferralFilter={defaultReferralFilter}
               defaultAttrsFilter={defaultAttrsFilter}

--- a/frontend/src/components/entry/SearchResultsTableHead.tsx
+++ b/frontend/src/components/entry/SearchResultsTableHead.tsx
@@ -40,6 +40,7 @@ const StyledTableCell = styled(TableCell)(({ theme }) => ({
 
 interface Props {
   hasReferral: boolean;
+  attrTypes: Record<string, number>;
   defaultEntryFilter?: string;
   defaultReferralFilter?: string;
   defaultAttrsFilter?: AttrsFilter;
@@ -47,6 +48,7 @@ interface Props {
 
 export const SearchResultsTableHead: FC<Props> = ({
   hasReferral,
+  attrTypes,
   defaultEntryFilter,
   defaultReferralFilter,
   defaultAttrsFilter = {},
@@ -196,6 +198,7 @@ export const SearchResultsTableHead: FC<Props> = ({
                   attrName
                 )}
                 handleUpdateAttrFilter={handleUpdateAttrFilter(attrName)}
+                attrType={attrTypes[attrName]}
               />
             </HeaderBox>
           </StyledTableCell>


### PR DESCRIPTION
The attribute filter on the advanced search result page is not so user-friendly for now. Its hard to select date/boolean typed value on just a text field. So I introduce these type specific selectors if the types can be guesses appropriately.

<img width="937" alt="image" src="https://github.com/dmm-com/airone/assets/191684/8268d48f-5bc7-4c76-af94-0abaaf86af39">
<img width="614" alt="image" src="https://github.com/dmm-com/airone/assets/191684/b07fd390-fed4-4be1-8aa2-2ea3907e379c">

As the limitation, type guess just uses the first element on search results. **The element sometimes doesn't have attribute type (for e.g. a date type attribute was appended after the first element created.)** To cover such a situation, we need to get more correct attribute types via API.