### PR TITLE
Added processing to invoke TriggerAction when an Entry is created or updated through APIv1 and ordinary view

### DIFF
--- a/api_v1/tests/test_api.py
+++ b/api_v1/tests/test_api.py
@@ -19,6 +19,8 @@ from entry.settings import CONFIG as ENTRY_CONFIG
 from group.models import Group
 from job.models import Job, JobOperation
 from role.models import Role
+from trigger import tasks as trigger_tasks
+from trigger.models import TriggerCondition
 from user.models import User
 
 
@@ -1277,3 +1279,107 @@ class APITest(AironeViewTest):
         }
         resp = self.client.post("/api/v1/entry", json.dumps(params), "application/json")
         self.assertEqual(resp.status_code, 200)
+
+    @mock.patch(
+        "trigger.tasks.may_invoke_trigger.delay",
+        mock.Mock(side_effect=trigger_tasks.may_invoke_trigger),
+    )
+    def test_create_entry_when_trigger_is_set(self):
+        user = self.guest_login()
+
+        # Initialize Entity, Entries and TriggerConditoin
+        ref_entity = Entity.objects.create(name="Referred Entity", created_user=user)
+        ref_entry = Entry.objects.create(name="ref0", schema=ref_entity, created_user=user)
+        params = self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY.copy()
+        for param in params:
+            if param["type"] & AttrTypeValue["object"]:
+                param["ref"] = ref_entity
+
+        entity = self.create_entity(
+            **{"user": user, "name": "Entity", "attrs": params}
+        )
+        TriggerCondition.register(
+            entity,
+            [
+                {"attr_id": entity.attrs.get(name="val").id, "cond": "hoge"},
+                {"attr_id": entity.attrs.get(name="ref").id, "cond": ref_entry.id},
+                {"attr_id": entity.attrs.get(name="bool").id, "cond": True},
+                {"attr_id": entity.attrs.get(name="vals").id, "cond": "hoge"},
+                {"attr_id": entity.attrs.get(name="text").id, "cond": "hoge"},
+                {"attr_id": entity.attrs.get(name="refs").id, "cond": ref_entry.id},
+            ],
+            [
+                {"attr_id": entity.attrs.get(name="vals").id, "values": ["fuga", "piyo"]}
+            ],
+        )
+
+        # send a request to create an Entry with value that invoke TriggerAction
+        params = {
+            "name": "entry1",
+            "entity": entity.name,
+            "attrs": {
+                "val": "hoge",
+                "ref": "ref0",
+                "bool": True,
+                "vals": ["hoge", "fuga"],
+                "text": "hoge",
+                "refs": ["ref0"],
+            },
+        }
+        resp = self.client.post("/api/v1/entry", json.dumps(params), "application/json")
+        self.assertEqual(resp.status_code, 200)
+
+        # check trigger action was worked properly
+        job_query = Job.objects.filter(operation=JobOperation.MAY_INVOKE_TRIGGER.value)
+        self.assertEqual(job_query.count(), 1)
+        self.assertEqual(job_query.first().status, Job.STATUS["DONE"])
+
+        # check created Entry has expected value that is set by TriggerAction
+        entry = Entry.objects.get(id=resp.json()["result"])
+        self.assertEqual(entry.name, "entry1")
+        self.assertEqual(entry.get_attrv("val").value, "hoge")
+        self.assertEqual([x.referral.id for x in entry.get_attrv("refs").data_array.all()], [ref_entry.id])
+        self.assertEqual([x.value for x in entry.get_attrv("vals").data_array.all()], ["fuga", "piyo"])
+
+    @mock.patch(
+        "trigger.tasks.may_invoke_trigger.delay",
+        mock.Mock(side_effect=trigger_tasks.may_invoke_trigger),
+    )
+    def test_update_entry_when_trigger_is_set(self):
+        user = self.guest_login()
+
+        # Initialize Entity, Entry and TriggerConditoin
+        entity = self.create_entity(
+            **{
+                "user": user,
+                "name": "Entity",
+                "attrs": self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY,
+            }
+        )
+        entry = self.add_entry(user, "entry", entity)
+        TriggerCondition.register(
+            entity,
+            [{"attr_id": entity.attrs.get(name="val").id, "cond": "hoge"}],
+            [{"attr_id": entity.attrs.get(name="vals").id, "values": ["fuga", "piyo"]}],
+        )
+
+        # send a request to edit created Entry with value toinvoke TriggerAction
+        params = {
+            "id": entry.id,
+            "name": "Changing Entry name",
+            "entity": entity.name,
+            "attrs": {
+                "val": "hoge",
+            },
+        }
+        resp = self.client.post("/api/v1/entry", json.dumps(params), "application/json")
+        self.assertEqual(resp.status_code, 200)
+
+        # check trigger action was worked properly
+        job_query = Job.objects.filter(operation=JobOperation.MAY_INVOKE_TRIGGER.value)
+        self.assertEqual(job_query.count(), 1)
+        self.assertEqual(job_query.first().status, Job.STATUS["DONE"])
+
+        # check created Entry has expected value that is set by TriggerAction
+        self.assertEqual(entry.get_attrv("val").value, "hoge")
+        self.assertEqual([x.value for x in entry.get_attrv("vals").data_array.all()], ["fuga", "piyo"])

