### PR TITLE
Change super-class of AttrType from IntFlag to IntEnum

### DIFF
--- a/airone/lib/types.py
+++ b/airone/lib/types.py
@@ -3,7 +3,7 @@ from typing import Any
 
 
 @enum.unique
-class AttrType(enum.IntFlag):
+class AttrType(enum.IntEnum):
     OBJECT = 1 << 0
     STRING = 1 << 1
     TEXT = 1 << 2


### PR DESCRIPTION
It's impossible to read whole AttrType values by following processing as below.
```
>>> from airone.lib.types import AttrType
>>> [k.name for k in AttrType]
['OBJECT', 'STRING', 'TEXT', 'BOOLEAN', 'GROUP', 'DATE', 'ROLE', '_ARRAY', '_NAMED']
>>>
```

This is because IntFlag can't handles value that is composited one of multile flags like NAMED_OBJECT. The AttrType is supposed to those composite values by multiple flags, so this commit changes its super class to IntEnum to hanedle those values.

As a result, we can use whole values that are declared in the AttrType as below.
```
>>> from airone.lib.types import AttrType
>>> [k.name for k in AttrType]
['OBJECT', 'STRING', 'TEXT', 'BOOLEAN', 'GROUP', 'DATE', 'ROLE', '_ARRAY', '_NAMED', 'NAMED_OBJECT', 'ARRAY_OBJECT', 'ARRAY_STRING', 'ARRAY_NAMED_OBJECT', 'ARRAY_NAMED_OBJECT_BOOLEAN', 'ARRAY_GROUP', 'ARRAY_ROLE']
```