### PR TITLE
Fix deps to avoid inifinite fetching

### DIFF
--- a/frontend/src/pages/ACLHistoryPage.tsx
+++ b/frontend/src/pages/ACLHistoryPage.tsx
@@ -78,7 +78,7 @@ export const ACLHistoryPage: FC = () => {
         });
         break;
     }
-  }, [acl]);
+  }, [acl.loading]);
 
   return (
     <Box className="container-fluid">


### PR DESCRIPTION
Current deps on the `useEffect()` fetches entity/entry are bad. It occurs infinite fetching:
<img width="710" alt="image" src="https://github.com/dmm-com/airone/assets/191684/71d19e09-2654-4946-8ea1-b81a320cd638">
