### PR TITLE
Update mysql-innodboperator because helm-dependency-build fails

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: mysql-innodbcluster
   repository: https://mysql.github.io/mysql-operator/
-  version: 2.0.12
+  version: 2.0.13
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.17.3
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 11.1.1
-digest: sha256:786ead0c3a677803bdd0e51b3756f2be32da18b80bb45cfba6658b964cc43336
-generated: "2023-10-30T13:47:16.447745529+09:00"
+digest: sha256:a92ddbb4c1d6978b196670fc0aad8d21ee8ee2d617a6c4add7524eec8e2023c5
+generated: "2024-01-27T10:58:01.260311+09:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     name: mysql-innodbcluster
     alias: mysql
     repository: https://mysql.github.io/mysql-operator/
-    version: 2.0.12
+    version: 2.0.13
   - condition: elasticsearch.enabled
     name: elasticsearch
     repository: https://helm.elastic.co


### PR DESCRIPTION
Fix the build failures https://github.com/dmm-com/airone/actions/runs/7664204490/job/20888201486

(btw the operator seems that depends on MySQL 8.x so I wonder if it works fine without https://github.com/dmm-com/airone/pull/968#discussion_r1342084703 