### PR TITLE
Added an ID attribute to Entry exported yaml data for importing its data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 ### Changed
+* Added an ID attribute to Entry exported yaml data for importing its data.
+  Contributed by @userlocalhost
 
 ### Fixed
 

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -127,6 +127,7 @@ def _yaml_export(job: Job, values, recv_data: dict, has_referral: bool) -> Optio
     resp_data: dict = {}
     for index, entry_info in enumerate(values):
         data: dict = {
+            "id": entry_info["entry"]["id"],
             "name": entry_info["entry"]["name"],
             "attrs": {},
         }

--- a/dashboard/tests/test_view.py
+++ b/dashboard/tests/test_view.py
@@ -1256,6 +1256,7 @@ class ViewTest(AironeViewTest):
             "date": {"type": AttrTypeValue["date"], "value": date(2020, 1, 1)},
         }
         entities = []
+        test_entries = []
         for index in range(2):
             entity = Entity.objects.create(name="Entity-%d" % index, created_user=user)
             for attr_name, info in attr_info.items():
@@ -1283,6 +1284,7 @@ class ViewTest(AironeViewTest):
                     attrv = attr.add_value(user, info["value"])
 
                 entry.register_es()
+                test_entries.append(entry)
 
             entities.append(entity)
 
@@ -1308,6 +1310,7 @@ class ViewTest(AironeViewTest):
                 len(resp_data[entity.name]), Entry.objects.filter(schema=entity).count()
             )
             for e_data in resp_data[entity.name]:
+                self.assertTrue(e_data["id"] in [x.id for x in test_entries])
                 self.assertTrue(e_data["name"] in ["e-0", "e-1"])
                 self.assertTrue(all([x in attr_info.keys() for x in e_data["attrs"]]))
 

--- a/entry/models.py
+++ b/entry/models.py
@@ -1747,7 +1747,7 @@ class Entry(ACLBase):
             else:
                 attrinfo[attr.schema.name] = None
 
-        return {"name": self.name, "attrs": attrinfo}
+        return {"id": self.id, "name": self.name, "attrs": attrinfo}
 
     def export_v2(self, user, with_entity: bool = False) -> dict:
         attrinfo = []
@@ -1790,7 +1790,7 @@ class Entry(ACLBase):
                 }
             )
 
-        return {"name": self.name, "attrs": attrinfo}
+        return {"id": self.id, "name": self.name, "attrs": attrinfo}
 
     # NOTE: Type-Write
     def get_es_document(self, es=None, entity_attrs=None):

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -41,6 +41,7 @@ class ExportedEntryAttribute(TypedDict):
 
 
 class ExportedEntry(TypedDict):
+    id: int
     name: str
     attrs: list[ExportedEntryAttribute]
     referrals: NotRequired[list[dict]]  # same as ExportedEntityEntries, avoiding cycle definition

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -321,6 +321,7 @@ def _yaml_export_v2(job: Job, values, recv_data: dict, has_referral: bool) -> Op
     resp_data: List[ExportedEntityEntries] = []
     for index, entry_info in enumerate(values):
         data: ExportedEntry = {
+            "id": entry_info["entry"]["id"],
             "name": entry_info["entry"]["name"],
             "attrs": [],
         }

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -4155,7 +4155,7 @@ class ViewTest(AironeViewTest):
         "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)
     )
     def test_export_with_all_entities(self):
-        self.add_entry(self.user, "Entry", self.entity, values={"val": "hoge"})
+        test_entry = self.add_entry(self.user, "Entry", self.entity, values={"val": "hoge"})
 
         resp = self.client.post(
             "/entry/api/v2/advanced_search_result_export/",
@@ -4202,7 +4202,7 @@ class ViewTest(AironeViewTest):
             [
                 {
                     "entity": "test-entity",
-                    "entries": [{"attrs": [{"name": "val", "value": "hoge"}], "name": "Entry"}],
+                    "entries": [{"attrs": [{"name": "val", "value": "hoge"}], "name": "Entry", "id": test_entry.id}],
                 }
             ],
         )

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -4202,7 +4202,13 @@ class ViewTest(AironeViewTest):
             [
                 {
                     "entity": "test-entity",
-                    "entries": [{"attrs": [{"name": "val", "value": "hoge"}], "name": "Entry", "id": test_entry.id}],
+                    "entries": [
+                        {
+                            "attrs": [{"name": "val", "value": "hoge"}],
+                            "name": "Entry",
+                            "id": test_entry.id,
+                        }
+                    ],
                 }
             ],
         )

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -1865,6 +1865,8 @@ class ModelTest(AironeTestCase):
         )
         exported_data = entry.export(user)
         self.assertTrue("new_attr" in exported_data["attrs"])
+        self.assertEqual(exported_data["id"], entry.id)
+        self.assertEqual(exported_data["name"], entry.name)
 
     def test_export_entry_v2(self):
         user = User.objects.create(username="hoge")
@@ -1901,6 +1903,7 @@ class ModelTest(AironeTestCase):
         entry.attrs.get(name="str2").add_value(user, "bar")
 
         exported_data = entry.export_v2(user)
+        self.assertEqual(exported_data["id"], entry.id)
         self.assertEqual(exported_data["name"], entry.name)
         self.assertEqual(
             len(exported_data["attrs"]),


### PR DESCRIPTION
This is necessary when import Entries using data that is exported from AirOne,
because previous implementation doesn't write Entry-ID attribute to export data.
Import processing couldn't understand which Entry is updated Entry or new created one.

This commit fixed that processing by adding Entry ID to export data.