### PR TITLE
Enable to toggle webhook feature

### DIFF
--- a/airone/lib/event_notification.py
+++ b/airone/lib/event_notification.py
@@ -13,7 +13,7 @@ urllib3.disable_warnings(InsecureRequestWarning)
 def _send_request_to_webhook_endpoint(entry, user, event_type):
     if not settings.AIRONE_FLAGS["WEBHOOK"]:
         Logger.warning(
-            "skipped to send requests to endpoints because webhook is disabled. skipped webhook urls are %s",
+            "skipped to send requests because webhook is disabled. skipped urls are %s",
             [w.url for w in entry.schema.webhooks.filter(is_enabled=True, is_verified=True)],
         )
         return

--- a/airone/lib/event_notification.py
+++ b/airone/lib/event_notification.py
@@ -4,10 +4,20 @@ import requests
 import urllib3
 from urllib3.exceptions import InsecureRequestWarning
 
+from airone import settings
+from airone.lib.log import Logger
+
 urllib3.disable_warnings(InsecureRequestWarning)
 
 
 def _send_request_to_webhook_endpoint(entry, user, event_type):
+    if not settings.AIRONE_FLAGS["WEBHOOK"]:
+        Logger.warning(
+            "skipped to send requests to endpoints because webhook is disabled. skipped webhook urls are %s",
+            [w.url for w in entry.schema.webhooks.filter(is_enabled=True, is_verified=True)],
+        )
+        return
+
     # send requests for each webhook endpoints
     for webhook in entry.schema.webhooks.filter(is_enabled=True, is_verified=True):
         requests.post(

--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -200,8 +200,8 @@ def render(request, template, context={}):
     # set AirOne context to templates
     context["airone"] = settings.AIRONE
 
-    # set AirOne context to templates
-    context["airone"] = settings.AIRONE
+    # set AirOne flags context to templates
+    context["airone_flags"] = settings.AIRONE_FLAGS
 
     return django_render(request, template, context)
 

--- a/airone/lib/test.py
+++ b/airone/lib/test.py
@@ -39,6 +39,7 @@ class AironeTestCase(TestCase):
         OVERRIDE_ES_CONFIG = settings.ES_CONFIG.copy()
         OVERRIDE_ES_CONFIG["INDEX_NAME"] = "test-" + settings.ES_CONFIG["INDEX_NAME"]
         OVERRIDE_AIRONE = settings.AIRONE.copy()
+        OVERRIDE_AIRONE_FLAGS = settings.AIRONE_FLAGS.copy()
         MEDIA_ROOT = "/tmp/airone_app_test"
 
         if not os.path.exists("/tmp/airone_app_test"):
@@ -46,7 +47,10 @@ class AironeTestCase(TestCase):
 
         # update django settings
         self._settings: override_settings = self.settings(
-            ES_CONFIG=OVERRIDE_ES_CONFIG, AIRONE=OVERRIDE_AIRONE, MEDIA_ROOT=MEDIA_ROOT
+            ES_CONFIG=OVERRIDE_ES_CONFIG,
+            AIRONE=OVERRIDE_AIRONE,
+            AIRONE_FLAGS=OVERRIDE_AIRONE_FLAGS,
+            MEDIA_ROOT=MEDIA_ROOT,
         )
         self._settings.enable()
         self.modify_settings(

--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -239,6 +239,11 @@ class Common(Configuration):
         # )),
     }
 
+    # flags to enable/disable AirOne core features
+    AIRONE_FLAGS: dict[str, bool] = {
+        "WEBHOOK": env.bool("AIRONE_FLAGS_WEBHOOK", True),
+    }
+
     try:
         proc = subprocess.Popen(
             "cd %s && git describe --tags" % BASE_DIR,

--- a/entity/api_v2/serializers.py
+++ b/entity/api_v2/serializers.py
@@ -3,6 +3,7 @@ import json
 from typing import Any, Optional, TypedDict
 
 import requests
+from django.conf import settings
 from django.core.validators import URLValidator
 from drf_spectacular.utils import extend_schema_field
 from requests.exceptions import ConnectionError
@@ -10,7 +11,6 @@ from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied, ValidationError
 
 import custom_view
-from airone import settings
 from airone.lib.acl import ACLType
 from airone.lib.drf import DuplicatedObjectExistsError, ObjectNotExistsError, RequiredParameterError
 from airone.lib.log import Logger

--- a/entity/tests/test_api_v2.py
+++ b/entity/tests/test_api_v2.py
@@ -5,7 +5,6 @@ from unittest import mock
 
 import yaml
 from django.urls import reverse
-from django.test import override_settings
 from rest_framework.exceptions import ValidationError
 
 from acl.models import ACLBase

--- a/entity/tests/test_api_v2.py
+++ b/entity/tests/test_api_v2.py
@@ -5,9 +5,11 @@ from unittest import mock
 
 import yaml
 from django.urls import reverse
+from django.test import override_settings
 from rest_framework.exceptions import ValidationError
 
 from acl.models import ACLBase
+from airone import settings
 from airone.lib import types as atype
 from airone.lib.log import Logger
 from airone.lib.test import AironeViewTest
@@ -1315,6 +1317,31 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 201)
         self.assertTrue(mock_call_custom.called)
 
+    def test_create_entity_with_webhook_is_disabled(self):
+        params = {
+            "name": "entity1",
+            "note": "hoge",
+            "is_toplevel": True,
+            "attrs": [],
+            "webhooks": [
+                {
+                    "url": "http://airone.com",
+                    "label": "hoge",
+                    "is_enabled": True,
+                    "headers": [{"header_key": "Content-Type", "header_value": "application/json"}],
+                }
+            ],
+        }
+        try:
+            settings.AIRONE_FLAGS = {"WEBHOOK": False}
+            resp = self.client.post("/entity/api/v2/", json.dumps(params), "application/json")
+            self.assertEqual(resp.status_code, 400)
+            self.assertEqual(
+                resp.json(), {"webhooks": [{"code": "AE-121000", "message": "webhook is disabled"}]}
+            )
+        finally:
+            settings.AIRONE_FLAGS = {"WEBHOOK": True}
+
     def test_update_entity(self):
         entity: Entity = self.create_entity(
             **{
@@ -2591,6 +2618,41 @@ class ViewTest(AironeViewTest):
             "/entity/api/v2/%d/" % self.entity.id, json.dumps(params), "application/json"
         )
         self.assertEqual(resp.status_code, 200)
+
+    def test_update_entity_with_webhook_is_disabled(self):
+        entity: Entity = self.create_entity(
+            **{
+                "user": self.user,
+                "name": "entity1",
+                "attrs": [],
+                "webhooks": [],
+            }
+        )
+        params = {
+            "name": "entity1",
+            "note": "hoge",
+            "is_toplevel": True,
+            "attrs": [],
+            "webhooks": [
+                {
+                    "url": "http://airone.com",
+                    "label": "hoge",
+                    "is_enabled": True,
+                    "headers": [{"header_key": "Content-Type", "header_value": "application/json"}],
+                }
+            ],
+        }
+        try:
+            settings.AIRONE_FLAGS = {"WEBHOOK": False}
+            resp = self.client.put(
+                "/entity/api/v2/%d/" % entity.id, json.dumps(params), "application/json"
+            )
+            self.assertEqual(resp.status_code, 400)
+            self.assertEqual(
+                resp.json(), {"webhooks": [{"code": "AE-121000", "message": "webhook is disabled"}]}
+            )
+        finally:
+            settings.AIRONE_FLAGS = {"WEBHOOK": True}
 
     def test_delete_entity(self):
         resp = self.client.delete("/entity/api/v2/%d/" % self.entity.id, None, "application/json")

--- a/entity/tests/test_api_v2.py
+++ b/entity/tests/test_api_v2.py
@@ -4,11 +4,11 @@ import logging
 from unittest import mock
 
 import yaml
+from django.conf import settings
 from django.urls import reverse
 from rest_framework.exceptions import ValidationError
 
 from acl.models import ACLBase
-from airone import settings
 from airone.lib import types as atype
 from airone.lib.log import Logger
 from airone.lib.test import AironeViewTest

--- a/frontend/src/components/entity/EntityForm.tsx
+++ b/frontend/src/components/entity/EntityForm.tsx
@@ -5,6 +5,8 @@ import React, { FC } from "react";
 import { Control } from "react-hook-form";
 import { UseFormSetValue } from "react-hook-form/dist/types/form";
 
+import { DjangoContext } from "../../services/DjangoContext";
+
 import { AttributesFields } from "./entityForm/AttributesFields";
 import { BasicFields } from "./entityForm/BasicFields";
 import { Schema } from "./entityForm/EntityFormSchema";
@@ -30,11 +32,15 @@ export const EntityForm: FC<Props> = ({
   setValue,
   referralEntities,
 }) => {
+  const djangoContext = DjangoContext.getInstance();
+
   return (
     <StyledBox>
       <BasicFields control={control} />
 
-      <WebhookFields control={control} />
+      {(djangoContext?.flags.webhook ?? true) && (
+        <WebhookFields control={control} />
+      )}
 
       <AttributesFields
         control={control}

--- a/frontend/src/pages/EditEntityPage.tsx
+++ b/frontend/src/pages/EditEntityPage.tsx
@@ -161,6 +161,7 @@ export const EditEntityPage: FC = () => {
               default:
                 setError(name, { type: "custom", message: message });
             }
+            enqueueSubmitResult(false);
           }
         );
       } else {

--- a/frontend/src/services/DjangoContext.ts
+++ b/frontend/src/services/DjangoContext.ts
@@ -10,6 +10,11 @@ class User {
   }
 }
 
+const FlagKey = {
+  0: "webhook",
+} as const;
+type FlagKey = typeof FlagKey[keyof typeof FlagKey];
+
 // A JavaScript representation for Django context
 export class DjangoContext {
   loginNext: string;
@@ -25,6 +30,7 @@ export class DjangoContext {
     name: string;
     children: { name: string; url: string }[];
   }[];
+  flags: Record<FlagKey, boolean>;
 
   private static _instance: DjangoContext | undefined;
 
@@ -39,6 +45,7 @@ export class DjangoContext {
     this.singleSignOnLoginUrl = context.singleSignOnLoginUrl;
     this.legacyUiDisabled = context.legacyUiDisabled;
     this.extendedHeaderMenus = context.extendedHeaderMenus;
+    this.flags = context.flags ?? { webhook: true };
   }
 
   static getInstance() {

--- a/templates/frontend/index.html
+++ b/templates/frontend/index.html
@@ -32,6 +32,9 @@
           },
           legacyUiDisabled: {{airone.LEGACY_UI_DISABLED|yesno:"true,false"}},
           extendedHeaderMenus: {{ airone.EXTENDED_HEADER_MENUS|safe }},
+          flags: {
+              webhook: {{ airone_flags.WEBHOOK|yesno:"true,false" }},
+          },
       };
     </script>
     <script src="/static/js/ui.js"></script>


### PR DESCRIPTION
webhook is one of the rich feature provided by AirOne. I believe its not so useful for some users, so I'd like to enable/disable the feature, via environment variables.
If disabled,
- API v2 does not process creating/updating webhook settings
- Stop webhook requests
- Hide webhook form fields on the new UI