--- a/api_v1/tests/test_api.py
+++ b/api_v1/tests/test_api.py
@@ -1295,9 +1295,7 @@ class APITest(AironeViewTest):
             if param["type"] & AttrTypeValue["object"]:
                 param["ref"] = ref_entity
 
-        entity = self.create_entity(
-            **{"user": user, "name": "Entity", "attrs": params}
-        )
+        entity = self.create_entity(**{"user": user, "name": "Entity", "attrs": params})
         TriggerCondition.register(
             entity,
             [
@@ -1308,9 +1306,7 @@ class APITest(AironeViewTest):
                 {"attr_id": entity.attrs.get(name="text").id, "cond": "hoge"},
                 {"attr_id": entity.attrs.get(name="refs").id, "cond": ref_entry.id},
             ],
-            [
-                {"attr_id": entity.attrs.get(name="vals").id, "values": ["fuga", "piyo"]}
-            ],
+            [{"attr_id": entity.attrs.get(name="vals").id, "values": ["fuga", "piyo"]}],
         )
 
         # send a request to create an Entry with value that invoke TriggerAction
@@ -1338,8 +1334,12 @@ class APITest(AironeViewTest):
         entry = Entry.objects.get(id=resp.json()["result"])
         self.assertEqual(entry.name, "entry1")
         self.assertEqual(entry.get_attrv("val").value, "hoge")
