### PR TITLE
Remove redundant .value

### DIFF
--- a/acl/api_v2/views.py
+++ b/acl/api_v2/views.py
@@ -64,7 +64,7 @@ class ACLHistoryAPI(generics.ListAPIView):
             | Q(codename="%s.%s" % (instance.id, ACLType.Writable.id))  # type: ignore
             | Q(codename="%s.%s" % (instance.id, ACLType.Readable.id))  # type: ignore
         )
-        if instance.objtype == ACLObjType.Entity.value:
+        if instance.objtype == ACLObjType.Entity:
             attrs = instance.attrs.filter(is_active=True)
             acl_history = acl_history + list(
                 itertools.chain.from_iterable([attr.history.all() for attr in attrs])

--- a/acl/models.py
+++ b/acl/models.py
@@ -149,17 +149,17 @@ class ACLBase(models.Model):
 
     def get_subclass_object(self):
         # Use importlib to prevent circular import
-        if self.objtype == ACLObjType.Entity.value:
-            model = importlib.import_module("entity.models").Entity
-        elif self.objtype == ACLObjType.EntityAttr.value:
-            model = importlib.import_module("entity.models").EntityAttr
-        elif self.objtype == ACLObjType.Entry.value:
-            model = importlib.import_module("entry.models").Entry
-        elif self.objtype == ACLObjType.EntryAttr.value:
-            model = importlib.import_module("entry.models").Attribute
-        else:
-            # set ACLBase model
-            model = type(self)
+        match self.objtype:
+            case ACLObjType.Entity:
+                model = importlib.import_module("entity.models").Entity
+            case ACLObjType.EntityAttr:
+                model = importlib.import_module("entity.models").EntityAttr
+            case ACLObjType.Entry:
+                model = importlib.import_module("entry.models").Entry
+            case ACLObjType.EntryAttr:
+                model = importlib.import_module("entry.models").Attribute
+            case _:
+                model = type(self)
 
         return model.objects.get(id=self.id)
 

--- a/acl/views.py
+++ b/acl/views.py
@@ -154,13 +154,13 @@ def set(request, recv_data):
 
 
 def _get_acl_model(object_id):
-    if int(object_id) == ACLObjType.Entity.value:
+    if int(object_id) == ACLObjType.Entity:
         return Entity
-    if int(object_id) == ACLObjType.Entry.value:
+    if int(object_id) == ACLObjType.Entry:
         return Entry
-    elif int(object_id) == ACLObjType.EntityAttr.value:
+    elif int(object_id) == ACLObjType.EntityAttr:
         return EntityAttr
-    elif int(object_id) == ACLObjType.EntryAttr.value:
+    elif int(object_id) == ACLObjType.EntryAttr:
         return Attribute
     else:
         return ACLBase

--- a/airone/celery.py
+++ b/airone/celery.py
@@ -68,5 +68,5 @@ def celery_task_failure_update_job_status(**kwargs):
 
     job_id = kwargs["args"][0]
     job = Job.objects.get(id=job_id)
-    job.status = JobStatus.ERROR.value
+    job.status = JobStatus.ERROR
     job.save(update_fields=["status"])

--- a/airone/lib/acl.py
+++ b/airone/lib/acl.py
@@ -10,7 +10,7 @@ class Iteratable(object):
         return self._types.__iter__()
 
 
-class ACLObjType(enum.Enum):
+class ACLObjType(enum.IntEnum):
     Entity = 1 << 0
     EntityAttr = 1 << 1
     Entry = 1 << 2

--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -38,7 +38,7 @@ class AdvancedSearchResults(TypedDict):
     ret_values: list[AdvancedSearchResultValue]
 
 
-class FilterKey(enum.Enum):
+class FilterKey(enum.IntEnum):
     CLEARED = 0
     EMPTY = 1
     NON_EMPTY = 2
@@ -257,14 +257,14 @@ def make_query(
     # Conversion processing from "filter_key" to "keyword" for each hint_attrs
     for hint_attr in hint_attrs:
         match hint_attr.get("filter_key", None):
-            case FilterKey.CLEARED.value:
+            case FilterKey.CLEARED:
                 # remove "keyword" parameter
                 hint_attr.pop("keyword", None)
-            case FilterKey.EMPTY.value:
+            case FilterKey.EMPTY:
                 hint_attr["keyword"] = "\\"
-            case FilterKey.NON_EMPTY.value:
+            case FilterKey.NON_EMPTY:
                 hint_attr["keyword"] = "*"
-            case FilterKey.DUPLICATED.value:
+            case FilterKey.DUPLICATED:
                 aggs_query = make_aggs_query(hint_attr["name"])
                 # TODO Set to 1 for convenience
                 resp = execute_query(aggs_query, 1)
@@ -828,7 +828,7 @@ def _make_an_attribute_filter(hint: AttrHint, keyword: str) -> dict[str, dict]:
 
         str_cond = {"regexp": {"attr.value": _get_regex_pattern(keyword)}}
 
-        if hint.get("filter_key") == FilterKey.TEXT_NOT_CONTAINED.value:
+        if hint.get("filter_key") == FilterKey.TEXT_NOT_CONTAINED:
             cond_attr.append({"bool": {"must_not": [date_cond, str_cond]}})
         else:
             cond_attr.append({"bool": {"should": [date_cond, str_cond]}})
@@ -857,7 +857,7 @@ def _make_an_attribute_filter(hint: AttrHint, keyword: str) -> dict[str, dict]:
             if "exact_match" not in hint:
                 cond_val.append({"regexp": {"attr.value": _get_regex_pattern(hint_keyword_val)}})
 
-            if hint.get("filter_key") == FilterKey.TEXT_NOT_CONTAINED.value:
+            if hint.get("filter_key") == FilterKey.TEXT_NOT_CONTAINED:
                 cond_attr.append({"bool": {"must_not": cond_val}})
             else:
                 cond_attr.append({"bool": {"should": cond_val}})

--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -135,10 +135,10 @@ def render(request, template, context={}):
     context["navigator"] = {
         "entities": [x for x in entity_objects],
         "acl_objtype": {
-            "entity": ACLObjType.Entity.value,
-            "entry": ACLObjType.Entry.value,
-            "attrbase": ACLObjType.EntityAttr.value,
-            "attr": ACLObjType.EntryAttr.value,
+            "entity": ACLObjType.Entity,
+            "entry": ACLObjType.Entry,
+            "attrbase": ACLObjType.EntityAttr,
+            "attr": ACLObjType.EntryAttr,
         },
     }
 
@@ -157,21 +157,21 @@ def render(request, template, context={}):
     context["JOB"] = {
         "STATUS": {s.name: s.value for s in JobStatus},
         "OPERATION": {
-            "CREATE": JobOperation.CREATE_ENTRY.value,
-            "EDIT": JobOperation.EDIT_ENTRY.value,
-            "DELETE": JobOperation.DELETE_ENTRY.value,
-            "COPY": JobOperation.COPY_ENTRY.value,
-            "DO_COPY": JobOperation.DO_COPY_ENTRY.value,
-            "IMPORT": JobOperation.IMPORT_ENTRY.value,
-            "IMPORT_V2": JobOperation.IMPORT_ENTRY_V2.value,
-            "EXPORT": JobOperation.EXPORT_ENTRY.value,
-            "EXPORT_V2": JobOperation.EXPORT_ENTRY_V2.value,
-            "RESTORE": JobOperation.RESTORE_ENTRY.value,
-            "EXPORT_SEARCH_RESULT": JobOperation.EXPORT_SEARCH_RESULT.value,
-            "EXPORT_SEARCH_RESULT_V2": JobOperation.EXPORT_SEARCH_RESULT_V2.value,
-            "CREATE_ENTITY": JobOperation.CREATE_ENTITY.value,
-            "EDIT_ENTITY": JobOperation.EDIT_ENTITY.value,
-            "DELETE_ENTITY": JobOperation.DELETE_ENTITY.value,
+            "CREATE": JobOperation.CREATE_ENTRY,
+            "EDIT": JobOperation.EDIT_ENTRY,
+            "DELETE": JobOperation.DELETE_ENTRY,
+            "COPY": JobOperation.COPY_ENTRY,
+            "DO_COPY": JobOperation.DO_COPY_ENTRY,
+            "IMPORT": JobOperation.IMPORT_ENTRY,
+            "IMPORT_V2": JobOperation.IMPORT_ENTRY_V2,
+            "EXPORT": JobOperation.EXPORT_ENTRY,
+            "EXPORT_V2": JobOperation.EXPORT_ENTRY_V2,
+            "RESTORE": JobOperation.RESTORE_ENTRY,
+            "EXPORT_SEARCH_RESULT": JobOperation.EXPORT_SEARCH_RESULT,
+            "EXPORT_SEARCH_RESULT_V2": JobOperation.EXPORT_SEARCH_RESULT_V2,
+            "CREATE_ENTITY": JobOperation.CREATE_ENTITY,
+            "EDIT_ENTITY": JobOperation.EDIT_ENTITY,
+            "DELETE_ENTITY": JobOperation.DELETE_ENTITY,
         },
     }
 

--- a/airone/lib/job.py
+++ b/airone/lib/job.py
@@ -14,7 +14,7 @@ def may_schedule_until_job_is_ready(
         if not job.proceed_if_ready():
             return
         # update Job status from PREPARING to PROCEEDING
-        job.update(JobStatus.PROCESSING.value)
+        job.update(JobStatus.PROCESSING)
 
         try:
             # running Job processing
@@ -24,10 +24,10 @@ def may_schedule_until_job_is_ready(
 
         # update Job status after finishing Job processing
         if isinstance(ret, JobStatus):
-            job.update(status=ret.value)
+            job.update(status=ret)
         elif isinstance(ret, tuple) and isinstance(ret[0], JobStatus) and isinstance(ret[1], str):
-            job.update(status=ret[0].value, text=ret[1])
+            job.update(status=ret[0], text=ret[1])
         elif not job.is_canceled():
-            job.update(JobStatus.DONE.value)
+            job.update(JobStatus.DONE)
 
     return wrapper

--- a/airone/lib/types.py
+++ b/airone/lib/types.py
@@ -162,7 +162,7 @@ AttrDefaultValue = {
 }
 
 
-class AttrType(enum.Enum):
+class AttrType(enum.IntEnum):
     OBJECT = AttrTypeObj.TYPE
     STRING = AttrTypeStr.TYPE
     NAMED_OBJECT = AttrTypeNamedObj.TYPE

--- a/airone/tests/test_celery.py
+++ b/airone/tests/test_celery.py
@@ -33,7 +33,7 @@ class CeleryTest(AironeViewTest):
 
     def test_celery_task_failure_update_job_status(self):
         user = self.guest_login()
-        job: Job = Job.objects.create(user=user, status=JobStatus.PREPARING.value)
+        job: Job = Job.objects.create(user=user, status=JobStatus.PREPARING)
         celery_task_failure_update_job_status(
             task_id="test_task_id",
             exception=Exception("Test"),
@@ -43,4 +43,4 @@ class CeleryTest(AironeViewTest):
             einfo=ExceptionInfo,
         )
         job.refresh_from_db()
-        self.assertEqual(job.status, JobStatus.ERROR.value)
+        self.assertEqual(job.status, JobStatus.ERROR)

--- a/api_v1/job/views.py
+++ b/api_v1/job/views.py
@@ -18,27 +18,27 @@ class JobAPI(APIView):
 
         constant = {
             "status": {
-                "processing": JobStatus.PROCESSING.value,
-                "done": JobStatus.DONE.value,
-                "error": JobStatus.ERROR.value,
-                "timeout": JobStatus.TIMEOUT.value,
+                "processing": JobStatus.PROCESSING,
+                "done": JobStatus.DONE,
+                "error": JobStatus.ERROR,
+                "timeout": JobStatus.TIMEOUT,
             },
             "operation": {
-                "create": JobOperation.CREATE_ENTRY.value,
-                "edit": JobOperation.EDIT_ENTRY.value,
-                "delete": JobOperation.DELETE_ENTRY.value,
-                "copy": JobOperation.COPY_ENTRY.value,
-                "do_copy": JobOperation.DO_COPY_ENTRY.value,
-                "import": JobOperation.IMPORT_ENTRY.value,
-                "import_v2": JobOperation.IMPORT_ENTRY_V2.value,
-                "export": JobOperation.EXPORT_ENTRY.value,
-                "export_v2": JobOperation.EXPORT_ENTRY_V2.value,
-                "export_search_result": JobOperation.EXPORT_SEARCH_RESULT.value,
-                "export_search_result_v2": JobOperation.EXPORT_SEARCH_RESULT_V2.value,
-                "restore": JobOperation.RESTORE_ENTRY.value,
-                "create_entity": JobOperation.CREATE_ENTITY.value,
-                "edit_entity": JobOperation.EDIT_ENTITY.value,
-                "delete_entity": JobOperation.DELETE_ENTITY.value,
+                "create": JobOperation.CREATE_ENTRY,
+                "edit": JobOperation.EDIT_ENTRY,
+                "delete": JobOperation.DELETE_ENTRY,
+                "copy": JobOperation.COPY_ENTRY,
+                "do_copy": JobOperation.DO_COPY_ENTRY,
+                "import": JobOperation.IMPORT_ENTRY,
+                "import_v2": JobOperation.IMPORT_ENTRY_V2,
+                "export": JobOperation.EXPORT_ENTRY,
+                "export_v2": JobOperation.EXPORT_ENTRY_V2,
+                "export_search_result": JobOperation.EXPORT_SEARCH_RESULT,
+                "export_search_result_v2": JobOperation.EXPORT_SEARCH_RESULT_V2,
+                "restore": JobOperation.RESTORE_ENTRY,
+                "create_entity": JobOperation.CREATE_ENTITY,
+                "edit_entity": JobOperation.EDIT_ENTITY,
+                "delete_entity": JobOperation.DELETE_ENTITY,
             },
         }
 
@@ -72,14 +72,14 @@ class JobAPI(APIView):
                 "Failed to find Job(id=%s)" % job_id, status=status.HTTP_400_BAD_REQUEST
             )
 
-        if job.status == JobStatus.DONE.value:
+        if job.status == JobStatus.DONE:
             return Response("Target job has already been done")
 
         if job.operation not in Job.CANCELABLE_OPERATIONS:
             return Response("Target job cannot be canceled", status=status.HTTP_400_BAD_REQUEST)
 
         # update job.status to be canceled
-        job.update(JobStatus.CANCELED.value)
+        job.update(JobStatus.CANCELED)
 
         return Response("Success to cancel job")
 
@@ -93,9 +93,9 @@ class SpecificJobAPI(APIView):
             )
 
         # check job status before starting processing
-        if job.status == JobStatus.DONE.value:
+        if job.status == JobStatus.DONE:
             return Response("Target job has already been done")
-        elif job.status == JobStatus.PROCESSING.value:
+        elif job.status == JobStatus.PROCESSING:
             return Response("Target job is under processing", status=status.HTTP_400_BAD_REQUEST)
 
         # check job target status

--- a/api_v1/tests/job/test_api.py
+++ b/api_v1/tests/job/test_api.py
@@ -44,30 +44,30 @@ class APITest(AironeViewTest):
         self.assertEqual(
             results["constant"]["operation"],
             {
-                "create": JobOperation.CREATE_ENTRY.value,
-                "edit": JobOperation.EDIT_ENTRY.value,
-                "delete": JobOperation.DELETE_ENTRY.value,
-                "copy": JobOperation.COPY_ENTRY.value,
-                "do_copy": JobOperation.DO_COPY_ENTRY.value,
-                "import": JobOperation.IMPORT_ENTRY.value,
-                "import_v2": JobOperation.IMPORT_ENTRY_V2.value,
-                "export": JobOperation.EXPORT_ENTRY.value,
-                "export_search_result": JobOperation.EXPORT_SEARCH_RESULT.value,
-                "export_v2": JobOperation.EXPORT_ENTRY_V2.value,
-                "export_search_result_v2": JobOperation.EXPORT_SEARCH_RESULT_V2.value,
-                "restore": JobOperation.RESTORE_ENTRY.value,
-                "create_entity": JobOperation.CREATE_ENTITY.value,
-                "edit_entity": JobOperation.EDIT_ENTITY.value,
-                "delete_entity": JobOperation.DELETE_ENTITY.value,
+                "create": JobOperation.CREATE_ENTRY,
+                "edit": JobOperation.EDIT_ENTRY,
+                "delete": JobOperation.DELETE_ENTRY,
+                "copy": JobOperation.COPY_ENTRY,
+                "do_copy": JobOperation.DO_COPY_ENTRY,
+                "import": JobOperation.IMPORT_ENTRY,
+                "import_v2": JobOperation.IMPORT_ENTRY_V2,
+                "export": JobOperation.EXPORT_ENTRY,
+                "export_search_result": JobOperation.EXPORT_SEARCH_RESULT,
+                "export_v2": JobOperation.EXPORT_ENTRY_V2,
+                "export_search_result_v2": JobOperation.EXPORT_SEARCH_RESULT_V2,
+                "restore": JobOperation.RESTORE_ENTRY,
+                "create_entity": JobOperation.CREATE_ENTITY,
+                "edit_entity": JobOperation.EDIT_ENTITY,
+                "delete_entity": JobOperation.DELETE_ENTITY,
             },
         )
         self.assertEqual(
             results["constant"]["status"],
             {
-                "processing": JobStatus.PROCESSING.value,
-                "done": JobStatus.DONE.value,
-                "error": JobStatus.ERROR.value,
-                "timeout": JobStatus.TIMEOUT.value,
+                "processing": JobStatus.PROCESSING,
+                "done": JobStatus.DONE,
+                "error": JobStatus.ERROR,
+                "timeout": JobStatus.TIMEOUT,
             },
         )
 
@@ -119,7 +119,7 @@ class APITest(AironeViewTest):
         self.assertEqual(resp.content, b'"Success to run command"')
 
         job = Job.objects.get(id=job.id)
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        self.assertEqual(job.status, JobStatus.DONE)
         self.assertEqual(entry.attrs.count(), 1)
 
         attrv = entry.attrs.first().get_latest_value()
@@ -152,7 +152,7 @@ class APITest(AironeViewTest):
 
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content, b'"Success to run command"')
-        self.assertEqual(Job.objects.get(id=job.id).status, JobStatus.DONE.value)
+        self.assertEqual(Job.objects.get(id=job.id).status, JobStatus.DONE)
         self.assertEqual(entry.attrs.first().get_latest_value().value, "fuga")
 
         # make and send a job to copy entry
@@ -161,7 +161,7 @@ class APITest(AironeViewTest):
 
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content, b'"Success to run command"')
-        self.assertEqual(Job.objects.get(id=job.id).status, JobStatus.DONE.value)
+        self.assertEqual(Job.objects.get(id=job.id).status, JobStatus.DONE)
 
         # checks it's success to clone entry
         new_entry = Entry.objects.get(name="new_entry", schema=entity)
