### PR TITLE
Change not to override configuration parameter every time test instance is spawned

### DIFF
--- a/airone/lib/test.py
+++ b/airone/lib/test.py
@@ -37,7 +37,10 @@ class AironeTestCase(TestCase):
 
     def setUp(self):
         OVERRIDE_ES_CONFIG = settings.ES_CONFIG.copy()
-        OVERRIDE_ES_CONFIG["INDEX_NAME"] = "test-" + settings.ES_CONFIG["INDEX_NAME"]
+        # Attach prefix "test-" to distinguish index name for test with configured one.
+        # This should be only one time.
+        if settings.ES_CONFIG["INDEX_NAME"].find("test-") != 0:
+            OVERRIDE_ES_CONFIG["INDEX_NAME"] = "test-" + settings.ES_CONFIG["INDEX_NAME"]
         OVERRIDE_AIRONE = settings.AIRONE.copy()
         OVERRIDE_AIRONE_FLAGS = settings.AIRONE_FLAGS.copy()
         MEDIA_ROOT = "/tmp/airone_app_test"


### PR DESCRIPTION
In the previous implementation of AironeTestCase, prefix word "test-" would be attached to the index name that is configured in the Django settings in the setUp() method of its class to distinguish elasticsearch index for test processing. But below exception woule be happend when there are many test cases in a repository because it would be chained every time test is run.
```
elasticsearch.exceptions.RequestError: RequestError(400, 'invalid_index_name_exception', 'Invalid index name [test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-airone], index name is too long, (256 > 255)')
```

This commit changes its re-configuration processing only one time.