-        self.assertEqual([x.referral.id for x in entry.get_attrv("refs").data_array.all()], [ref_entry.id])
-        self.assertEqual([x.value for x in entry.get_attrv("vals").data_array.all()], ["fuga", "piyo"])
+        self.assertEqual(
+            [x.referral.id for x in entry.get_attrv("refs").data_array.all()], [ref_entry.id]
+        )
+        self.assertEqual(
+            [x.value for x in entry.get_attrv("vals").data_array.all()], ["fuga", "piyo"]
+        )
 
     @mock.patch(
         "trigger.tasks.may_invoke_trigger.delay",
@@ -1382,4 +1382,6 @@ class APITest(AironeViewTest):
 
         # check created Entry has expected value that is set by TriggerAction
         self.assertEqual(entry.get_attrv("val").value, "hoge")
-        self.assertEqual([x.value for x in entry.get_attrv("vals").data_array.all()], ["fuga", "piyo"])
+        self.assertEqual(
+            [x.value for x in entry.get_attrv("vals").data_array.all()], ["fuga", "piyo"]
+        )

--- a/api_v1/tests/test_api.py
+++ b/api_v1/tests/test_api.py
@@ -756,21 +756,25 @@ class APITest(AironeViewTest):
         self.assertEqual(len(results[0]["attrs"]), entry.attrs.count())
         self.assertEqual(
             [x for x in results[0]["attrs"] if x["name"] == "group"],
-            [{
-                "id": entry.attrs.get(schema__name="group").id,
-                "schema_id": entry.attrs.get(schema__name="group").schema.id,
-                "name": "group",
-                "value": "group1"
-            }],
+            [
+                {
+                    "id": entry.attrs.get(schema__name="group").id,
+                    "schema_id": entry.attrs.get(schema__name="group").schema.id,
+                    "name": "group",
+                    "value": "group1",
+                }
+            ],
         )
         self.assertEqual(
             [x for x in results[0]["attrs"] if x["name"] == "groups"],
-            [{
-                "id": entry.attrs.get(schema__name="groups").id,
-                "schema_id": entry.attrs.get(schema__name="groups").schema.id,
-                "name": "groups",
-                "value": ["group1", "group2"]
-            }],
+            [
+                {
+                    "id": entry.attrs.get(schema__name="groups").id,
+                    "schema_id": entry.attrs.get(schema__name="groups").schema.id,
+                    "name": "groups",
+                    "value": ["group1", "group2"],
+                }
+            ],
         )
 
         # the case to specify only 'entry' parameter

--- a/api_v1/tests/test_api.py
+++ b/api_v1/tests/test_api.py
@@ -756,11 +756,21 @@ class APITest(AironeViewTest):
         self.assertEqual(len(results[0]["attrs"]), entry.attrs.count())
         self.assertEqual(
             [x for x in results[0]["attrs"] if x["name"] == "group"],
-            [{"name": "group", "value": "group1"}],
+            [{
+                "id": entry.attrs.get(schema__name="group").id,
+                "schema_id": entry.attrs.get(schema__name="group").schema.id,
+                "name": "group",
+                "value": "group1"
+            }],
         )
         self.assertEqual(
             [x for x in results[0]["attrs"] if x["name"] == "groups"],
-            [{"name": "groups", "value": ["group1", "group2"]}],
+            [{
+                "id": entry.attrs.get(schema__name="groups").id,
+                "schema_id": entry.attrs.get(schema__name="groups").schema.id,
+                "name": "groups",
+                "value": ["group1", "group2"]
+            }],
         )
 
         # the case to specify only 'entry' parameter

--- a/api_v1/views.py
+++ b/api_v1/views.py
@@ -26,7 +26,7 @@ class EntryAPI(APIView):
 
             elif attrtype & AttrTypeValue["named"]:
                 [co_value] = list(value.values())
-                
+
                 return co_value["id"] if co_value else None
 
             elif attrtype & AttrTypeValue["object"]:
@@ -38,21 +38,19 @@ class EntryAPI(APIView):
         trigger_params = []
         for attrname in request_params["attrs"].keys():
             try:
-                [(entity_attr_id, attrtype, attrvalue)] = [(
-                    x["schema_id"],
-                    x["value"]["type"],
-                    x["value"]["value"]
-                ) for x in entry_dict["attrs"] if x["name"] == attrname]
+                [(entity_attr_id, attrtype, attrvalue)] = [
+                    (x["schema_id"], x["value"]["type"], x["value"]["value"])
+                    for x in entry_dict["attrs"]
+                    if x["name"] == attrname
+                ]
             except ValueError:
-                continue 
+                continue
 
-            trigger_params.append({
-                "id": entity_attr_id,
-                "value": _get_value(attrname, attrtype, attrvalue)
-            })
+            trigger_params.append(
+                {"id": entity_attr_id, "value": _get_value(attrname, attrtype, attrvalue)}
+            )
 
         return trigger_params
-
 
     def post(self, request, format=None):
         sel = PostEntrySerializer(data=request.data)

--- a/api_v1/views.py
+++ b/api_v1/views.py
@@ -7,6 +7,7 @@ from rest_framework.views import APIView
 
 import custom_view
 from airone.lib.acl import ACLType
+from airone.lib.types import AttrTypeValue
 from entity.models import Entity
 from entry.models import Entry
 from entry.settings import CONFIG as ENTRY_CONFIG
@@ -16,6 +17,43 @@ from .serializers import PostEntrySerializer
 
 
 class EntryAPI(APIView):
+    def _be_compatible_with_trigger(self, entry, request_params):
+        entry_dict = entry.to_dict(self.request.user, with_metainfo=True)
+
+        def _get_value(attrname, attrtype, value):
+            if isinstance(value, list):
+                return [_get_value(attrname, attrtype, x) for x in value]
+
+            elif attrtype & AttrTypeValue["named"]:
+                [co_value] = list(value.values())
+                
+                return co_value["id"] if co_value else None
+
+            elif attrtype & AttrTypeValue["object"]:
+                return value["id"] if value else None
+
+            else:
+                return value
+
+        trigger_params = []
+        for attrname in request_params["attrs"].keys():
+            try:
+                [(entity_attr_id, attrtype, attrvalue)] = [(
+                    x["schema_id"],
+                    x["value"]["type"],
+                    x["value"]["value"]
+                ) for x in entry_dict["attrs"] if x["name"] == attrname]
+            except ValueError:
+                continue 
+
+            trigger_params.append({
+                "id": entity_attr_id,
+                "value": _get_value(attrname, attrtype, attrvalue)
+            })
+
+        return trigger_params
+
+
     def post(self, request, format=None):
         sel = PostEntrySerializer(data=request.data)
 
@@ -134,6 +172,12 @@ class EntryAPI(APIView):
 
         # register target Entry to the Elasticsearch
         entry.register_es()
+
+        # Create job for TriggerAction. Before calling, it's necessary to make parameters to pass
+        # to TriggerAction from raw_request_data by _be_compatible_with_trigger() method.
+        Job.new_invoke_trigger(
+            request.user, entry, self._be_compatible_with_trigger(entry, raw_request_data)
+        ).run()
 
         entry.del_status(Entry.STATUS_CREATING | Entry.STATUS_EDITING)
 

--- a/entry/models.py
+++ b/entry/models.py
@@ -1628,6 +1628,8 @@ class Entry(ACLBase):
             if attrv is None:
                 returning_attrs.append(
                     {
+                        "id": attr.id,
+                        "schema_id": attr.schema.id,
                         "name": attr.schema.name,
                         "value": AttributeValue.get_default_value(attr),
                     }
@@ -1636,6 +1638,8 @@ class Entry(ACLBase):
             else:
                 returning_attrs.append(
                     {
+                        "id": attr.id,
+                        "schema_id": attr.schema.id,
                         "name": attr.schema.name,
                         "value": attrv.get_value(serialize=True, with_metainfo=with_metainfo),
                     }

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -3777,6 +3777,8 @@ class ModelTest(AironeTestCase):
                 [x["value"] for x in ret_dict["attrs"] if x["name"] == info["name"]],
                 [info["value"]],
             )
+            self.assertIn("id", info)
+            self.assertIn("schema_id", info)
 
     def test_to_dict_entry_for_checking_permission(self):
         admin_user = User.objects.create(username="admin", is_superuser=True)

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -3773,12 +3773,11 @@ class ModelTest(AironeTestCase):
             },
         ]
         for info in expected_attrinfos:
