### PR TITLE
Try python match syntax to simplify type checking

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -257,7 +257,7 @@ def make_query(
     # Conversion processing from "filter_key" to "keyword" for each hint_attrs
     for hint_attr in hint_attrs:
         match hint_attr.get("filter_key", None):
-            case FilterKey.TEXT_CONTAINED.value:
+            case FilterKey.CLEARED.value:
                 # remove "keyword" parameter
                 hint_attr.pop("keyword", None)
             case FilterKey.EMPTY.value:
@@ -1028,7 +1028,14 @@ def make_search_results(
                     ret_attrinfo["is_readable"] = False
                     continue
 
-            match attrinfo["type"]:
+            try:
+                attr_type = AttrType(attrinfo["type"])
+            except ValueError:
+                # For compatibility; continue that, and record the error
+                Logger.error("Invalid attribute type: %s" % attrinfo["type"])
+                continue
+
+            match attr_type:
                 case AttrType.STRING | AttrType.TEXT | AttrType.BOOLEAN:
                     ret_attrinfo["value"] = attrinfo["value"]
 
@@ -1064,7 +1071,7 @@ def make_search_results(
                     if attrinfo["key"] == attrinfo["value"] == attrinfo["referral_id"] == "":
                         continue
 
-                    match attrinfo["type"]:
+                    match attr_type:
                         case AttrType.ARRAY_NAMED_OBJECT:
                             ret_attrinfo["value"].append(
                                 {


### PR DESCRIPTION
I propose a new coding style, using pattern matching introduced at Python 3.10:
https://qiita.com/ksato9700/items/3ce4c68c0d713874b693

We have a lot of matching logics, especially around checking attribute types. I think it helps to simplify the logics. It can replace `if attr_type == AttrType.STRING; elif attr_type == ...` pattern with `match attr_type; case AttrType.STRING; case ...`