### PR TITLE
Enable collecting coverage on the frontend

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -91,9 +91,9 @@ jobs:
           poetry run tox
         env:
           TOXENV: "py311"
-      - name: Coverage
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov -t ${CODECOV_TOKEN}
+      - name: coverage
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+          flags: core
         continue-on-error: true

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -70,3 +70,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: test
         run: npm run test
+      - name: codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+          flags: ui
+        continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -169,9 +169,10 @@ docs/public
 # https://qiita.com/knakajima3027/items/f8d10e3066fbcde117d3
 static_root
 
-# React
+# JavaScript, TypeScript, React
 node_modules
 static/js/ui.js*
+coverage
 
 # local django configuration
 airone/settings.py

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "watch:custom": "webpack build --watch --entry ./frontend/src/customview/CustomApp.tsx --mode development",
     "lint": "npx eslint frontend && npx prettier --check frontend",
     "fix": "npx eslint --fix frontend ; npx prettier --write frontend",
-    "test": "TZ=UTC npx jest frontend",
+    "test": "TZ=UTC npx jest --coverage frontend",
     "test:update": "TZ=UTC npx jest -u frontend"
   },
   "repository": {


### PR DESCRIPTION
To visualize code coverage for the frontend with codecov, like the AirOne core.