-            self.assertEqual(
-                [x["value"] for x in ret_dict["attrs"] if x["name"] == info["name"]],
-                [info["value"]],
-            )
-            self.assertIn("id", info)
-            self.assertIn("schema_id", info)
+            ret_attr_infos = [x for x in ret_dict["attrs"] if x["name"] == info["name"]]
+            self.assertEqual(len(ret_attr_infos), 1)
+            self.assertEqual(ret_attr_infos[0]["value"], info["value"])
+            self.assertIn("id", ret_attr_infos[0])
+            self.assertIn("schema_id", ret_attr_infos[0])
 
     def test_to_dict_entry_for_checking_permission(self):
         admin_user = User.objects.create(username="admin", is_superuser=True)
@@ -3831,7 +3830,12 @@ class ModelTest(AironeTestCase):
                 "name": entries[2].name,
                 "entity": {"id": public_entity.id, "name": public_entity.name},
                 "attrs": [
-                    {"name": "attr1", "value": "hoge"},
+                    {
+                        "id": entries[2].attrs.get(schema__name="attr1").id,
+                        "schema_id": entries[2].attrs.get(schema__name="attr1").schema.id,
+                        "name": "attr1",
+                        "value": "hoge"
+                    },
                 ],
             },
         )

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -3834,7 +3834,7 @@ class ModelTest(AironeTestCase):
                         "id": entries[2].attrs.get(schema__name="attr1").id,
                         "schema_id": entries[2].attrs.get(schema__name="attr1").schema.id,
                         "name": "attr1",
-                        "value": "hoge"
+                        "value": "hoge",
                     },
                 ],
             },

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -357,10 +357,20 @@ class ViewTest(AironeViewTest):
         # checks created jobs and its params are as expected
         jobs = Job.objects.filter(user=user, target=entry)
         job_expectations = [
-            {"operation": JobOperation.CREATE_ENTRY, "status": Job.STATUS["DONE"]},
+            {
+                "operation": JobOperation.CREATE_ENTRY,
+                "status": Job.STATUS["DONE"],
+                "dependent_job": None,
+            },
             {
                 "operation": JobOperation.NOTIFY_CREATE_ENTRY,
                 "status": Job.STATUS["DONE"],
+                "dependent_job": None,
+            },
+            {
+                "operation": JobOperation.MAY_INVOKE_TRIGGER,
+                "status": Job.STATUS["PREPARING"],
+                "dependent_job": jobs.get(operation=JobOperation.CREATE_ENTRY.value),
             },
         ]
         self.assertEqual(jobs.count(), len(job_expectations))
