### PR TITLE
Fixed slow ACL search and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ user@hostname:~/airone$ source virtualenv/bin/activate
 (virtualenv) user@hostname:~/airone$ tools/clear_and_initdb.sh
 ```
 
+(Optional) Please set the index as necessary.
+```
+mysql> CREATE INDEX permission_codename_idx ON auth_permission (codename);
+```
+
 Finally, you should create an initial user to login the system using `tools/register_user.sh`.
 ```
 (virtualenv) user@hostname:~/airone$ tools/register_user.sh demo

--- a/acl/api_v2/serializers.py
+++ b/acl/api_v2/serializers.py
@@ -163,13 +163,13 @@ class ACLSerializer(serializers.ModelSerializer):
 
         permissions = {
             "full": HistoricalPermission.objects.get(
-                codename="%s.%s" % (instance.id, ACLType.Full.id)
+                codename="%s.%d" % (instance.id, ACLType.Full.id)  # type: ignore
             ),
             "writable": HistoricalPermission.objects.get(
-                codename="%s.%s" % (instance.id, ACLType.Writable.id)
+                codename="%s.%d" % (instance.id, ACLType.Writable.id)  # type: ignore
             ),
             "readable": HistoricalPermission.objects.get(
-                codename="%s.%s" % (instance.id, ACLType.Readable.id)
+                codename="%s.%d" % (instance.id, ACLType.Readable.id)  # type: ignore
             ),
         }
 

--- a/acl/api_v2/views.py
+++ b/acl/api_v2/views.py
@@ -53,9 +53,9 @@ class ACLHistoryAPI(generics.ListAPIView):
 
         acl_history = list(instance.history.all())
         codename_query = (
-            Q(codename="%s.%s" % (instance.id, ACLType.Full.id))
-            | Q(codename="%s.%s" % (instance.id, ACLType.Writable.id))
-            | Q(codename="%s.%s" % (instance.id, ACLType.Readable.id))
+            Q(codename="%s.%s" % (instance.id, ACLType.Full.id))  # type: ignore
+            | Q(codename="%s.%s" % (instance.id, ACLType.Writable.id))  # type: ignore
+            | Q(codename="%s.%s" % (instance.id, ACLType.Readable.id))  # type: ignore
         )
         if instance.objtype == ACLObjType.Entity.value:
             attrs = instance.attrs.filter(is_active=True)
@@ -64,9 +64,9 @@ class ACLHistoryAPI(generics.ListAPIView):
             )
             for attr in attrs:
                 codename_query |= (
-                    Q(codename="%s.%s" % (attr.id, ACLType.Full.id))
-                    | Q(codename="%s.%s" % (attr.id, ACLType.Writable.id))
-                    | Q(codename="%s.%s" % (attr.id, ACLType.Readable.id))
+                    Q(codename="%s.%s" % (attr.id, ACLType.Full.id))  # type: ignore
+                    | Q(codename="%s.%s" % (attr.id, ACLType.Writable.id))  # type: ignore
+                    | Q(codename="%s.%s" % (attr.id, ACLType.Readable.id))  # type: ignore
                 )
 
         permissions = HistoricalPermission.objects.filter(codename_query)


### PR DESCRIPTION
3 HistoricalPermission objects are generated for each object of ACLBase model.
A large number of ACLBase objects has a significant impact on performance.

Please set the index below.
```
mysql> CREATE INDEX permission_codename_idx ON auth_permission (codename);
```

API response 5s -> 500ms