### PR TITLE
Fixed update acl error when another role was already set

### DIFF
--- a/acl/api_v2/serializers.py
+++ b/acl/api_v2/serializers.py
@@ -139,12 +139,6 @@ class ACLSerializer(serializers.ModelSerializer):
                         "value": int(x["value"]),
                     }
                     for x in attrs.get("acl_settings", [])
-                ]
-                + [
-                    {"role": role, "value": ACLType.Full}
-                    for role in acl.full.roles.exclude(
-                        id__in=[x["member_id"] for x in attrs.get("acl_settings", [])]
-                    )
                 ],
             },
         ):

--- a/acl/tests/test_api_v2.py
+++ b/acl/tests/test_api_v2.py
@@ -357,6 +357,30 @@ class ViewTest(AironeViewTest):
         )
         self.assertEqual(resp.status_code, 403)
 
+        role2 = Role.objects.create(name="role2")
+
+        acl.is_public = True
+        acl.save()
+        acl.full.roles.remove(role)
+        acl.full.roles.add(role2)
+
+        resp = self.client.put(
+            "/acl/api/v2/acls/%s" % acl.id,
+            json.dumps(
+                {
+                    "is_public": False,
+                    "acl_settings": [
+                        {
+                            "member_id": str(role.id),
+                            "value": str(ACLType.Full.id),
+                        }
+                    ],
+                }
+            ),
+            "application/json;charset=utf-8",
+        )
+        self.assertEqual(resp.status_code, 200)
+
     def test_remove_acl_when_administrative_role_is_left(self):
         user = self.guest_login()
         acl = ACLBase.objects.create(name="test", created_user=user)


### PR DESCRIPTION
Steps to reproduce the bug

1. Create an entity
2. Only user A creates administrator role A
3. Set FULL permission only for role A on entity
4. Set the entity back to public
5. Change entity ACL settings with user B