@@ -369,7 +379,7 @@ class ViewTest(AironeViewTest):
             self.assertEqual(obj.target.id, entry.id)
             self.assertEqual(obj.target_type, Job.TARGET_ENTRY)
             self.assertEqual(obj.status, expectation["status"])
-            self.assertIsNone(obj.dependent_job)
+            self.assertEqual(obj.dependent_job, expectation["dependent_job"])
 
         # checks specify part of attribute parameter then set AttributeValue
         # which is only specified one
@@ -887,14 +897,25 @@ class ViewTest(AironeViewTest):
         # checks created jobs and its params are as expected
         jobs = Job.objects.filter(user=user, target=entry)
         job_expectations = [
-            {"operation": JobOperation.EDIT_ENTRY, "status": Job.STATUS["DONE"]},
+            {
+                "operation": JobOperation.EDIT_ENTRY,
+                "status": Job.STATUS["DONE"],
+                "dependent_job": None,
+            },
             {
                 "operation": JobOperation.REGISTER_REFERRALS,
                 "status": Job.STATUS["PREPARING"],
+                "dependent_job": None,
             },
             {
                 "operation": JobOperation.NOTIFY_UPDATE_ENTRY,
                 "status": Job.STATUS["DONE"],
+                "dependent_job": None,
+            },
+            {
+                "operation": JobOperation.MAY_INVOKE_TRIGGER,
+                "status": Job.STATUS["PREPARING"],
+                "dependent_job": jobs.get(operation=JobOperation.EDIT_ENTRY.value),
             },
         ]
         self.assertEqual(jobs.count(), len(job_expectations))
@@ -903,7 +924,7 @@ class ViewTest(AironeViewTest):
             self.assertEqual(obj.target.id, entry.id)
             self.assertEqual(obj.target_type, Job.TARGET_ENTRY)
             self.assertEqual(obj.status, expectation["status"])
-            self.assertIsNone(obj.dependent_job)
+            self.assertEqual(obj.dependent_job, expectation["dependent_job"])
 
         # checks specify part of attribute parameter then set AttributeValue
         # which is only specified one
@@ -5256,10 +5277,20 @@ class ViewTest(AironeViewTest):
         # checks created jobs and its params are as expected
         jobs = Job.objects.filter(user=user, target=entry)
         job_expectations = [
-            {"operation": JobOperation.CREATE_ENTRY, "status": Job.STATUS["DONE"]},
+            {
+                "operation": JobOperation.CREATE_ENTRY,
+                "status": Job.STATUS["DONE"],
+                "dependent_job": None,
+            },
             {
                 "operation": JobOperation.NOTIFY_CREATE_ENTRY,
                 "status": Job.STATUS["PREPARING"],
+                "dependent_job": None,
+            },
+            {
+                "operation": JobOperation.MAY_INVOKE_TRIGGER,
+                "status": Job.STATUS["PREPARING"],
+                "dependent_job": jobs.get(operation=JobOperation.CREATE_ENTRY.value),
             },
         ]
         self.assertEqual(jobs.count(), len(job_expectations))
@@ -5268,7 +5299,7 @@ class ViewTest(AironeViewTest):
             self.assertEqual(obj.target.id, entry.id)
             self.assertEqual(obj.target_type, Job.TARGET_ENTRY)
             self.assertEqual(obj.status, expectation["status"])
-            self.assertIsNone(obj.dependent_job)
+            self.assertEqual(obj.dependent_job, expectation["dependent_job"])
 
         # Rerun creating that entry job (This is core processing of this test)
         job_create = Job.objects.get(user=user, operation=JobOperation.CREATE_ENTRY.value)

--- a/entry/views.py
+++ b/entry/views.py
@@ -251,6 +251,9 @@ def do_create(request, entity_id, recv_data):
     job_create_entry = Job.new_create(request.user, entry, params=recv_data)
     job_create_entry.run()
 