@@ -203,12 +203,12 @@ class APITest(AironeViewTest):
         self.assertEqual(resp.status_code, 400)
 
         # send request with a GET parameter that doesn't match any job
-        resp = self.client.get("/api/v1/job/search", {"operation": JobOperation.COPY_ENTRY.value})
+        resp = self.client.get("/api/v1/job/search", {"operation": JobOperation.COPY_ENTRY})
         self.assertEqual(resp.status_code, 404)
 
         # send requests with GET parameter that matches the created job
         for param in [
-            {"operation": JobOperation.DELETE_ENTRY.value},
+            {"operation": JobOperation.DELETE_ENTRY},
             {"target_id": entry.id},
         ]:
             resp = self.client.get("/api/v1/job/search", param)
@@ -225,7 +225,7 @@ class APITest(AironeViewTest):
 
         # make a job
         job = Job.new_delete(user, entry)
-        self.assertEqual(job.status, JobStatus.PREPARING.value)
+        self.assertEqual(job.status, JobStatus.PREPARING)
 
         # send request without any parameters
         resp = self.client.delete("/api/v1/job/", json.dumps({}), "application/json")
@@ -246,7 +246,7 @@ class APITest(AironeViewTest):
 
         # send request with proper parameter
         job = Job.new_create(user, entry)
