### PR TITLE
airone -> pagoda

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1,6 +1,6 @@
 ---
-baseURL: https://dmm-com.github.io/airone/
-title: AirOne
+baseURL: https://dmm-com.github.io/pagoda/
+title: Pagoda
 theme: hugo-geekdoc
 canonifyURLs: true
 pygmentsUseClasses: true

--- a/docs/data/menu/more.yaml
+++ b/docs/data/menu/more.yaml
@@ -4,10 +4,10 @@ more:
     ref: "/posts"
     icon: "notification"
   - name: Releases
-    ref: "https://github.com/dmm-com/airone/releases"
+    ref: "https://github.com/dmm-com/pagoda/releases"
     external: true
     icon: "download"
   - name: "View Source"
-    ref: "https://github.com/dmm-com/airone"
+    ref: "https://github.com/dmm-com/pagoda"
     external: true
     icon: "github"


### PR DESCRIPTION
The docs page is now broken, probably because of baseURL.
https://dmm-com.github.io/pagoda/