+    # Create job for TriggerAction
+    Job.new_invoke_trigger(request.user, entry, recv_data.get("attrs", []), job_create_entry).run()
+
     return JsonResponse(
         {
             "entry_id": entry.id,
@@ -354,6 +357,9 @@ def do_edit(request, entry_id, recv_data):
     # Create new jobs to edit entry and notify it to registered webhook endpoint if it's necessary
     job_edit_entry = Job.new_edit(request.user, entry, params=recv_data)
     job_edit_entry.run()
+
+    # Create job for TriggerAction
+    Job.new_invoke_trigger(request.user, entry, recv_data.get("attrs", []), job).run()
 
     # running job of re-register referrals because of chaning entry's name
     if job_register_referrals:

--- a/entry/views.py
+++ b/entry/views.py
@@ -359,7 +359,7 @@ def do_edit(request, entry_id, recv_data):
     job_edit_entry.run()
 
     # Create job for TriggerAction
-    Job.new_invoke_trigger(request.user, entry, recv_data.get("attrs", []), job).run()
+    Job.new_invoke_trigger(request.user, entry, recv_data.get("attrs", []), job_edit_entry).run()
 
     # running job of re-register referrals because of chaning entry's name
     if job_register_referrals:

--- a/job/models.py
+++ b/job/models.py
@@ -262,7 +262,7 @@ class Job(models.Model):
             return method(self.id)
 
     @classmethod
-    def _create_new_job(kls, user, target, operation, text, params) -> "Job":
+    def _create_new_job(kls, user, target, operation, text, params, depend_on=None) -> "Job":
         t_type = kls.TARGET_UNKNOWN
         if isinstance(target, Entry):
             t_type = kls.TARGET_ENTRY
@@ -280,6 +280,9 @@ class Job(models.Model):
                 .order_by("updated_at")
                 .last()
             )
+
+        if dependent_job is None and depend_on is not None:
+            dependent_job = depend_on
 
         params = {
             "user": user,
@@ -527,9 +530,9 @@ class Job(models.Model):
         )
 
     @classmethod
-    def new_invoke_trigger(kls, user, target_entry, recv_attrs={}):
+    def new_invoke_trigger(kls, user, target_entry, recv_attrs={}, dependent_job=None):
         return kls._create_new_job(
-            user, target_entry, JobOperation.MAY_INVOKE_TRIGGER.value, "", json.dumps(recv_attrs)
+            user, target_entry, JobOperation.MAY_INVOKE_TRIGGER.value, "", json.dumps(recv_attrs), dependent_job
         )
 
     def set_cache(self, value):

--- a/job/models.py
+++ b/job/models.py
@@ -532,7 +532,12 @@ class Job(models.Model):
     @classmethod
     def new_invoke_trigger(kls, user, target_entry, recv_attrs={}, dependent_job=None):
         return kls._create_new_job(
-            user, target_entry, JobOperation.MAY_INVOKE_TRIGGER.value, "", json.dumps(recv_attrs), dependent_job
+            user,
+            target_entry,
+            JobOperation.MAY_INVOKE_TRIGGER.value,
+            "",
+            json.dumps(recv_attrs),
+            dependent_job,
         )
 
     def set_cache(self, value):

--- a/trigger/models.py
+++ b/trigger/models.py
@@ -335,7 +335,9 @@ class TriggerCondition(models.Model):
             This method retrieve value from recv_value that is specified by user. This processing
             is necessary to compatible with both API versions (v1 and v2)
             """
-            if isinstance(recv_value, list) and all([isinstance(x, dict) and "data" in x for x in recv_value]):
+            if isinstance(recv_value, list) and all(
+                [isinstance(x, dict) and "data" in x for x in recv_value]
+            ):
                 # In this case, the recv_value is compatible with APIv1 standard
                 # it's necessary to convert it to APIv2 standard
                 if self.attr.type & AttrTypeValue["array"]:
@@ -348,9 +350,9 @@ class TriggerCondition(models.Model):
                 # and this method designed for it.
                 return recv_value
 
-
         # This is a helper method when AttrType is "object" or "named_object"
         recv_value = _compatible_with_apiv1(raw_recv_value)
+
         def _is_match_object(val):
             if isinstance(val, int) or isinstance(val, str):
                 if self.ref_cond and self.ref_cond.is_active:


### PR DESCRIPTION
The new feature TriggerAction was added by https://github.com/dmm-com/airone/pull/1003.
But this feature is activated only from request via APIv2. This feature makes impact for users and they might require to use this from traditional UI (Django view and APIv1).

This PR exceptionally supports TriggerAction invocation processing to the traditional UI.

## ToDo
This PR should enable to invoke TriggerAction when user creates or updates Entry through
- [x] Django view processing (do_create and do_edit in the `entry/views.py`)
- [x] APIv1 processing
- [ ] import processing
- [ ] retrieve processing