-        self.assertEqual(job.status, JobStatus.PREPARING.value)
+        self.assertEqual(job.status, JobStatus.PREPARING)
 
         resp = self.client.delete(
             "/api/v1/job/", json.dumps({"job_id": job.id}), "application/json"
@@ -255,7 +255,7 @@ class APITest(AironeViewTest):
         self.assertEqual(resp.content, b'"Success to cancel job"')
 
         job.refresh_from_db()
-        self.assertEqual(job.status, JobStatus.CANCELED.value)
+        self.assertEqual(job.status, JobStatus.CANCELED)
 
     def test_hidden_jobs_is_not_shown(self):
         user = self.guest_login()
@@ -275,4 +275,4 @@ class APITest(AironeViewTest):
         # check API result doesn't contain hidden job
         resp_data = resp.json()
         self.assertEqual(len(resp_data["result"]), 1)
-        self.assertEqual(resp_data["result"][0]["operation"], JobOperation.CREATE_ENTRY.value)
+        self.assertEqual(resp_data["result"][0]["operation"], JobOperation.CREATE_ENTRY)

--- a/api_v1/tests/test_api.py
+++ b/api_v1/tests/test_api.py
@@ -1181,8 +1181,8 @@ class APITest(AironeViewTest):
 
         # check notification event was invoked
         entry = Entry.objects.get(id=resp.json()["result"])
-        job_notify = Job.objects.get(target=entry, operation=JobOperation.NOTIFY_CREATE_ENTRY.value)
-        self.assertEqual(job_notify.status, JobStatus.DONE.value)
+        job_notify = Job.objects.get(target=entry, operation=JobOperation.NOTIFY_CREATE_ENTRY)
+        self.assertEqual(job_notify.status, JobStatus.DONE)
 
     @mock.patch("entry.tasks.notify_entry_update", mock.Mock(return_value=mock.Mock()))
     @mock.patch(
@@ -1204,9 +1204,7 @@ class APITest(AironeViewTest):
         # check creating NOTIFY_UPDATE_ENTRY is restricted because entry is not actually changed
         self.assertEqual(updated_entry.id, entry.id)
         self.assertFalse(
-            Job.objects.filter(
-                target=entry, operation=JobOperation.NOTIFY_UPDATE_ENTRY.value
-            ).exists()
+            Job.objects.filter(target=entry, operation=JobOperation.NOTIFY_UPDATE_ENTRY).exists()
         )
 
     @mock.patch("entry.tasks.notify_entry_update", mock.Mock(return_value=mock.Mock()))
@@ -1233,8 +1231,8 @@ class APITest(AironeViewTest):
         self.assertEqual(updated_entry.id, entry.id)
 
         # check creating NOTIFY_UPDATE_ENTRY is created because of changing Entry name
-        job_notify = Job.objects.get(target=entry, operation=JobOperation.NOTIFY_UPDATE_ENTRY.value)
-        self.assertEqual(job_notify.status, JobStatus.DONE.value)
+        job_notify = Job.objects.get(target=entry, operation=JobOperation.NOTIFY_UPDATE_ENTRY)
+        self.assertEqual(job_notify.status, JobStatus.DONE)
 
     @mock.patch("entry.tasks.delete_entry.delay", mock.Mock(side_effect=tasks.delete_entry))
     @mock.patch("entry.tasks.notify_entry_delete", mock.Mock(return_value=mock.Mock()))
@@ -1259,8 +1257,8 @@ class APITest(AironeViewTest):
         )
         self.assertEqual(resp.status_code, 200)
 
-        job_notify = Job.objects.get(target=entry, operation=JobOperation.NOTIFY_DELETE_ENTRY.value)
-        self.assertEqual(job_notify.status, JobStatus.DONE.value)
+        job_notify = Job.objects.get(target=entry, operation=JobOperation.NOTIFY_DELETE_ENTRY)
+        self.assertEqual(job_notify.status, JobStatus.DONE)
 
     def test_update_entry_that_has_deleted_attribute(self):
         """
@@ -1340,9 +1338,9 @@ class APITest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
 
         # check trigger action was worked properly
-        job_query = Job.objects.filter(operation=JobOperation.MAY_INVOKE_TRIGGER.value)
+        job_query = Job.objects.filter(operation=JobOperation.MAY_INVOKE_TRIGGER)
         self.assertEqual(job_query.count(), 1)
-        self.assertEqual(job_query.first().status, JobStatus.DONE.value)
+        self.assertEqual(job_query.first().status, JobStatus.DONE)
 
         # check created Entry has expected value that is set by TriggerAction
         entry = Entry.objects.get(id=resp.json()["result"])
@@ -1390,9 +1388,9 @@ class APITest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
 
         # check trigger action was worked properly
-        job_query = Job.objects.filter(operation=JobOperation.MAY_INVOKE_TRIGGER.value)
+        job_query = Job.objects.filter(operation=JobOperation.MAY_INVOKE_TRIGGER)
         self.assertEqual(job_query.count(), 1)
-        self.assertEqual(job_query.first().status, JobStatus.DONE.value)
+        self.assertEqual(job_query.first().status, JobStatus.DONE)
 
         # check created Entry has expected value that is set by TriggerAction
         self.assertEqual(entry.get_attrv("val").value, "hoge")

--- a/dashboard/tests/test_view.py
+++ b/dashboard/tests/test_view.py
@@ -272,8 +272,8 @@ class ViewTest(AironeViewTest):
 
         # check export task is executed
         job = Job.objects.last()
-        self.assertEqual(job.operation, JobOperation.EXPORT_SEARCH_RESULT.value)
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        self.assertEqual(job.operation, JobOperation.EXPORT_SEARCH_RESULT)
+        self.assertEqual(job.status, JobStatus.DONE)
         self.assertEqual(json.loads(job.params), export_params)
 
         # check result is set at cache
@@ -300,7 +300,7 @@ class ViewTest(AironeViewTest):
             # check export task is executed
             job = Job.objects.last()
             self.assertEqual(resp.status_code, 200)
-            self.assertEqual(job.operation, JobOperation.EXPORT_SEARCH_RESULT.value)
+            self.assertEqual(job.operation, JobOperation.EXPORT_SEARCH_RESULT)
             with self.assertRaises(OSError) as e:
                 raise OSError
 
@@ -1450,7 +1450,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
 
         # When the job is finished, the processing is passed.
-        job.status = JobStatus.DONE.value
+        job.status = JobStatus.DONE
         job.save(update_fields=["status"])
         resp = self.client.post(
             reverse("dashboard:export_search_result"),

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -305,7 +305,7 @@ def advanced_search_result(request):
 )
 def export_search_result(request, recv_data):
     # check whether same job is sent
-    job_status_not_finished = [JobStatus.PREPARING.value, JobStatus.PROCESSING.value]
+    job_status_not_finished: list[JobStatus] = [JobStatus.PREPARING, JobStatus.PROCESSING]
     if (
         Job.get_job_with_params(request.user, recv_data)
         .filter(status__in=job_status_not_finished)

--- a/entity/models.py
+++ b/entity/models.py
@@ -34,7 +34,7 @@ class EntityAttr(ACLBase):
 
     def __init__(self, *args, **kwargs):
         super(ACLBase, self).__init__(*args, **kwargs)
-        self.objtype = ACLObjType.EntityAttr.value
+        self.objtype = ACLObjType.EntityAttr
 
     def is_updated(self, name, is_mandatory, is_delete_in_chain, index):
         # checks each parameters that are different between current object parameters
@@ -102,7 +102,7 @@ class Entity(ACLBase):
 
     def __init__(self, *args, **kwargs):
         super(Entity, self).__init__(*args, **kwargs)
-        self.objtype = ACLObjType.Entity.value
+        self.objtype = ACLObjType.Entity
 
     def save(self, *args, **kwargs) -> None:
         max_entities: Optional[int] = settings.MAX_ENTITIES

--- a/entity/tests/test_api_v2.py
+++ b/entity/tests/test_api_v2.py
@@ -3507,7 +3507,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual([x["name"] for x in resp.json()], sorted(["bar", "fuga"]))
         self.assertEqual(
-            [x["referral"] for x in resp.json() if x["type"] == AttrType.OBJECT.value][0],
+            [x["referral"] for x in resp.json() if x["type"] == AttrType.OBJECT][0],
             list(entities.values_list("id", flat=True)),
         )
 

--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -1204,7 +1204,7 @@ class AdvancedSearchResultExportSerializer(serializers.Serializer):
     def save(self, **kwargs) -> None:
         user: User = self.context["request"].user
 
-        job_status_not_finished = [JobStatus.PREPARING.value, JobStatus.PROCESSING.value]
+        job_status_not_finished: list[JobStatus] = [JobStatus.PREPARING, JobStatus.PROCESSING]
         if (
             Job.get_job_with_params(user, self.validated_data)
             .filter(status__in=job_status_not_finished)

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -345,7 +345,7 @@ class AdvancedSearchAPI(generics.GenericAPIView):
             blank_joining_info = {
                 "%s.%s" % (join_attr["name"], k["name"]): {
                     "is_readable": True,
-                    "type": AttrType.STRING.value,
+                    "type": AttrType.STRING,
                     "value": "",
                 }
                 for k in join_attr["attrinfo"]
@@ -370,7 +370,7 @@ class AdvancedSearchAPI(generics.GenericAPIView):
                     ref_info is None
                     or
                     # ignore unexpected typed attributes
-                    ref_info["type"] != AttrType.OBJECT.value
+                    ref_info["type"] != AttrType.OBJECT
                     or
                     # ignore when original result doesn't refer any item
                     ref_info["value"].get("id") is None
@@ -533,7 +533,7 @@ class EntryExportAPI(generics.GenericAPIView):
         }
 
         # check whether same job is sent
-        job_status_not_finished = [JobStatus.PREPARING.value, JobStatus.PROCESSING.value]
+        job_status_not_finished = [JobStatus.PREPARING, JobStatus.PROCESSING]
         if (
             Job.get_job_with_params(request.user, job_params)
             .filter(status__in=job_status_not_finished)
@@ -628,15 +628,15 @@ class EntryImportAPI(generics.GenericAPIView):
 
         # limit import job to deny accidental frequent import for same entity
         if request.query_params.get("force", "") not in ["true", "True"]:
-            valid_statuses = [
-                JobStatus.PREPARING.value,
-                JobStatus.PROCESSING.value,
-                JobStatus.DONE.value,
+            valid_statuses: list[JobStatus] = [
+                JobStatus.PREPARING,
+                JobStatus.PROCESSING,
+                JobStatus.DONE,
             ]
             yesterday = datetime.now() - timedelta(days=1)
             if Job.objects.filter(
                 status__in=valid_statuses,
-                operation=JobOperation.IMPORT_ENTRY_V2.value,
+                operation=JobOperation.IMPORT_ENTRY_V2,
                 target__in=entities,
                 created_at__gte=yesterday,
             ).exists():

--- a/entry/models.py
+++ b/entry/models.py
@@ -489,7 +489,7 @@ class Attribute(ACLBase):
 
     def __init__(self, *args, **kwargs):
         super(Attribute, self).__init__(*args, **kwargs)
-        self.objtype = ACLObjType.EntryAttr.value
+        self.objtype = ACLObjType.EntryAttr
 
     def is_array(self):
         return self.schema.type & AttrTypeValue["array"]
@@ -1333,7 +1333,7 @@ class Entry(ACLBase):
 
     def __init__(self, *args, **kwargs):
         super(Entry, self).__init__(*args, **kwargs)
-        self.objtype = ACLObjType.Entry.value
+        self.objtype = ACLObjType.Entry
 
     def add_attribute_from_base(self, base, request_user):
         if not isinstance(base, EntityAttr):

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -1993,8 +1993,8 @@ class ViewTest(AironeViewTest):
         )
 
         job = Job.objects.last()
-        self.assertEqual(job.operation, JobOperation.EXPORT_ENTRY_V2.value)
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        self.assertEqual(job.operation, JobOperation.EXPORT_ENTRY_V2)
+        self.assertEqual(job.status, JobStatus.DONE)
         self.assertEqual(job.text, "entry_ほげ.yaml")
 
         obj = yaml.load(job.get_cache(), Loader=yaml.SafeLoader)
@@ -2068,7 +2068,7 @@ class ViewTest(AironeViewTest):
         )
 
         job = Job.objects.last()
-        self.assertEqual(job.operation, JobOperation.EXPORT_ENTRY_V2.value)
+        self.assertEqual(job.operation, JobOperation.EXPORT_ENTRY_V2)
         self.assertEqual(job.text, "entry_ほげ.yaml")
         with self.assertRaises(OSError) as e:
             raise OSError
@@ -2162,8 +2162,8 @@ class ViewTest(AironeViewTest):
         )
 
         job = Job.objects.last()
-        self.assertEqual(job.operation, JobOperation.EXPORT_ENTRY_V2.value)
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        self.assertEqual(job.operation, JobOperation.EXPORT_ENTRY_V2)
+        self.assertEqual(job.status, JobStatus.DONE)
 
         obj = yaml.load(job.get_cache(), Loader=yaml.SafeLoader)
 
@@ -2494,8 +2494,8 @@ class ViewTest(AironeViewTest):
         fp.close()
 
         self.assertEqual(resp.status_code, 200)
-        job = Job.objects.get(operation=JobOperation.IMPORT_ENTRY_V2.value)
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        job = Job.objects.get(operation=JobOperation.IMPORT_ENTRY_V2)
+        self.assertEqual(job.status, JobStatus.DONE)
         self.assertEqual(job.text, "Imported Entry count: 1")
         self.assertEqual(
             resp.json(),
@@ -2530,8 +2530,8 @@ class ViewTest(AironeViewTest):
             self.assertEqual(result["ret_values"][0]["attrs"][attr_name]["value"], attrs[attr_name])
 
         entry = Entry.objects.get(name="test-entry")
-        job_notify = Job.objects.get(target=entry, operation=JobOperation.NOTIFY_CREATE_ENTRY.value)
-        self.assertEqual(job_notify.status, JobStatus.DONE.value)
+        job_notify = Job.objects.get(target=entry, operation=JobOperation.NOTIFY_CREATE_ENTRY)
+        self.assertEqual(job_notify.status, JobStatus.DONE)
 
     @patch("entry.tasks.notify_update_entry.delay", Mock(side_effect=tasks.notify_update_entry))
     @patch("entry.tasks.import_entries_v2.delay", Mock(side_effect=tasks.import_entries_v2))
@@ -2542,8 +2542,8 @@ class ViewTest(AironeViewTest):
         fp.close()
 
         self.assertEqual(resp.status_code, 200)
-        job = Job.objects.get(operation=JobOperation.IMPORT_ENTRY_V2.value)
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        job = Job.objects.get(operation=JobOperation.IMPORT_ENTRY_V2)
+        self.assertEqual(job.status, JobStatus.DONE)
 
         result = Entry.search_entries(self.user, [self.entity.id], is_output_all=True)
         self.assertEqual(result["ret_count"], 1)
@@ -2566,8 +2566,8 @@ class ViewTest(AironeViewTest):
         for attr_name in result["ret_values"][0]["attrs"]:
             self.assertEqual(result["ret_values"][0]["attrs"][attr_name]["value"], attrs[attr_name])
 
-        job_notify = Job.objects.get(target=entry, operation=JobOperation.NOTIFY_UPDATE_ENTRY.value)
-        self.assertEqual(job_notify.status, JobStatus.DONE.value)
+        job_notify = Job.objects.get(target=entry, operation=JobOperation.NOTIFY_UPDATE_ENTRY)
+        self.assertEqual(job_notify.status, JobStatus.DONE)
 
         # Update only some attributes
         fp = self.open_fixture_file("import_data_v2_update_some.yaml")
@@ -2575,8 +2575,8 @@ class ViewTest(AironeViewTest):
         fp.close()
 
         self.assertEqual(resp.status_code, 200)
-        job = Job.objects.filter(operation=JobOperation.IMPORT_ENTRY_V2.value).last()
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        job = Job.objects.filter(operation=JobOperation.IMPORT_ENTRY_V2).last()
+        self.assertEqual(job.status, JobStatus.DONE)
 
         result = Entry.search_entries(self.user, [self.entity.id], is_output_all=True)
         attrs["val"] = "bar"
@@ -2589,8 +2589,8 @@ class ViewTest(AironeViewTest):
         fp.close()
 
         self.assertEqual(resp.status_code, 200)
-        job = Job.objects.filter(operation=JobOperation.IMPORT_ENTRY_V2.value).last()
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        job = Job.objects.filter(operation=JobOperation.IMPORT_ENTRY_V2).last()
+        self.assertEqual(job.status, JobStatus.DONE)
 
         result = Entry.search_entries(self.user, [self.entity.id], is_output_all=True)
         attrs = {
@@ -2623,8 +2623,8 @@ class ViewTest(AironeViewTest):
         fp.close()
 
         self.assertEqual(resp.status_code, 200)
-        job1 = Job.objects.get(target=entity1, operation=JobOperation.IMPORT_ENTRY_V2.value)
-        job2 = Job.objects.get(target=entity2, operation=JobOperation.IMPORT_ENTRY_V2.value)
+        job1 = Job.objects.get(target=entity1, operation=JobOperation.IMPORT_ENTRY_V2)
+        job2 = Job.objects.get(target=entity2, operation=JobOperation.IMPORT_ENTRY_V2)
         self.assertEqual(job1.text, "Imported Entry count: 1")
         self.assertEqual(job2.text, "Imported Entry count: 1")
         self.assertEqual(
@@ -2656,8 +2656,8 @@ class ViewTest(AironeViewTest):
         fp.close()
 
         self.assertEqual(resp.status_code, 200)
-        job = Job.objects.get(operation=JobOperation.IMPORT_ENTRY_V2.value)
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        job = Job.objects.get(operation=JobOperation.IMPORT_ENTRY_V2)
+        self.assertEqual(job.status, JobStatus.DONE)
         self.assertEqual(job.text, "Imported Entry count: 1")
         self.assertEqual(
             resp.json(),
@@ -2692,8 +2692,8 @@ class ViewTest(AironeViewTest):
             self.assertEqual(result["ret_values"][0]["attrs"][attr_name]["value"], attrs[attr_name])
 
         entry = Entry.objects.get(name="test-entry")
-        job_notify = Job.objects.get(target=entry, operation=JobOperation.NOTIFY_CREATE_ENTRY.value)
-        self.assertEqual(job_notify.status, JobStatus.DONE.value)
+        job_notify = Job.objects.get(target=entry, operation=JobOperation.NOTIFY_CREATE_ENTRY)
+        self.assertEqual(job_notify.status, JobStatus.DONE)
 
         with self.assertLogs(logger=Logger, level=logging.WARNING) as warning_log:
             fp = self.open_fixture_file("import_data_v2.yaml")
@@ -2851,7 +2851,7 @@ class ViewTest(AironeViewTest):
         fp.close()
         job_id = resp.json()["result"]["job_ids"][0]
         job = Job.objects.get(id=job_id)
-        self.assertEqual(job.status, JobStatus.WARNING.value)
+        self.assertEqual(job.status, JobStatus.WARNING)
         self.assertTrue("Imported Entry count: 17" in job.text)
 
     @patch("entry.tasks.import_entries_v2.delay", Mock(side_effect=tasks.import_entries_v2))
@@ -2896,7 +2896,7 @@ class ViewTest(AironeViewTest):
         resp = self.client.post("/entry/api/v2/import/", fp.read(), "application/yaml")
         fp.close()
         self.assertEqual(resp.status_code, 200)
-        job = Job.objects.get(target=self.entity, operation=JobOperation.IMPORT_ENTRY_V2.value)
+        job = Job.objects.get(target=self.entity, operation=JobOperation.IMPORT_ENTRY_V2)
         self.assertEqual(resp.json()["result"], {"job_ids": [job.id], "error": []})
 
     @patch("entry.tasks.import_entries_v2.delay", Mock(side_effect=tasks.import_entries_v2))
@@ -2908,7 +2908,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
         job_id = resp.json()["result"]["job_ids"][0]
         job = Job.objects.get(id=job_id)
-        self.assertEqual(job.status, JobStatus.WARNING.value)
+        self.assertEqual(job.status, JobStatus.WARNING)
         self.assertEqual(job.text, "Imported Entry count: 2, Failed import Entry: ['test-entry1']")
         self.assertTrue(Entry.objects.filter(name="test-entry2").exists())
 
@@ -2922,7 +2922,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
         job_id = resp.json()["result"]["job_ids"][0]
         job = Job.objects.get(id=job_id)
-        self.assertEqual(job.status, JobStatus.CANCELED.value)
+        self.assertEqual(job.status, JobStatus.CANCELED)
         self.assertEqual(job.text, "Now importing... (progress: [    1/    1])")
         self.assertFalse(Entry.objects.filter(name="test-entry").exists())
 
@@ -3291,7 +3291,7 @@ class ViewTest(AironeViewTest):
                 {
                     "name": "ref",
                     "attrinfo": [
-                        {"name": "val", "filter_key": FilterKey.EMPTY.value},
+                        {"name": "val", "filter_key": FilterKey.EMPTY},
                     ],
                 },
             ],
@@ -3313,7 +3313,7 @@ class ViewTest(AironeViewTest):
                 {
                     "name": "ref",
                     "attrinfo": [
-                        {"name": "val", "filter_key": FilterKey.NON_EMPTY.value},
+                        {"name": "val", "filter_key": FilterKey.NON_EMPTY},
                     ],
                 },
             ],
@@ -4232,7 +4232,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
 
         # When the job is finished, the processing is passed.
-        job.status = JobStatus.DONE.value
+        job.status = JobStatus.DONE
         job.save(update_fields=["status"])
         resp = self.client.post(
             "/entry/api/v2/advanced_search_result_export/",

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -149,7 +149,7 @@ class ModelTest(AironeTestCase):
         self._attr.values.add(value)
 
         self.assertEqual(Attribute.objects.count(), 1)
-        self.assertEqual(Attribute.objects.last().objtype, ACLObjType.EntryAttr.value)
+        self.assertEqual(Attribute.objects.last().objtype, ACLObjType.EntryAttr)
         self.assertEqual(Attribute.objects.last().values.count(), 1)
         self.assertEqual(Attribute.objects.last().values.last(), value)
 
@@ -2198,7 +2198,7 @@ class ModelTest(AironeTestCase):
                     {
                         "name": attr.name,
                         "keyword": "*",
-                        "filter_key": FilterKey.TEXT_CONTAINED.value,
+                        "filter_key": FilterKey.TEXT_CONTAINED,
                     }
                 ],
             )
@@ -2213,7 +2213,7 @@ class ModelTest(AironeTestCase):
                 [
                     {
                         "name": attr.name,
-                        "filter_key": FilterKey.NON_EMPTY.value,
+                        "filter_key": FilterKey.NON_EMPTY,
                     }
                 ],
             )
@@ -2227,7 +2227,7 @@ class ModelTest(AironeTestCase):
                 [
                     {
                         "name": attr.name,
-                        "filter_key": FilterKey.EMPTY.value,
+                        "filter_key": FilterKey.EMPTY,
                     }
                 ],
             )
@@ -2246,7 +2246,7 @@ class ModelTest(AironeTestCase):
                     {
                         "name": attr.name,
                         "keyword": "DO MATCH NOTHING",
-                        "filter_key": FilterKey.CLEARED.value,
+                        "filter_key": FilterKey.CLEARED,
                     }
                 ],
             )
@@ -2281,7 +2281,7 @@ class ModelTest(AironeTestCase):
             [
                 {
                     "name": "str",
-                    "filter_key": FilterKey.DUPLICATED.value,
+                    "filter_key": FilterKey.DUPLICATED,
                 },
             ],
         )
@@ -2311,7 +2311,7 @@ class ModelTest(AironeTestCase):
                 {
                     "name": "str",
                     "keyword": "hoge",
-                    "filter_key": FilterKey.TEXT_NOT_CONTAINED.value,
+                    "filter_key": FilterKey.TEXT_NOT_CONTAINED,
                 },
             ],
         )

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -359,25 +359,25 @@ class ViewTest(AironeViewTest):
         job_expectations = [
             {
                 "operation": JobOperation.CREATE_ENTRY,
-                "status": JobStatus.DONE.value,
+                "status": JobStatus.DONE,
                 "dependent_job": None,
             },
             {
                 "operation": JobOperation.NOTIFY_CREATE_ENTRY,
-                "status": JobStatus.DONE.value,
+                "status": JobStatus.DONE,
                 "dependent_job": None,
             },
             {
                 "operation": JobOperation.MAY_INVOKE_TRIGGER,
-                "status": JobStatus.PREPARING.value,
-                "dependent_job": jobs.get(operation=JobOperation.CREATE_ENTRY.value),
+                "status": JobStatus.PREPARING,
+                "dependent_job": jobs.get(operation=JobOperation.CREATE_ENTRY),
             },
         ]
         self.assertEqual(jobs.count(), len(job_expectations))
         for expectation in job_expectations:
             obj = jobs.get(operation=expectation["operation"].value)
             self.assertEqual(obj.target.id, entry.id)
-            self.assertEqual(obj.target_type, JobTarget.ENTRY.value)
+            self.assertEqual(obj.target_type, JobTarget.ENTRY)
             self.assertEqual(obj.status, expectation["status"])
             self.assertEqual(obj.dependent_job, expectation["dependent_job"])
 
@@ -899,30 +899,30 @@ class ViewTest(AironeViewTest):
         job_expectations = [
             {
                 "operation": JobOperation.EDIT_ENTRY,
-                "status": JobStatus.DONE.value,
+                "status": JobStatus.DONE,
                 "dependent_job": None,
             },
             {
                 "operation": JobOperation.REGISTER_REFERRALS,
-                "status": JobStatus.PREPARING.value,
+                "status": JobStatus.PREPARING,
                 "dependent_job": None,
             },
             {
                 "operation": JobOperation.NOTIFY_UPDATE_ENTRY,
-                "status": JobStatus.DONE.value,
+                "status": JobStatus.DONE,
                 "dependent_job": None,
             },
             {
                 "operation": JobOperation.MAY_INVOKE_TRIGGER,
-                "status": JobStatus.PREPARING.value,
-                "dependent_job": jobs.get(operation=JobOperation.EDIT_ENTRY.value),
+                "status": JobStatus.PREPARING,
+                "dependent_job": jobs.get(operation=JobOperation.EDIT_ENTRY),
             },
         ]
         self.assertEqual(jobs.count(), len(job_expectations))
         for expectation in job_expectations:
             obj = jobs.get(operation=expectation["operation"].value)
             self.assertEqual(obj.target.id, entry.id)
-            self.assertEqual(obj.target_type, JobTarget.ENTRY.value)
+            self.assertEqual(obj.target_type, JobTarget.ENTRY)
             self.assertEqual(obj.status, expectation["status"])
             self.assertEqual(obj.dependent_job, expectation["dependent_job"])
 
@@ -1395,8 +1395,8 @@ class ViewTest(AironeViewTest):
         )
 
         job = Job.objects.last()
-        self.assertEqual(job.operation, JobOperation.EXPORT_ENTRY.value)
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        self.assertEqual(job.operation, JobOperation.EXPORT_ENTRY)
+        self.assertEqual(job.status, JobStatus.DONE)
         self.assertEqual(job.text, "entry_ほげ.yaml")
 
         obj = yaml.load(job.get_cache(), Loader=yaml.SafeLoader)
@@ -1465,7 +1465,7 @@ class ViewTest(AironeViewTest):
         )
 
         job = Job.objects.last()
-        self.assertEqual(job.operation, JobOperation.EXPORT_ENTRY.value)
+        self.assertEqual(job.operation, JobOperation.EXPORT_ENTRY)
         self.assertEqual(job.text, "entry_ほげ.yaml")
         with self.assertRaises(OSError) as e:
             raise OSError
@@ -1617,12 +1617,12 @@ class ViewTest(AironeViewTest):
         job_expectations = [
             {
                 "operation": JobOperation.DELETE_ENTRY,
-                "status": JobStatus.DONE.value,
-                "dependent_job": jobs.get(operation=JobOperation.NOTIFY_DELETE_ENTRY.value),
+                "status": JobStatus.DONE,
+                "dependent_job": jobs.get(operation=JobOperation.NOTIFY_DELETE_ENTRY),
             },
             {
                 "operation": JobOperation.NOTIFY_DELETE_ENTRY,
-                "status": JobStatus.DONE.value,
+                "status": JobStatus.DONE,
                 "dependent_job": None,
             },
         ]
@@ -1630,7 +1630,7 @@ class ViewTest(AironeViewTest):
         for expectation in job_expectations:
             obj = jobs.get(operation=expectation["operation"].value)
             self.assertEqual(obj.target.id, entry.id)
-            self.assertEqual(obj.target_type, JobTarget.ENTRY.value)
+            self.assertEqual(obj.target_type, JobTarget.ENTRY)
             self.assertEqual(obj.status, expectation["status"])
             self.assertEqual(obj.dependent_job, expectation["dependent_job"])
 
@@ -1972,9 +1972,9 @@ class ViewTest(AironeViewTest):
         )
 
         # check trigger action was worked properly
-        job_query = Job.objects.filter(operation=JobOperation.MAY_INVOKE_TRIGGER.value)
+        job_query = Job.objects.filter(operation=JobOperation.MAY_INVOKE_TRIGGER)
         self.assertEqual(job_query.count(), 1)
-        self.assertEqual(job_query.first().status, JobStatus.DONE.value)
+        self.assertEqual(job_query.first().status, JobStatus.DONE)
 
         # check created Entry's attributes are set properly by TriggerAction
         entry = Entry.objects.get(id=resp.json().get("entry_id"))
@@ -2072,9 +2072,9 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
 
         # check trigger action was worked properly
-        job_query = Job.objects.filter(operation=JobOperation.MAY_INVOKE_TRIGGER.value)
+        job_query = Job.objects.filter(operation=JobOperation.MAY_INVOKE_TRIGGER)
         self.assertEqual(job_query.count(), 1)
-        self.assertEqual(job_query.first().status, JobStatus.DONE.value)
+        self.assertEqual(job_query.first().status, JobStatus.DONE)
 
         # check updated Entry's attributes are set properly by TriggerAction
         self.assertEqual(resp.json().get("entry_id"), entry.id)
@@ -3276,25 +3276,25 @@ class ViewTest(AironeViewTest):
         self.assertEqual(res["hits"]["total"]["value"], 3)
 
         # checks jobs were created as expected
-        copy_job = Job.objects.filter(user=user, operation=JobOperation.COPY_ENTRY.value).first()
+        copy_job = Job.objects.filter(user=user, operation=JobOperation.COPY_ENTRY).first()
         self.assertEqual(copy_job.text, "Copy completed [%5d/%5d]" % (3, 3))
         self.assertEqual(copy_job.target.entry, entry)
-        self.assertEqual(copy_job.status, JobStatus.DONE.value)
+        self.assertEqual(copy_job.status, JobStatus.DONE)
 
-        do_copy_jobs = Job.objects.filter(user=user, operation=JobOperation.DO_COPY_ENTRY.value)
+        do_copy_jobs = Job.objects.filter(user=user, operation=JobOperation.DO_COPY_ENTRY)
         self.assertEqual(do_copy_jobs.count(), 3)
         for obj in do_copy_jobs.all():
             self.assertTrue(any([obj.target.name == x for x in ["foo", "bar", "baz"]]))
             self.assertEqual(obj.text, "original entry: %s" % entry.name)
-            self.assertEqual(obj.target_type, JobTarget.ENTRY.value)
-            self.assertEqual(obj.status, JobStatus.DONE.value)
+            self.assertEqual(obj.target_type, JobTarget.ENTRY)
+            self.assertEqual(obj.status, JobStatus.DONE)
             self.assertNotEqual(obj.created_at, obj.updated_at)
             self.assertTrue((obj.updated_at - obj.created_at).total_seconds() > 0)
 
         # check notification jobs were create in the copy entry's processing
         notify_jobs = Job.objects.filter(
-            operation=JobOperation.NOTIFY_CREATE_ENTRY.value,
-            status=JobStatus.PREPARING.value,
+            operation=JobOperation.NOTIFY_CREATE_ENTRY,
+            status=JobStatus.PREPARING,
             user=user,
         )
         self.assertEqual(notify_jobs.count(), do_copy_jobs.count())
@@ -3533,14 +3533,14 @@ class ViewTest(AironeViewTest):
         # checks created jobs and its params are as expected
         jobs = Job.objects.filter(user=user)
         job_expectations = [
-            {"operation": JobOperation.IMPORT_ENTRY, "status": JobStatus.DONE.value},
+            {"operation": JobOperation.IMPORT_ENTRY, "status": JobStatus.DONE},
             {
                 "operation": JobOperation.MAY_INVOKE_TRIGGER,
-                "status": JobStatus.PREPARING.value,
+                "status": JobStatus.PREPARING,
             },
             {
                 "operation": JobOperation.NOTIFY_CREATE_ENTRY,
-                "status": JobStatus.PREPARING.value,
+                "status": JobStatus.PREPARING,
             },
         ]
         self.assertEqual(jobs.count(), len(job_expectations))
@@ -3808,12 +3808,10 @@ class ViewTest(AironeViewTest):
         self.client.post(reverse("entry:do_import", args=[self._entity.id]), {"file": fp})
         fp.close()
 
-        job = Job.objects.filter(operation=JobOperation.IMPORT_ENTRY.value).last()
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        job = Job.objects.filter(operation=JobOperation.IMPORT_ENTRY).last()
+        self.assertEqual(job.status, JobStatus.DONE)
 
-        self.assertTrue(
-            Job.objects.filter(operation=JobOperation.NOTIFY_CREATE_ENTRY.value).exists()
-        )
+        self.assertTrue(Job.objects.filter(operation=JobOperation.NOTIFY_CREATE_ENTRY).exists())
 
         ret = Entry.search_entries(user, [self._entity.id], [{"name": "test"}])
         self.assertEqual(ret["ret_count"], 1)
@@ -3827,12 +3825,10 @@ class ViewTest(AironeViewTest):
         self.client.post(reverse("entry:do_import", args=[self._entity.id]), {"file": fp})
         fp.close()
 
-        job = Job.objects.filter(operation=JobOperation.IMPORT_ENTRY.value).last()
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        job = Job.objects.filter(operation=JobOperation.IMPORT_ENTRY).last()
+        self.assertEqual(job.status, JobStatus.DONE)
 
-        self.assertFalse(
-            Job.objects.filter(operation=JobOperation.NOTIFY_UPDATE_ENTRY.value).exists()
-        )
+        self.assertFalse(Job.objects.filter(operation=JobOperation.NOTIFY_UPDATE_ENTRY).exists())
 
         Job.objects.all().delete()
 
@@ -3841,12 +3837,10 @@ class ViewTest(AironeViewTest):
         self.client.post(reverse("entry:do_import", args=[self._entity.id]), {"file": fp})
         fp.close()
 
-        job = Job.objects.filter(operation=JobOperation.IMPORT_ENTRY.value).last()
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        job = Job.objects.filter(operation=JobOperation.IMPORT_ENTRY).last()
+        self.assertEqual(job.status, JobStatus.DONE)
 
-        self.assertTrue(
-            Job.objects.filter(operation=JobOperation.NOTIFY_UPDATE_ENTRY.value).exists()
-        )
+        self.assertTrue(Job.objects.filter(operation=JobOperation.NOTIFY_UPDATE_ENTRY).exists())
 
         ret = Entry.search_entries(user, [self._entity.id], [{"name": "test"}])
         self.assertEqual(ret["ret_count"], 1)
@@ -4451,9 +4445,9 @@ class ViewTest(AironeViewTest):
 
             self.assertEqual(job.user.id, user.id)
             self.assertEqual(job.target.id, entry.id)
-            self.assertEqual(job.target_type, JobTarget.ENTRY.value)
-            self.assertEqual(job.status, JobStatus.PREPARING.value)
-            self.assertEqual(job.operation, JobOperation.EDIT_ENTRY.value)
+            self.assertEqual(job.target_type, JobTarget.ENTRY)
+            self.assertEqual(job.status, JobStatus.PREPARING)
+            self.assertEqual(job.operation, JobOperation.EDIT_ENTRY)
 
         with patch("entry.tasks.edit_entry_attrs.delay", Mock(side_effect=side_effect)):
             resp = self.client.post(
@@ -4917,9 +4911,9 @@ class ViewTest(AironeViewTest):
         self.assertEqual(entry.get_attrv("action").value, "fuga")
 
         # check trigger action was worked properly
-        job_query = Job.objects.filter(operation=JobOperation.MAY_INVOKE_TRIGGER.value)
+        job_query = Job.objects.filter(operation=JobOperation.MAY_INVOKE_TRIGGER)
         self.assertEqual(job_query.count(), 1)
-        self.assertEqual(job_query.first().status, JobStatus.DONE.value)
+        self.assertEqual(job_query.first().status, JobStatus.DONE)
 
     def test_revert_attrv_with_invalid_value(self):
         user = self.guest_login()
@@ -5143,8 +5137,8 @@ class ViewTest(AironeViewTest):
         )
 
         # Check Job processing was ended successfully
-        job = Job.objects.filter(user=user, operation=JobOperation.IMPORT_ENTRY.value).last()
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        job = Job.objects.filter(user=user, operation=JobOperation.IMPORT_ENTRY).last()
+        self.assertEqual(job.status, JobStatus.DONE)
 
     @patch("entry.tasks.import_entries.delay", Mock(side_effect=tasks.import_entries))
     @patch("entry.tasks._do_import_entries")
@@ -5166,8 +5160,8 @@ class ViewTest(AironeViewTest):
         fp.close()
 
         # Check Job processing was failed
-        job = Job.objects.filter(user=user, operation=JobOperation.IMPORT_ENTRY.value).last()
-        self.assertEqual(job.status, JobStatus.ERROR.value)
+        job = Job.objects.filter(user=user, operation=JobOperation.IMPORT_ENTRY).last()
+        self.assertEqual(job.status, JobStatus.ERROR)
         self.assertEqual(
             job.text,
             "[task.import] [job:%d] Unexpected situation was happened" % job.id,
@@ -5268,7 +5262,7 @@ class ViewTest(AironeViewTest):
         for entity_name in ["hoge", "fuga"]:
             self.assertTrue(
                 Job.objects.filter(
-                    target__name=entity_name, operation=JobOperation.IMPORT_ENTRY.value
+                    target__name=entity_name, operation=JobOperation.IMPORT_ENTRY
                 ).exists()
             )
             self.assertTrue(
@@ -5363,31 +5357,31 @@ class ViewTest(AironeViewTest):
         job_expectations = [
             {
                 "operation": JobOperation.CREATE_ENTRY,
-                "status": JobStatus.DONE.value,
+                "status": JobStatus.DONE,
                 "dependent_job": None,
             },
             {
                 "operation": JobOperation.NOTIFY_CREATE_ENTRY,
-                "status": JobStatus.PREPARING.value,
+                "status": JobStatus.PREPARING,
                 "dependent_job": None,
             },
             {
                 "operation": JobOperation.MAY_INVOKE_TRIGGER,
-                "status": JobStatus.PREPARING.value,
-                "dependent_job": jobs.get(operation=JobOperation.CREATE_ENTRY.value),
+                "status": JobStatus.PREPARING,
+                "dependent_job": jobs.get(operation=JobOperation.CREATE_ENTRY),
             },
         ]
         self.assertEqual(jobs.count(), len(job_expectations))
         for expectation in job_expectations:
             obj = jobs.get(operation=expectation["operation"].value)
             self.assertEqual(obj.target.id, entry.id)
-            self.assertEqual(obj.target_type, JobTarget.ENTRY.value)
+            self.assertEqual(obj.target_type, JobTarget.ENTRY)
             self.assertEqual(obj.status, expectation["status"])
             self.assertEqual(obj.dependent_job, expectation["dependent_job"])
 
         # Rerun creating that entry job (This is core processing of this test)
-        job_create = Job.objects.get(user=user, operation=JobOperation.CREATE_ENTRY.value)
-        job_create.status = JobStatus.PREPARING.value
+        job_create = Job.objects.get(user=user, operation=JobOperation.CREATE_ENTRY)
+        job_create.status = JobStatus.PREPARING
         job_create.save()
         job_create.run(will_delay=False)
 

--- a/entry/views.py
+++ b/entry/views.py
@@ -459,7 +459,7 @@ def export(request, entity_id, recv_data):
         job_params["export_format"] = "csv"
 
     # check whether same job is sent
-    job_status_not_finished = [JobStatus.PREPARING.value, JobStatus.PROCESSING.value]
+    job_status_not_finished = [JobStatus.PREPARING, JobStatus.PROCESSING]
     if (
         Job.get_job_with_params(request.user, job_params)
         .filter(status__in=job_status_not_finished)

--- a/group/api_v2/serializers.py
+++ b/group/api_v2/serializers.py
@@ -68,7 +68,7 @@ class GroupCreateUpdateSerializer(serializers.ModelSerializer):
             job_register_referrals = Job.new_register_referrals(
                 self.context["request"].user,
                 None,
-                operation_value=JobOperation.GROUP_REGISTER_REFERRAL.value,
+                operation_value=JobOperation.GROUP_REGISTER_REFERRAL,
                 params={"group_id": instance.id},
             )
 

--- a/group/views.py
+++ b/group/views.py
@@ -100,7 +100,7 @@ def do_edit(request, group_id, recv_data):
         job_register_referrals = Job.new_register_referrals(
             request.user,
             None,
-            operation_value=JobOperation.GROUP_REGISTER_REFERRAL.value,
+            operation_value=JobOperation.GROUP_REGISTER_REFERRAL,
             params={"group_id": group.id},
         )
 

--- a/job/models.py
+++ b/job/models.py
@@ -100,43 +100,43 @@ class Job(models.Model):
     # In some jobs sholdn't make user aware of existence because of user experience
     # (e.g. re-registrating elasticsearch data of entries which refer to changed name entry).
     # These are the jobs that should be proceeded transparently.
-    HIDDEN_OPERATIONS = [
-        JobOperation.REGISTER_REFERRALS.value,
-        JobOperation.NOTIFY_CREATE_ENTRY.value,
-        JobOperation.NOTIFY_UPDATE_ENTRY.value,
-        JobOperation.NOTIFY_DELETE_ENTRY.value,
-        JobOperation.UPDATE_DOCUMENT.value,
-        JobOperation.MAY_INVOKE_TRIGGER.value,
+    HIDDEN_OPERATIONS: list[JobOperation] = [
+        JobOperation.REGISTER_REFERRALS,
+        JobOperation.NOTIFY_CREATE_ENTRY,
+        JobOperation.NOTIFY_UPDATE_ENTRY,
+        JobOperation.NOTIFY_DELETE_ENTRY,
+        JobOperation.UPDATE_DOCUMENT,
+        JobOperation.MAY_INVOKE_TRIGGER,
     ]
 
-    CANCELABLE_OPERATIONS = [
-        JobOperation.CREATE_ENTRY.value,
-        JobOperation.COPY_ENTRY.value,
-        JobOperation.IMPORT_ENTRY.value,
-        JobOperation.IMPORT_ENTRY_V2.value,
-        JobOperation.EXPORT_ENTRY.value,
-        JobOperation.EXPORT_ENTRY_V2.value,
-        JobOperation.REGISTER_REFERRALS.value,
-        JobOperation.EXPORT_SEARCH_RESULT.value,
-        JobOperation.EXPORT_SEARCH_RESULT_V2.value,
+    CANCELABLE_OPERATIONS: list[JobOperation] = [
+        JobOperation.CREATE_ENTRY,
+        JobOperation.COPY_ENTRY,
+        JobOperation.IMPORT_ENTRY,
+        JobOperation.IMPORT_ENTRY_V2,
+        JobOperation.EXPORT_ENTRY,
+        JobOperation.EXPORT_ENTRY_V2,
+        JobOperation.REGISTER_REFERRALS,
+        JobOperation.EXPORT_SEARCH_RESULT,
+        JobOperation.EXPORT_SEARCH_RESULT_V2,
     ]
 
-    PARALLELIZABLE_OPERATIONS = [
-        JobOperation.NOTIFY_CREATE_ENTRY.value,
-        JobOperation.NOTIFY_UPDATE_ENTRY.value,
-        JobOperation.NOTIFY_DELETE_ENTRY.value,
-        JobOperation.COPY_ENTRY.value,
-        JobOperation.DO_COPY_ENTRY.value,
-        JobOperation.IMPORT_ENTRY.value,
-        JobOperation.EXPORT_ENTRY.value,
-        JobOperation.UPDATE_DOCUMENT.value,
+    PARALLELIZABLE_OPERATIONS: list[JobOperation] = [
+        JobOperation.NOTIFY_CREATE_ENTRY,
+        JobOperation.NOTIFY_UPDATE_ENTRY,
+        JobOperation.NOTIFY_DELETE_ENTRY,
+        JobOperation.COPY_ENTRY,
+        JobOperation.DO_COPY_ENTRY,
+        JobOperation.IMPORT_ENTRY,
+        JobOperation.EXPORT_ENTRY,
+        JobOperation.UPDATE_DOCUMENT,
     ]
 
-    DOWNLOADABLE_OPERATIONS = [
-        JobOperation.EXPORT_ENTRY.value,
-        JobOperation.EXPORT_ENTRY_V2.value,
-        JobOperation.EXPORT_SEARCH_RESULT.value,
-        JobOperation.EXPORT_SEARCH_RESULT_V2.value,
+    DOWNLOADABLE_OPERATIONS: list[JobOperation] = [
+        JobOperation.EXPORT_ENTRY,
+        JobOperation.EXPORT_ENTRY_V2,
+        JobOperation.EXPORT_SEARCH_RESULT,
+        JobOperation.EXPORT_SEARCH_RESULT_V2,
     ]
 
     user = models.ForeignKey(User, on_delete=models.DO_NOTHING)
@@ -188,12 +188,12 @@ class Job(models.Model):
         self.refresh_from_db(fields=["status"])
 
         # This value indicates that there is no more processing for a job
-        finished_status = [
-            JobStatus.DONE.value,
-            JobStatus.ERROR.value,
-            JobStatus.TIMEOUT.value,
-            JobStatus.CANCELED.value,
-            JobStatus.WARNING.value,
+        finished_status: list[JobStatus] = [
+            JobStatus.DONE,
+            JobStatus.ERROR,
+            JobStatus.TIMEOUT,
+            JobStatus.CANCELED,
+            JobStatus.WARNING,
         ]
 
         return self.status in finished_status or self.is_timeout()
@@ -202,11 +202,11 @@ class Job(models.Model):
         # Sync status flag information with the data which is stored in database
         self.refresh_from_db(fields=["status"])
 
-        return self.status == JobStatus.CANCELED.value
+        return self.status == JobStatus.CANCELED
 
     def proceed_if_ready(self):
         # In this case, job is finished (might be canceled or proceeded same job by other process)
-        if self.is_finished() or self.status == JobStatus.PROCESSING.value:
+        if self.is_finished() or self.status == JobStatus.PROCESSING:
             return False
 
         # This checks whether dependent job is and it hasn't finished yet.
@@ -279,11 +279,11 @@ class Job(models.Model):
         params,
         depend_on=None,
     ) -> "Job":
-        t_type = JobTarget.UNKNOWN.value
+        t_type = JobTarget.UNKNOWN
         if isinstance(target, Entry):
-            t_type = JobTarget.ENTRY.value
+            t_type = JobTarget.ENTRY
         elif isinstance(target, Entity):
-            t_type = JobTarget.ENTITY.value
+            t_type = JobTarget.ENTITY
 
         # set dependent job to prevent running tasks simultaneously which set to target same one.
         dependent_job = None
@@ -304,7 +304,7 @@ class Job(models.Model):
             "user": user,
             "target": target,
             "target_type": t_type,
-            "status": JobStatus.PREPARING.value,
+            "status": JobStatus.PREPARING,
             "operation": operation,
             "text": text,
             "params": params,
@@ -331,35 +331,35 @@ class Job(models.Model):
             trigger_task = kls.get_task_module("trigger.tasks")
 
             kls._METHOD_TABLE = {
-                JobOperation.CREATE_ENTRY.value: entry_task.create_entry_attrs,
-                JobOperation.EDIT_ENTRY.value: entry_task.edit_entry_attrs,
-                JobOperation.DELETE_ENTRY.value: entry_task.delete_entry,
-                JobOperation.COPY_ENTRY.value: entry_task.copy_entry,
-                JobOperation.DO_COPY_ENTRY.value: entry_task.do_copy_entry,
-                JobOperation.IMPORT_ENTRY.value: entry_task.import_entries,
-                JobOperation.IMPORT_ENTRY_V2.value: entry_task.import_entries_v2,
-                JobOperation.EXPORT_ENTRY.value: entry_task.export_entries,
-                JobOperation.EXPORT_ENTRY_V2.value: entry_task.export_entries_v2,
-                JobOperation.RESTORE_ENTRY.value: entry_task.restore_entry,
-                JobOperation.EXPORT_SEARCH_RESULT.value: dashboard_task.export_search_result,
-                JobOperation.REGISTER_REFERRALS.value: entry_task.register_referrals,
-                JobOperation.CREATE_ENTITY.value: entity_task.create_entity,
-                JobOperation.EDIT_ENTITY.value: entity_task.edit_entity,
-                JobOperation.DELETE_ENTITY.value: entity_task.delete_entity,
-                JobOperation.NOTIFY_CREATE_ENTRY.value: entry_task.notify_create_entry,
-                JobOperation.NOTIFY_UPDATE_ENTRY.value: entry_task.notify_update_entry,
-                JobOperation.NOTIFY_DELETE_ENTRY.value: entry_task.notify_delete_entry,
-                JobOperation.GROUP_REGISTER_REFERRAL.value: group_task.edit_group_referrals,
-                JobOperation.ROLE_REGISTER_REFERRAL.value: role_task.edit_role_referrals,
-                JobOperation.UPDATE_DOCUMENT.value: entry_task.update_es_documents,
-                JobOperation.EXPORT_SEARCH_RESULT_V2.value: entry_task.export_search_result_v2,
-                JobOperation.MAY_INVOKE_TRIGGER.value: trigger_task.may_invoke_trigger,
-                JobOperation.CREATE_ENTITY_V2.value: entity_task.create_entity_v2,
-                JobOperation.EDIT_ENTITY_V2.value: entity_task.edit_entity_v2,
-                JobOperation.DELETE_ENTITY_V2.value: entity_task.delete_entity_v2,
-                JobOperation.CREATE_ENTRY_V2.value: entry_task.create_entry_v2,
-                JobOperation.EDIT_ENTRY_V2.value: entry_task.edit_entry_v2,
-                JobOperation.DELETE_ENTRY_V2.value: entry_task.delete_entry_v2,
+                JobOperation.CREATE_ENTRY: entry_task.create_entry_attrs,
+                JobOperation.EDIT_ENTRY: entry_task.edit_entry_attrs,
+                JobOperation.DELETE_ENTRY: entry_task.delete_entry,
+                JobOperation.COPY_ENTRY: entry_task.copy_entry,
+                JobOperation.DO_COPY_ENTRY: entry_task.do_copy_entry,
+                JobOperation.IMPORT_ENTRY: entry_task.import_entries,
+                JobOperation.IMPORT_ENTRY_V2: entry_task.import_entries_v2,
+                JobOperation.EXPORT_ENTRY: entry_task.export_entries,
+                JobOperation.EXPORT_ENTRY_V2: entry_task.export_entries_v2,
+                JobOperation.RESTORE_ENTRY: entry_task.restore_entry,
+                JobOperation.EXPORT_SEARCH_RESULT: dashboard_task.export_search_result,
+                JobOperation.REGISTER_REFERRALS: entry_task.register_referrals,
+                JobOperation.CREATE_ENTITY: entity_task.create_entity,
+                JobOperation.EDIT_ENTITY: entity_task.edit_entity,
+                JobOperation.DELETE_ENTITY: entity_task.delete_entity,
+                JobOperation.NOTIFY_CREATE_ENTRY: entry_task.notify_create_entry,
+                JobOperation.NOTIFY_UPDATE_ENTRY: entry_task.notify_update_entry,
+                JobOperation.NOTIFY_DELETE_ENTRY: entry_task.notify_delete_entry,
+                JobOperation.GROUP_REGISTER_REFERRAL: group_task.edit_group_referrals,
+                JobOperation.ROLE_REGISTER_REFERRAL: role_task.edit_role_referrals,
+                JobOperation.UPDATE_DOCUMENT: entry_task.update_es_documents,
+                JobOperation.EXPORT_SEARCH_RESULT_V2: entry_task.export_search_result_v2,
+                JobOperation.MAY_INVOKE_TRIGGER: trigger_task.may_invoke_trigger,
+                JobOperation.CREATE_ENTITY_V2: entity_task.create_entity_v2,
+                JobOperation.EDIT_ENTITY_V2: entity_task.edit_entity_v2,
+                JobOperation.DELETE_ENTITY_V2: entity_task.delete_entity_v2,
+                JobOperation.CREATE_ENTRY_V2: entry_task.create_entry_v2,
+                JobOperation.EDIT_ENTRY_V2: entry_task.edit_entry_v2,
+                JobOperation.DELETE_ENTRY_V2: entry_task.delete_entry_v2,
             }
 
         return kls._METHOD_TABLE
@@ -381,7 +381,7 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.CREATE_ENTRY.value,
+            JobOperation.CREATE_ENTRY,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
@@ -391,21 +391,21 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.EDIT_ENTRY.value,
+            JobOperation.EDIT_ENTRY,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
 
     @classmethod
     def new_delete(kls, user, target, text="", params={}):
-        return kls._create_new_job(user, target, JobOperation.DELETE_ENTRY.value, text, params)
+        return kls._create_new_job(user, target, JobOperation.DELETE_ENTRY, text, params)
 
     @classmethod
     def new_copy(kls, user, target, text="", params={}):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.COPY_ENTRY.value,
+            JobOperation.COPY_ENTRY,
             text,
             json.dumps(params, sort_keys=True),
         )
@@ -415,7 +415,7 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.DO_COPY_ENTRY.value,
+            JobOperation.DO_COPY_ENTRY,
             text,
             json.dumps(params, sort_keys=True),
         )
@@ -425,7 +425,7 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             entity,
-            JobOperation.IMPORT_ENTRY.value,
+            JobOperation.IMPORT_ENTRY,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
@@ -435,7 +435,7 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             entity,
-            JobOperation.IMPORT_ENTRY_V2.value,
+            JobOperation.IMPORT_ENTRY_V2,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
@@ -445,7 +445,7 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.EXPORT_ENTRY.value,
+            JobOperation.EXPORT_ENTRY,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
@@ -455,21 +455,21 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.EXPORT_ENTRY_V2.value,
+            JobOperation.EXPORT_ENTRY_V2,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
 
     @classmethod
     def new_restore(kls, user, target, text="", params={}):
-        return kls._create_new_job(user, target, JobOperation.RESTORE_ENTRY.value, text, params)
+        return kls._create_new_job(user, target, JobOperation.RESTORE_ENTRY, text, params)
 
     @classmethod
     def new_export_search_result(kls, user, target=None, text="", params={}):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.EXPORT_SEARCH_RESULT.value,
+            JobOperation.EXPORT_SEARCH_RESULT,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
@@ -479,14 +479,14 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.EXPORT_SEARCH_RESULT_V2.value,
+            JobOperation.EXPORT_SEARCH_RESULT_V2,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
 
     @classmethod
     def new_register_referrals(
-        kls, user, target, operation_value=JobOperation.REGISTER_REFERRALS.value, params={}
+        kls, user, target, operation_value=JobOperation.REGISTER_REFERRALS, params={}
     ):
         return kls._create_new_job(
             user,
@@ -501,7 +501,7 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.CREATE_ENTITY.value,
+            JobOperation.CREATE_ENTITY,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
@@ -511,14 +511,14 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.EDIT_ENTITY.value,
+            JobOperation.EDIT_ENTITY,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
 
     @classmethod
     def new_delete_entity(kls, user, target, text="", params={}):
-        return kls._create_new_job(user, target, JobOperation.DELETE_ENTITY.value, text, params)
+        return kls._create_new_job(user, target, JobOperation.DELETE_ENTITY, text, params)
 
     @classmethod
     def new_update_documents(kls, target, text="", params={}):
@@ -528,35 +528,29 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.UPDATE_DOCUMENT.value,
+            JobOperation.UPDATE_DOCUMENT,
             text,
             json.dumps(params, sort_keys=True),
         )
 
     @classmethod
     def new_notify_create_entry(kls, user, target, text="", params={}):
-        return kls._create_new_job(
-            user, target, JobOperation.NOTIFY_CREATE_ENTRY.value, text, params
-        )
+        return kls._create_new_job(user, target, JobOperation.NOTIFY_CREATE_ENTRY, text, params)
 
     @classmethod
     def new_notify_update_entry(kls, user, target, text="", params={}):
-        return kls._create_new_job(
-            user, target, JobOperation.NOTIFY_UPDATE_ENTRY.value, text, params
-        )
+        return kls._create_new_job(user, target, JobOperation.NOTIFY_UPDATE_ENTRY, text, params)
 
     @classmethod
     def new_notify_delete_entry(kls, user, target, text="", params={}):
-        return kls._create_new_job(
-            user, target, JobOperation.NOTIFY_DELETE_ENTRY.value, text, params
-        )
+        return kls._create_new_job(user, target, JobOperation.NOTIFY_DELETE_ENTRY, text, params)
 
     @classmethod
     def new_invoke_trigger(kls, user, target_entry, recv_attrs={}, dependent_job=None):
         return kls._create_new_job(
             user,
             target_entry,
-            JobOperation.MAY_INVOKE_TRIGGER.value,
+            JobOperation.MAY_INVOKE_TRIGGER,
             "",
             json.dumps(recv_attrs),
             dependent_job,
@@ -567,7 +561,7 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.CREATE_ENTITY_V2.value,
+            JobOperation.CREATE_ENTITY_V2,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
@@ -577,7 +571,7 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.EDIT_ENTITY_V2.value,
+            JobOperation.EDIT_ENTITY_V2,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
@@ -587,7 +581,7 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.DELETE_ENTITY_V2.value,
+            JobOperation.DELETE_ENTITY_V2,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
@@ -597,7 +591,7 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.CREATE_ENTRY_V2.value,
+            JobOperation.CREATE_ENTRY_V2,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
@@ -607,7 +601,7 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.EDIT_ENTRY_V2.value,
+            JobOperation.EDIT_ENTRY_V2,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )
@@ -617,7 +611,7 @@ class Job(models.Model):
         return kls._create_new_job(
             user,
             target,
-            JobOperation.DELETE_ENTRY_V2.value,
+            JobOperation.DELETE_ENTRY_V2,
             text,
             json.dumps(params, default=_support_time_default, sort_keys=True),
         )

--- a/job/tests/test_api_v2.py
+++ b/job/tests/test_api_v2.py
@@ -61,7 +61,7 @@ class ViewTest(AironeViewTest):
         # Confirm that the delete job can be obtained
         body = resp.json()
         self.assertEqual(body["count"], 1)
-        self.assertEqual(body["results"][0]["operation"], JobOperation.DELETE_ENTRY.value)
+        self.assertEqual(body["results"][0]["operation"], JobOperation.DELETE_ENTRY)
 
     def test_get_non_target_job(self):
         user = self.guest_login()
@@ -119,7 +119,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
         self.assertEqual(body["id"], job.id)
-        self.assertEqual(body["status"], JobStatus.PREPARING.value)
+        self.assertEqual(body["status"], JobStatus.PREPARING)
         self.assertEqual(body["text"], "hoge")
 
     def test_get_job_with_invalid_param(self):
@@ -153,7 +153,7 @@ class ViewTest(AironeViewTest):
 
         # make a job which isn't cancellable
         job = Job.new_delete(user, entry)
-        self.assertEqual(job.status, JobStatus.PREPARING.value)
+        self.assertEqual(job.status, JobStatus.PREPARING)
 
         # send request with invalid job id
         resp = self.client.delete("/job/api/v2/%d/" % 99999)
@@ -165,7 +165,7 @@ class ViewTest(AironeViewTest):
 
         # make a cancellable job
         job = Job.new_create(user, entry)
-        self.assertEqual(job.status, JobStatus.PREPARING.value)
+        self.assertEqual(job.status, JobStatus.PREPARING)
         resp = self.client.delete("/job/api/v2/%d/" % job.id)
         self.assertEqual(resp.status_code, 204)
 
@@ -202,7 +202,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 200)
 
         job = Job.objects.get(id=job.id)
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        self.assertEqual(job.status, JobStatus.DONE)
         self.assertEqual(entry.attrs.count(), 1)
 
         attrv = entry.attrs.first().get_latest_value()
@@ -232,14 +232,14 @@ class ViewTest(AironeViewTest):
         )
         resp = self.client.patch("/job/api/v2/%d/rerun" % job.id)
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(Job.objects.get(id=job.id).status, JobStatus.DONE.value)
+        self.assertEqual(Job.objects.get(id=job.id).status, JobStatus.DONE)
         self.assertEqual(entry.attrs.first().get_latest_value().value, "fuga")
 
         # make and send a job to copy entry
         job = Job.new_do_copy(user, entry, params={"new_name": "new_entry"})
         resp = self.client.patch("/job/api/v2/%d/rerun" % job.id)
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(Job.objects.get(id=job.id).status, JobStatus.DONE.value)
+        self.assertEqual(Job.objects.get(id=job.id).status, JobStatus.DONE)
 
         # checks it's success to clone entry
         new_entry = Entry.objects.get(name="new_entry", schema=entity)
@@ -293,7 +293,7 @@ class ViewTest(AironeViewTest):
         )
 
         # send request to download job when not exists file
-        job.status = JobStatus.DONE.value
+        job.status = JobStatus.DONE
         job.save()
 
         resp = self.client.get("/job/api/v2/%d/download" % job.id)

--- a/job/tests/test_model.py
+++ b/job/tests/test_model.py
@@ -22,18 +22,18 @@ class ModelTest(AironeTestCase):
 
     def test_create_object(self):
         jobinfos = [
-            {"method": "new_create", "op": JobOperation.CREATE_ENTRY.value},
-            {"method": "new_edit", "op": JobOperation.EDIT_ENTRY.value},
-            {"method": "new_delete", "op": JobOperation.DELETE_ENTRY.value},
-            {"method": "new_copy", "op": JobOperation.COPY_ENTRY.value},
+            {"method": "new_create", "op": JobOperation.CREATE_ENTRY},
+            {"method": "new_edit", "op": JobOperation.EDIT_ENTRY},
+            {"method": "new_delete", "op": JobOperation.DELETE_ENTRY},
+            {"method": "new_copy", "op": JobOperation.COPY_ENTRY},
         ]
         for info in jobinfos:
             job = getattr(Job, info["method"])(self.guest, self.entry)
 
             self.assertEqual(job.user, self.guest)
             self.assertEqual(job.target, self.entry)
-            self.assertEqual(job.target_type, JobTarget.ENTRY.value)
-            self.assertEqual(job.status, JobStatus.PREPARING.value)
+            self.assertEqual(job.target_type, JobTarget.ENTRY)
+            self.assertEqual(job.status, JobStatus.PREPARING)
             self.assertEqual(job.operation, info["op"])
 
     def test_get_object(self):
@@ -48,8 +48,8 @@ class ModelTest(AironeTestCase):
 
         # create a new job
         job = Job.new_export(self.guest, text="hoge", params=params)
-        self.assertEqual(job.target_type, JobTarget.UNKNOWN.value)
-        self.assertEqual(job.operation, JobOperation.EXPORT_ENTRY.value)
+        self.assertEqual(job.target_type, JobTarget.UNKNOWN)
+        self.assertEqual(job.operation, JobOperation.EXPORT_ENTRY)
         self.assertEqual(job.text, "hoge")
 
         # check created job is got by specified params
@@ -103,11 +103,11 @@ class ModelTest(AironeTestCase):
         job = Job.new_create(self.guest, self.entry)
 
         for status in [
-            JobStatus.DONE.value,
-            JobStatus.ERROR.value,
-            JobStatus.TIMEOUT.value,
-            JobStatus.CANCELED.value,
-            JobStatus.WARNING.value,
+            JobStatus.DONE,
+            JobStatus.ERROR,
+            JobStatus.TIMEOUT,
+            JobStatus.CANCELED,
+            JobStatus.WARNING,
         ]:
             job.status = status
             job.save(update_fields=["status"])
@@ -119,83 +119,83 @@ class ModelTest(AironeTestCase):
         self.assertFalse(job.is_canceled())
 
         # change status of target job
-        job.update(JobStatus.CANCELED.value)
+        job.update(JobStatus.CANCELED)
 
         # confirms that is_canceled would be true by changing job status parameter
         self.assertTrue(job.is_canceled())
 
     def test_update_method(self):
         job = Job.new_create(self.guest, self.entry, "original text")
-        self.assertEqual(job.status, JobStatus.PREPARING.value)
-        self.assertEqual(job.operation, JobOperation.CREATE_ENTRY.value)
+        self.assertEqual(job.status, JobStatus.PREPARING)
+        self.assertEqual(job.operation, JobOperation.CREATE_ENTRY)
         last_updated_time = job.updated_at
 
         # When an invalid status value is specified, status value won't be changed
         job.update(9999)
         job.refresh_from_db()
 
-        self.assertEqual(job.status, JobStatus.PREPARING.value)
+        self.assertEqual(job.status, JobStatus.PREPARING)
         self.assertEqual(job.text, "original text")
         self.assertEqual(job.target.id, self.entry.id)
-        self.assertEqual(job.operation, JobOperation.CREATE_ENTRY.value)
+        self.assertEqual(job.operation, JobOperation.CREATE_ENTRY)
         self.assertGreater(job.updated_at, last_updated_time)
         last_updated_time = job.updated_at
 
         # update only status parameter
-        job.update(JobStatus.PROCESSING.value)
+        job.update(JobStatus.PROCESSING)
         job.refresh_from_db()
 
-        self.assertEqual(job.status, JobStatus.PROCESSING.value)
+        self.assertEqual(job.status, JobStatus.PROCESSING)
         self.assertEqual(job.text, "original text")
         self.assertEqual(job.target.id, self.entry.id)
-        self.assertEqual(job.operation, JobOperation.CREATE_ENTRY.value)
+        self.assertEqual(job.operation, JobOperation.CREATE_ENTRY)
         self.assertGreater(job.updated_at, last_updated_time)
         last_updated_time = job.updated_at
 
         # update status and text parameters
-        job.update(JobStatus.CANCELED.value, "changed message")
+        job.update(JobStatus.CANCELED, "changed message")
         job.refresh_from_db()
-        self.assertEqual(job.status, JobStatus.CANCELED.value)
+        self.assertEqual(job.status, JobStatus.CANCELED)
         self.assertEqual(job.text, "changed message")
         self.assertEqual(job.target.id, self.entry.id)
-        self.assertEqual(job.operation, JobOperation.CREATE_ENTRY.value)
+        self.assertEqual(job.operation, JobOperation.CREATE_ENTRY)
         self.assertGreater(job.updated_at, last_updated_time)
         last_updated_time = job.updated_at
 
         # update status, text and target parameters
         new_entry = Entry.objects.create(name="newone", created_user=self.guest, schema=self.entity)
-        job.update(JobStatus.DONE.value, "further changed message", new_entry)
+        job.update(JobStatus.DONE, "further changed message", new_entry)
         job.refresh_from_db()
 
-        self.assertEqual(job.status, JobStatus.DONE.value)
+        self.assertEqual(job.status, JobStatus.DONE)
         self.assertEqual(job.text, "further changed message")
         self.assertEqual(job.target.id, new_entry.id)
-        self.assertEqual(job.operation, JobOperation.CREATE_ENTRY.value)
+        self.assertEqual(job.operation, JobOperation.CREATE_ENTRY)
         self.assertGreater(job.updated_at, last_updated_time)
 
         # update invalid operation, job operation parameter won't be changed
         job.update(operation=9999)
-        self.assertEqual(job.operation, JobOperation.CREATE_ENTRY.value)
+        self.assertEqual(job.operation, JobOperation.CREATE_ENTRY)
 
         # update valid operation, job operation parameter will be changed
-        job.update(operation=JobOperation.EDIT_ENTRY.value)
-        self.assertEqual(job.operation, JobOperation.EDIT_ENTRY.value)
+        job.update(operation=JobOperation.EDIT_ENTRY)
+        self.assertEqual(job.operation, JobOperation.EDIT_ENTRY)
 
     def test_proceed_if_ready(self):
         job = Job.new_create(self.guest, self.entry)
 
         for status in [
-            JobStatus.DONE.value,
-            JobStatus.ERROR.value,
-            JobStatus.TIMEOUT.value,
-            JobStatus.CANCELED.value,
-            JobStatus.PROCESSING.value,
+            JobStatus.DONE,
+            JobStatus.ERROR,
+            JobStatus.TIMEOUT,
+            JobStatus.CANCELED,
+            JobStatus.PROCESSING,
         ]:
             job.status = status
             job.save(update_fields=["status"])
             self.assertFalse(job.proceed_if_ready())
 
-        job.status = JobStatus.PREPARING.value
+        job.status = JobStatus.PREPARING
         job.save(update_fields=["status"])
         self.assertTrue(job.proceed_if_ready())
 
@@ -231,7 +231,7 @@ class ModelTest(AironeTestCase):
     def test_may_schedule_with_parallelizable_operation(self):
         [job1, job2] = [Job.new_notify_update_entry(self.guest, self.entry) for _ in range(2)]
         self.assertEqual(job2.dependent_job, job1)
-        self.assertEqual(job1.status, JobStatus.PREPARING.value)
+        self.assertEqual(job1.status, JobStatus.PREPARING)
         self.assertTrue(job2.proceed_if_ready())
 
     @mock.patch("job.models.import_module")

--- a/job/tests/test_view.py
+++ b/job/tests/test_view.py
@@ -92,7 +92,7 @@ class ViewTest(AironeViewTest):
 
         # Confirm that the delete job can be obtained
         self.assertEqual(len(resp.context["jobs"]), 1)
-        self.assertEqual(resp.context["jobs"][0]["operation"], JobOperation.DELETE_ENTRY.value)
+        self.assertEqual(resp.context["jobs"][0]["operation"], JobOperation.DELETE_ENTRY)
 
         # check respond HTML has expected elements which are specified of CSS selectors
         parser = HTML(html=resp.content.decode("utf-8"))
@@ -147,7 +147,7 @@ class ViewTest(AironeViewTest):
         def side_effect():
             # send re-run request for executing job by calling API
             job = Job.objects.last()
-            self.assertEqual(job.status, JobStatus.PROCESSING.value)
+            self.assertEqual(job.status, JobStatus.PROCESSING)
 
             # check that backend processing never run by calling API
             resp = self.client.post("/api/v1/job/run/%d" % job.id)
@@ -235,4 +235,4 @@ class ViewTest(AironeViewTest):
         resp = self.client.get("/job/")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.context["jobs"]), 1)
-        self.assertEqual(resp.context["jobs"][0]["operation"], JobOperation.CREATE_ENTRY.value)
+        self.assertEqual(resp.context["jobs"][0]["operation"], JobOperation.CREATE_ENTRY)

--- a/job/views.py
+++ b/job/views.py
@@ -22,8 +22,8 @@ def index(request):
         limitation = None
 
     export_operations = [
-        JobOperation.EXPORT_ENTRY.value,
-        JobOperation.EXPORT_SEARCH_RESULT.value,
+        JobOperation.EXPORT_ENTRY,
+        JobOperation.EXPORT_SEARCH_RESULT,
     ]
 
     query = Q(Q(user=request.user), ~Q(operation__in=Job.HIDDEN_OPERATIONS))
@@ -45,8 +45,8 @@ def index(request):
             if (
                 x.operation in export_operations
                 or (x.operation not in export_operations and x.target and x.target.is_active)
-                or (x.operation is JobOperation.DELETE_ENTITY.value and x.target)
-                or (x.operation is JobOperation.DELETE_ENTRY.value and x.target)
+                or (x.operation == JobOperation.DELETE_ENTITY and x.target)
+                or (x.operation == JobOperation.DELETE_ENTRY and x.target)
             )
         ]
     }

--- a/role/views.py
+++ b/role/views.py
@@ -214,7 +214,7 @@ def do_edit(request, role_id, recv_data):
         job_register_referrals = Job.new_register_referrals(
             request.user,
             None,
-            operation_value=JobOperation.ROLE_REGISTER_REFERRAL.value,
+            operation_value=JobOperation.ROLE_REGISTER_REFERRAL,
             params={"role_id": role.id},
         )
 


### PR DESCRIPTION
Enum values are directly usable! Calling `.value` is noisy and redundant, so I remove them to keep the code simple.