### PR TITLE
Migrate to enum based AttrType

### DIFF
--- a/acl/tests/test_api_v2.py
+++ b/acl/tests/test_api_v2.py
@@ -5,7 +5,7 @@ from mock import mock
 from acl.models import ACLBase
 from airone.lib.acl import ACLType
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity import tasks
 from entity.models import Entity, EntityAttr
 from role.models import Role
@@ -51,7 +51,7 @@ class ViewTest(AironeViewTest):
             attrs=[
                 {
                     "name": "attr01",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                 }
             ],
         )
@@ -98,7 +98,7 @@ class ViewTest(AironeViewTest):
             attrs=[
                 {
                     "name": "attr01",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                 }
             ],
         )
@@ -611,7 +611,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "string",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                 }
             ],
         }

--- a/acl/tests/test_model.py
+++ b/acl/tests/test_model.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 
 from acl.models import ACLBase
 from airone.lib.acl import ACLType
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from group.models import Group
 from role.models import Role
 from user.models import User
@@ -94,7 +94,7 @@ class ModelTest(TestCase):
             "created_user": self.user,
         }
         entity_attr_kwargs = {
-            "type": AttrTypeValue["object"],
+            "type": AttrType.OBJECT,
         }
 
         entity = model_entity.Entity.objects.create(**kwargs)

--- a/acl/tests/test_signal.py
+++ b/acl/tests/test_signal.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 
 from acl.models import ACLBase
 from airone.lib.acl import ACLType
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity, EntityAttr
 from entry.models import Attribute, Entry
 from user.models import User
@@ -51,7 +51,7 @@ class SignalTest(TestCase):
         entity = Entity.objects.create(name="object", created_user=self.user)
         obj = EntityAttr.objects.create(
             name="object",
-            type=AttrTypeValue["object"],
+            type=AttrType.OBJECT,
             created_user=self.user,
             parent_entity=entity,
         )
@@ -77,7 +77,7 @@ class SignalTest(TestCase):
         entity_attr = EntityAttr.objects.create(
             name="object",
             created_user=self.user,
-            type=AttrTypeValue["object"],
+            type=AttrType.OBJECT,
             parent_entity=entity,
         )
         entry = Entry.objects.create(name="object", created_user=self.user, schema=entity)

--- a/acl/tests/test_view.py
+++ b/acl/tests/test_view.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from acl.models import ACLBase
 from airone.lib.acl import ACLType
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity, EntityAttr
 from entry.models import Attribute, Entry
 from role.models import Role
@@ -113,7 +113,7 @@ class ViewTest(AironeViewTest):
 
         entity = Entity.objects.create(name="entity", created_user=user)
         attrbase = EntityAttr.objects.create(
-            name="hoge", type=AttrTypeValue["object"], created_user=user, parent_entity=entity
+            name="hoge", type=AttrType.OBJECT, created_user=user, parent_entity=entity
         )
         resp = self.send_set_request(attrbase, self._role)
 
@@ -139,7 +139,7 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.create(name="hoge", created_user=user)
         entry = Entry.objects.create(name="hoge", created_user=user, schema=entity)
         attrbase = EntityAttr.objects.create(
-            name="hoge", type=AttrTypeValue["object"], created_user=user, parent_entity=entity
+            name="hoge", type=AttrType.OBJECT, created_user=user, parent_entity=entity
         )
         entity.attrs.add(attrbase)
         attr = entry.add_attribute_from_base(attrbase, user)
@@ -289,7 +289,7 @@ class ViewTest(AironeViewTest):
 
         entity = Entity.objects.create(name="hoge", created_user=user)
         attrbase = EntityAttr.objects.create(
-            name="attr1", type=AttrTypeValue["object"], created_user=user, parent_entity=entity
+            name="attr1", type=AttrType.OBJECT, created_user=user, parent_entity=entity
         )
 
         entry = Entry.objects.create(name="fuga", created_user=user, schema=entity)

--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -8,7 +8,7 @@ from elasticsearch import Elasticsearch
 
 from airone.lib.acl import ACLType
 from airone.lib.log import Logger
-from airone.lib.types import AttrType, AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity
 from entry.settings import CONFIG
 from user.models import User
@@ -994,7 +994,7 @@ def make_search_results(
 
             # if target attribute is array type, then values would be stored in array
             if attrinfo["name"] not in ret_info["attrs"]:
-                if attrinfo["type"] & AttrTypeValue["array"]:
+                if attrinfo["type"] & AttrType._ARRAY:
                     ret_info["attrs"][attrinfo["name"]] = {}
                 else:
                     ret_info["attrs"][attrinfo["name"]] = ret_attrinfo

--- a/airone/lib/test.py
+++ b/airone/lib/test.py
@@ -7,7 +7,7 @@ from django.test import Client, TestCase, override_settings
 from pytz import timezone
 
 from airone.lib.acl import ACLType
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity, EntityAttr
 from entry.models import Entry
 from user.models import User
@@ -18,19 +18,19 @@ from .elasticsearch import ESS
 
 class AironeTestCase(TestCase):
     ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY = [
-        {"name": "val", "type": AttrTypeValue["string"]},
-        {"name": "vals", "type": AttrTypeValue["array_string"]},
-        {"name": "ref", "type": AttrTypeValue["object"]},
-        {"name": "refs", "type": AttrTypeValue["array_object"]},
-        {"name": "name", "type": AttrTypeValue["named_object"]},
-        {"name": "names", "type": AttrTypeValue["array_named_object"]},
-        {"name": "group", "type": AttrTypeValue["group"]},
-        {"name": "groups", "type": AttrTypeValue["array_group"]},
-        {"name": "bool", "type": AttrTypeValue["boolean"]},
-        {"name": "text", "type": AttrTypeValue["text"]},
-        {"name": "date", "type": AttrTypeValue["date"]},
-        {"name": "role", "type": AttrTypeValue["role"]},
-        {"name": "roles", "type": AttrTypeValue["array_role"]},
+        {"name": "val", "type": AttrType.STRING},
+        {"name": "vals", "type": AttrType.ARRAY_STRING},
+        {"name": "ref", "type": AttrType.OBJECT},
+        {"name": "refs", "type": AttrType.ARRAY_OBJECT},
+        {"name": "name", "type": AttrType.NAMED_OBJECT},
+        {"name": "names", "type": AttrType.ARRAY_NAMED_OBJECT},
+        {"name": "group", "type": AttrType.GROUP},
+        {"name": "groups", "type": AttrType.ARRAY_GROUP},
+        {"name": "bool", "type": AttrType.BOOLEAN},
+        {"name": "text", "type": AttrType.TEXT},
+        {"name": "date", "type": AttrType.DATE},
+        {"name": "role", "type": AttrType.ROLE},
+        {"name": "roles", "type": AttrType.ARRAY_ROLE},
     ]
 
     TZ_INFO = timezone(settings.TIME_ZONE)
@@ -105,7 +105,7 @@ class AironeTestCase(TestCase):
                 **{
                     "index": index,
                     "name": attr_info["name"],
-                    "type": attr_info.get("type", AttrTypeValue["string"]),
+                    "type": attr_info.get("type", AttrType.STRING),
                     "is_mandatory": attr_info.get("is_mandatory", False),
                     "is_public": attr_info.get("is_public", True),
                     "default_permission": attr_info.get("default_permission", ACLType.Nothing.id),

--- a/api_v1/serializers.py
+++ b/api_v1/serializers.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity
 from entry.models import AttributeValue, Entry
 from group.models import Group
@@ -24,11 +24,11 @@ class GetEntrySerializer(serializers.ModelSerializer):
             if not attrv:
                 return ""
 
-            if attr.schema.type & AttrTypeValue["array"]:
-                if attr.schema.type & AttrTypeValue["string"]:
+            if attr.schema.type & AttrType._ARRAY:
+                if attr.schema.type & AttrType.STRING:
                     return [x.value for x in attrv.data_array.all()]
 
-                elif attr.schema.type & AttrTypeValue["named"]:
+                elif attr.schema.type & AttrType._NAMED:
                     return [
                         {
                             "name": x.value,
@@ -38,7 +38,7 @@ class GetEntrySerializer(serializers.ModelSerializer):
                         for x in attrv.data_array.all()
                     ]
 
-                elif attr.schema.type & AttrTypeValue["object"]:
+                elif attr.schema.type & AttrType.OBJECT:
                     return [
                         {
                             "id": x.referral.id if x.referral else None,
@@ -47,32 +47,29 @@ class GetEntrySerializer(serializers.ModelSerializer):
                         for x in attrv.data_array.all()
                     ]
 
-            elif (
-                attr.schema.type & AttrTypeValue["string"]
-                or attr.schema.type & AttrTypeValue["text"]
-            ):
+            elif attr.schema.type & AttrType.STRING or attr.schema.type & AttrType.TEXT:
                 return attrv.value
 
-            elif attr.schema.type & AttrTypeValue["named"]:
+            elif attr.schema.type & AttrType._NAMED:
                 return {
                     "name": attrv.value,
                     "ref_id": attrv.referral.id if attrv.referral else None,
                     "ref_name": attrv.referral.name if attrv.referral else "",
                 }
 
-            elif attr.schema.type & AttrTypeValue["object"]:
+            elif attr.schema.type & AttrType.OBJECT:
                 return {
                     "id": attrv.referral.id if attrv.referral else None,
                     "name": attrv.referral.name if attrv.referral else "",
                 }
 
-            elif attr.schema.type & AttrTypeValue["boolean"]:
+            elif attr.schema.type & AttrType.BOOLEAN:
                 return attrv.boolean
 
-            elif attr.schema.type & AttrTypeValue["date"]:
+            elif attr.schema.type & AttrType.DATE:
                 return attrv.date
 
-            elif attr.schema.type & AttrTypeValue["group"]:
+            elif attr.schema.type & AttrType.GROUP:
                 group = Group.objects.get(id=attrv.value)
                 return {
                     "id": group.id,
@@ -95,7 +92,7 @@ class PostEntrySerializer(serializers.Serializer):
     attrs = serializers.DictField(required=True)
 
     def _validate_attr(self, attr, value):
-        """This method validate and convert attirubte valeu to be acceptable for AirOne"""
+        """This method validate and convert attribute value to be acceptable for AirOne"""
 
         def get_entry(schema, name):
             return Entry.objects.get(is_active=True, schema=schema, name=name)
@@ -116,7 +113,7 @@ class PostEntrySerializer(serializers.Serializer):
                     if is_entry(r, value["id"])
                 ]
 
-                # It means that there is no entry which is matched specified referrence
+                # It means that there is no entry which is matched specified reference
                 if not any(entryset):
                     return None
 
@@ -124,11 +121,11 @@ class PostEntrySerializer(serializers.Serializer):
 
             return value
 
-        if attr.type & AttrTypeValue["array"]:
+        if attr.type & AttrType._ARRAY:
             if not isinstance(value, list):
                 return None
 
-            if attr.type & AttrTypeValue["string"]:
+            if attr.type & AttrType.STRING:
                 if not all(
                     [
                         isinstance(v, str) or isinstance(v, int) or isinstance(v, float)
@@ -138,13 +135,13 @@ class PostEntrySerializer(serializers.Serializer):
                     return None
                 return value
 
-            elif attr.type & AttrTypeValue["named"]:
+            elif attr.type & AttrType._NAMED:
                 if not all([isinstance(v, dict) for v in value]):
                     return None
 
                 return [x for x in [validate_named_attr(v) for v in value] if x]
 
-            elif attr.type & AttrTypeValue["object"]:
+            elif attr.type & AttrType.OBJECT:
                 return sum(
                     [
                         [get_entry(r, v) for r in attr.referral.all() if is_entry(r, v)]
@@ -153,24 +150,24 @@ class PostEntrySerializer(serializers.Serializer):
                     [],
                 )
 
-            elif attr.type & AttrTypeValue["group"]:
+            elif attr.type & AttrType.GROUP:
                 return [x for x in [AttributeValue.uniform_storable(v, Group) for v in value] if x]
 
-            elif attr.type & AttrTypeValue["role"]:
+            elif attr.type & AttrType.ROLE:
                 return [x for x in [AttributeValue.uniform_storable(v, Role) for v in value] if x]
 
-        elif attr.type & AttrTypeValue["string"] or attr.type & AttrTypeValue["text"]:
+        elif attr.type & AttrType.STRING or attr.type & AttrType.TEXT:
             if not (isinstance(value, str) or isinstance(value, int) or isinstance(value, float)):
                 return None
             return value
 
-        elif attr.type & AttrTypeValue["named"]:
+        elif attr.type & AttrType._NAMED:
             if not isinstance(value, dict):
                 return None
 
             return validate_named_attr(value)
 
-        elif attr.type & AttrTypeValue["object"]:
+        elif attr.type & AttrType.OBJECT:
             if not value:
                 # This means not None but empty referral value
                 return 0
@@ -183,12 +180,12 @@ class PostEntrySerializer(serializers.Serializer):
             elif isinstance(value, int):
                 return Entry.objects.filter(id=value, is_active=True).first()
 
-        elif attr.type & AttrTypeValue["boolean"]:
+        elif attr.type & AttrType.BOOLEAN:
             if not isinstance(value, bool):
                 return None
             return value
 
-        elif attr.type & AttrTypeValue["date"]:
+        elif attr.type & AttrType.DATE:
             if isinstance(value, str):
                 try:
                     datetime.strptime(value, "%Y-%m-%d")
@@ -198,10 +195,10 @@ class PostEntrySerializer(serializers.Serializer):
             else:
                 return None
 
-        elif attr.type & AttrTypeValue["group"]:
+        elif attr.type & AttrType.GROUP:
             return AttributeValue.uniform_storable(value, Group)
 
-        elif attr.type & AttrTypeValue["role"]:
+        elif attr.type & AttrType.ROLE:
             return AttributeValue.uniform_storable(value, Role)
 
         return None

--- a/api_v1/tests/entity/test_api.py
+++ b/api_v1/tests/entity/test_api.py
@@ -1,5 +1,5 @@
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity, EntityAttr
 
 
@@ -18,7 +18,7 @@ class APITest(AironeViewTest):
                 entity.attrs.add(
                     EntityAttr.objects.create(
                         name=attrname,
-                        type=AttrTypeValue["string"],
+                        type=AttrType.STRING,
                         created_user=user,
                         parent_entity=entity,
                     )

--- a/api_v1/tests/entry/test_api.py
+++ b/api_v1/tests/entry/test_api.py
@@ -1,7 +1,7 @@
 import json
 
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity, EntityAttr
 from entry.models import Entry
 
@@ -64,7 +64,7 @@ class APITest(AironeViewTest):
                 EntityAttr.objects.create(
                     **{
                         "name": "attr",
-                        "type": AttrTypeValue["string"],
+                        "type": AttrType.STRING,
                         "created_user": user,
                         "parent_entity": entity,
                     }
@@ -74,7 +74,7 @@ class APITest(AironeViewTest):
             attr_ref = EntityAttr.objects.create(
                 **{
                     "name": "attr_ref",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "created_user": user,
                     "parent_entity": entity,
                 }
@@ -163,10 +163,10 @@ class APITest(AironeViewTest):
 
         # set EntityAttr that refers entity_ref
         attr_info = [
-            {"name": "r0", "type": AttrTypeValue["object"]},
-            {"name": "r1", "type": AttrTypeValue["named_object"]},
-            {"name": "r2", "type": AttrTypeValue["array_object"]},
-            {"name": "r3", "type": AttrTypeValue["array_named_object"]},
+            {"name": "r0", "type": AttrType.OBJECT},
+            {"name": "r1", "type": AttrType.NAMED_OBJECT},
+            {"name": "r2", "type": AttrType.ARRAY_OBJECT},
+            {"name": "r3", "type": AttrType.ARRAY_NAMED_OBJECT},
         ]
         for info in attr_info:
             attr = EntityAttr.objects.create(
@@ -432,7 +432,7 @@ class APITest(AironeViewTest):
         entity_attr1 = EntityAttr.objects.create(
             **{
                 "name": "attr1",
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "created_user": user,
                 "parent_entity": entity,
             }
@@ -440,7 +440,7 @@ class APITest(AironeViewTest):
         entity_attr2 = EntityAttr.objects.create(
             **{
                 "name": "attr2",
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "created_user": user,
                 "parent_entity": entity,
             }
@@ -496,7 +496,7 @@ class APITest(AironeViewTest):
             attrs=[
                 {
                     "name": "boolean",
-                    "type": AttrTypeValue["boolean"],
+                    "type": AttrType.BOOLEAN,
                 }
             ],
         )

--- a/api_v1/tests/entry/test_api_search_chain.py
+++ b/api_v1/tests/entry/test_api_search_chain.py
@@ -3,7 +3,7 @@ import json
 from unittest import mock
 
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from api_v1.entry import serializer
 from entry.models import Entry
 from entry.settings import CONFIG as ENTRY_CONFIG
@@ -31,14 +31,14 @@ class APITest(AironeViewTest):
             self.user,
             "VLAN",
             attrs=[
-                {"name": "note", "type": AttrTypeValue["string"]},
+                {"name": "note", "type": AttrType.STRING},
             ],
         )
         self.entity_network = self.create_entity(
             self.user,
             "Network",
             attrs=[
-                {"name": "vlan", "type": AttrTypeValue["object"], "ref": self.entity_vlan},
+                {"name": "vlan", "type": AttrType.OBJECT, "ref": self.entity_vlan},
             ],
         )
         self.entity_ipv4 = self.create_entity(
@@ -47,7 +47,7 @@ class APITest(AironeViewTest):
             attrs=[
                 {
                     "name": "network",
-                    "type": AttrTypeValue["named_object"],
+                    "type": AttrType.NAMED_OBJECT,
                     "ref": self.entity_network,
                 },
             ],
@@ -58,7 +58,7 @@ class APITest(AironeViewTest):
             attrs=[
                 {
                     "name": "IP address",
-                    "type": AttrTypeValue["array_object"],
+                    "type": AttrType.ARRAY_OBJECT,
                     "ref": self.entity_ipv4,
                 },
             ],
@@ -70,10 +70,10 @@ class APITest(AironeViewTest):
             attrs=[
                 {
                     "name": "Ports",
-                    "type": AttrTypeValue["array_named_object"],
+                    "type": AttrType.ARRAY_NAMED_OBJECT,
                     "ref": self.entity_nic,
                 },
-                {"name": "Status", "type": AttrTypeValue["object"], "ref": self.entity_status},
+                {"name": "Status", "type": AttrType.OBJECT, "ref": self.entity_status},
             ],
         )
 
@@ -797,7 +797,7 @@ class APITest(AironeViewTest):
             self.user,
             "IPv6 Network",
             attrs=[
-                {"name": "vlan", "type": AttrTypeValue["object"], "ref": self.entity_vlan},
+                {"name": "vlan", "type": AttrType.OBJECT, "ref": self.entity_vlan},
             ],
         )
         entity_ipv6_address = self.create_entity(
@@ -806,7 +806,7 @@ class APITest(AironeViewTest):
             attrs=[
                 {
                     "name": "network",
-                    "type": AttrTypeValue["named_object"],
+                    "type": AttrType.NAMED_OBJECT,
                     "ref": entity_ipv6_network,
                 },
             ],
@@ -817,7 +817,7 @@ class APITest(AironeViewTest):
             attrs=[
                 {
                     "name": "IP addresses",
-                    "type": AttrTypeValue["array_object"],
+                    "type": AttrType.ARRAY_OBJECT,
                     "ref": [
                         self.entity_ipv4,
                         entity_ipv6_address,

--- a/api_v1/tests/entry/test_update_history.py
+++ b/api_v1/tests/entry/test_update_history.py
@@ -4,7 +4,7 @@ import pytz
 from django.conf import settings
 
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity, EntityAttr
 from entry.models import Entry
 from entry.settings import CONFIG as CONFIG_ENTRY
@@ -26,34 +26,34 @@ class APITest(AironeViewTest):
         self.entity = Entity.objects.create(name="entity", created_user=self.user)
         self.test_attrs = {
             "str": {
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 # These values will be saved as each different AttributeValue for checking
                 # result order of update history API response.
                 "set_values": ["1", "2", "3"],
                 "ret_values": ["3", "2", "1"],
             },
             "obj": {
-                "type": AttrTypeValue["object"],
+                "type": AttrType.OBJECT,
                 "set_values": [ref_entry],
                 "ret_values": [{"id": ref_entry.id, "name": ref_entry.name}],
             },
             "map": {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "set_values": [{"name": "hoge", "id": ref_entry}],
                 "ret_values": [{"hoge": {"id": ref_entry.id, "name": ref_entry.name}}],
             },
             "arr_str": {
-                "type": AttrTypeValue["array_string"],
+                "type": AttrType.ARRAY_STRING,
                 "set_values": [["foo", "bar"]],
                 "ret_values": [["foo", "bar"], []],
             },
             "arr_obj": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "set_values": [[ref_entry]],
                 "ret_values": [[{"id": ref_entry.id, "name": ref_entry.name}], []],
             },
             "arr_map": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "set_values": [[{"name": "foo", "id": ref_entry}]],
                 "ret_values": [
                     [{"foo": {"id": ref_entry.id, "name": ref_entry.name}}],
@@ -61,22 +61,22 @@ class APITest(AironeViewTest):
                 ],
             },
             "group": {
-                "type": AttrTypeValue["group"],
+                "type": AttrType.GROUP,
                 "set_values": [str(self.group.id)],
                 "ret_values": [{"id": self.group.id, "name": self.group.name}],
             },
             "bool": {
-                "type": AttrTypeValue["boolean"],
+                "type": AttrType.BOOLEAN,
                 "set_values": [True],
                 "ret_values": [True],
             },
             "text": {
-                "type": AttrTypeValue["text"],
+                "type": AttrType.TEXT,
                 "set_values": ["text"],
                 "ret_values": ["text"],
             },
             "date": {
-                "type": AttrTypeValue["date"],
+                "type": AttrType.DATE,
                 "set_values": [date(2020, 1, 1)],
                 "ret_values": ["2020-01-01"],
             },
@@ -91,7 +91,7 @@ class APITest(AironeViewTest):
                 parent_entity=self.entity,
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             self.entity.attrs.add(attr)
@@ -172,7 +172,7 @@ class APITest(AironeViewTest):
 
             # check values has expected parameters
             attr_history = retdata[0]["attribute"]["history"]
-            if info["type"] & AttrTypeValue["array"]:
+            if info["type"] & AttrType._ARRAY:
                 self.assertEqual(len(attr_history), 1)
                 self.assertEqual(attr_history[0]["value"], [])
                 self.assertEqual(attr_history[0]["updated_username"], self.user.username)
@@ -240,7 +240,7 @@ class APITest(AironeViewTest):
             EntityAttr.objects.create(
                 **{
                     "name": "str",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "created_user": self.user,
                     "parent_entity": another_entity,
                 }

--- a/api_v1/tests/job/test_api.py
+++ b/api_v1/tests/job/test_api.py
@@ -2,7 +2,7 @@ import json
 from datetime import timedelta
 
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity, EntityAttr
 from entry.models import Entry
 from job.models import Job, JobOperation, JobStatus
@@ -92,7 +92,7 @@ class APITest(AironeViewTest):
         attr = EntityAttr.objects.create(
             name="attr",
             created_user=user,
-            type=AttrTypeValue["string"],
+            type=AttrType.STRING,
             parent_entity=entity,
         )
         entity.attrs.add(attr)

--- a/api_v1/tests/test_api.py
+++ b/api_v1/tests/test_api.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 
 from airone.lib.acl import ACLType
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity, EntityAttr
 from entry import tasks
 from entry.models import Attribute, AttributeValue, Entry
@@ -55,7 +55,7 @@ class APITest(AironeViewTest):
 
         params = self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY.copy()
         for param in params:
-            if param["type"] & AttrTypeValue["object"]:
+            if param["type"] & AttrType.OBJECT:
                 param["ref"] = ref_entity
 
         entity = self.create_entity(
@@ -256,7 +256,7 @@ class APITest(AironeViewTest):
             EntityAttr.objects.create(
                 **{
                     "name": "ref",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "created_user": user,
                     "parent_entity": entity,
                 }
@@ -351,8 +351,8 @@ class APITest(AironeViewTest):
 
         entity = Entity.objects.create(name="Entity", created_user=admin)
         attr_params = [
-            {"name": "val", "type": AttrTypeValue["string"], "required": True},
-            {"name": "ref", "type": AttrTypeValue["object"], "ref": ref_entity},
+            {"name": "val", "type": AttrType.STRING, "required": True},
+            {"name": "ref", "type": AttrType.OBJECT, "ref": ref_entity},
         ]
         for attr_info in attr_params:
             entity_attr = EntityAttr.objects.create(
@@ -473,8 +473,8 @@ class APITest(AironeViewTest):
 
         entity = Entity.objects.create(name="Entity", created_user=admin, is_public=False)
         attr_params = [
-            {"name": "attr1", "type": AttrTypeValue["string"], "is_public": True},
-            {"name": "attr2", "type": AttrTypeValue["string"], "is_public": False},
+            {"name": "attr1", "type": AttrType.STRING, "is_public": True},
+            {"name": "attr2", "type": AttrType.STRING, "is_public": False},
         ]
         for attr_info in attr_params:
             entity.attrs.add(
@@ -566,7 +566,7 @@ class APITest(AironeViewTest):
                 "user": admin,
                 "name": "Entity",
                 "attrs": [
-                    {"name": "string", "type": AttrTypeValue["string"]},
+                    {"name": "string", "type": AttrType.STRING},
                 ],
             }
         )
@@ -605,7 +605,7 @@ class APITest(AironeViewTest):
             EntityAttr.objects.create(
                 **{
                     "name": "attr",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "created_user": admin,
                     "parent_entity": entity,
                 }
@@ -698,15 +698,15 @@ class APITest(AironeViewTest):
         for entity_name in ["hoge", "fuga"]:
             entity = Entity.objects.create(name=entity_name, created_user=user)
             attr_info = {
-                "str": {"type": AttrTypeValue["string"], "value": "foo"},
+                "str": {"type": AttrType.STRING, "value": "foo"},
                 "ref": {
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.STRING,
                     "value": ref_entry,
                     "referral": ref_entity,
                 },
-                "no_str": {"type": AttrTypeValue["string"]},
-                "group": {"type": AttrTypeValue["group"], "value": test_groups[0]},
-                "groups": {"type": AttrTypeValue["array_group"], "value": test_groups},
+                "no_str": {"type": AttrType.STRING},
+                "group": {"type": AttrType.GROUP, "value": test_groups[0]},
+                "groups": {"type": AttrType.ARRAY_GROUP, "value": test_groups},
             }
             for name, info in attr_info.items():
                 attr = EntityAttr.objects.create(
@@ -873,7 +873,7 @@ class APITest(AironeViewTest):
         entity.attrs.add(
             EntityAttr.objects.create(
                 name="attr",
-                type=AttrTypeValue["string"],
+                type=AttrType.STRING,
                 parent_entity=entity,
                 created_user=user,
             )
@@ -1061,7 +1061,7 @@ class APITest(AironeViewTest):
         entity.attrs.add(
             EntityAttr.objects.create(
                 name="attr",
-                type=AttrTypeValue["string"],
+                type=AttrType.STRING,
                 parent_entity=entity,
                 created_user=user,
             )
@@ -1110,7 +1110,7 @@ class APITest(AironeViewTest):
         entity_attr = EntityAttr.objects.create(
             **{
                 "name": "attr",
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "created_user": users["_u1"],
                 "parent_entity": entity,
                 "is_public": False,
@@ -1270,7 +1270,7 @@ class APITest(AironeViewTest):
         entity = Entity.objects.create(name="Entity", created_user=user)
         attr_params = {
             "name": "attr",
-            "type": AttrTypeValue["string"],
+            "type": AttrType.STRING,
             "created_user": user,
             "parent_entity": entity,
         }
@@ -1304,7 +1304,7 @@ class APITest(AironeViewTest):
         ref_entry = Entry.objects.create(name="ref0", schema=ref_entity, created_user=user)
         params = self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY.copy()
         for param in params:
-            if param["type"] & AttrTypeValue["object"]:
+            if param["type"] & AttrType.OBJECT:
                 param["ref"] = ref_entity
 
         entity = self.create_entity(**{"user": user, "name": "Entity", "attrs": params})

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -9,7 +9,7 @@ from natsort import natsorted
 
 from airone.celery import app
 from airone.lib.job import may_schedule_until_job_is_ready
-from airone.lib.types import AttrType, AttrTypeValue
+from airone.lib.types import AttrType
 from entry.models import Entry
 from job.models import Job
 
@@ -97,8 +97,8 @@ def _yaml_export(job: Job, values, recv_data: dict, has_referral: bool) -> io.St
 
     def _get_attr_value(atype: int, value: dict):
         match atype:
-            case _ if atype & AttrTypeValue["array"]:
-                return [_get_attr_value(atype ^ AttrTypeValue["array"], x) for x in value]
+            case _ if atype & AttrType._ARRAY:
+                return [_get_attr_value(atype ^ AttrType._ARRAY, x) for x in value]
 
             case AttrType.NAMED_OBJECT:
                 [(key, val)] = value.items()

--- a/dashboard/tests/test_view.py
+++ b/dashboard/tests/test_view.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 
 from airone.lib.test import AironeViewTest
 from airone.lib.types import (
+    AttrType,
     AttrTypeArrNamedObj,
     AttrTypeArrObj,
     AttrTypeArrStr,
@@ -16,7 +17,6 @@ from airone.lib.types import (
     AttrTypeObj,
     AttrTypeStr,
     AttrTypeText,
-    AttrTypeValue,
 )
 from dashboard import tasks as dashboard_tasks
 from dashboard.settings import CONFIG
@@ -148,7 +148,7 @@ class ViewTest(AironeViewTest):
             EntityAttr.objects.create(
                 **{
                     "name": "attr-1-1",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "created_user": self.admin,
                     "parent_entity": entity1,
                 }
@@ -181,7 +181,7 @@ class ViewTest(AironeViewTest):
                 EntityAttr.objects.create(
                     **{
                         "name": "attr",
-                        "type": AttrTypeValue["string"],
+                        "type": AttrType.STRING,
                         "created_user": self.admin,
                         "parent_entity": entity,
                     }
@@ -620,23 +620,23 @@ class ViewTest(AironeViewTest):
         grp_entry = Group.objects.create(name="group_entry")
         role_entry = Role.objects.create(name="role_entry")
         attr_info = {
-            "str": {"type": AttrTypeValue["string"], "value": "foo"},
-            "text": {"type": AttrTypeValue["text"], "value": "foo"},
-            "bool": {"type": AttrTypeValue["boolean"], "value": True},
-            "date": {"type": AttrTypeValue["date"], "value": "2020-01-01"},
-            "obj": {"type": AttrTypeValue["object"], "value": ref_entry},
-            "grp": {"type": AttrTypeValue["group"], "value": grp_entry},
-            "role": {"type": AttrTypeValue["role"], "value": role_entry},
+            "str": {"type": AttrType.STRING, "value": "foo"},
+            "text": {"type": AttrType.TEXT, "value": "foo"},
+            "bool": {"type": AttrType.BOOLEAN, "value": True},
+            "date": {"type": AttrType.DATE, "value": "2020-01-01"},
+            "obj": {"type": AttrType.OBJECT, "value": ref_entry},
+            "grp": {"type": AttrType.GROUP, "value": grp_entry},
+            "role": {"type": AttrType.ROLE, "value": role_entry},
             "name": {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "value": {"name": "bar", "id": ref_entry.id},
             },
-            "arr_str": {"type": AttrTypeValue["array_string"], "value": ["foo"]},
-            "arr_obj": {"type": AttrTypeValue["array_object"], "value": [ref_entry]},
-            "arr_grp": {"type": AttrTypeValue["array_group"], "value": [grp_entry]},
-            "arr_role": {"type": AttrTypeValue["array_role"], "value": [role_entry]},
+            "arr_str": {"type": AttrType.ARRAY_STRING, "value": ["foo"]},
+            "arr_obj": {"type": AttrType.ARRAY_OBJECT, "value": [ref_entry]},
+            "arr_grp": {"type": AttrType.ARRAY_GROUP, "value": [grp_entry]},
+            "arr_role": {"type": AttrType.ARRAY_ROLE, "value": [role_entry]},
             "arr_name": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "value": [{"name": "hoge", "id": ref_entry.id}],
             },
         }
@@ -1001,7 +1001,7 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.create(name="entity", created_user=user)
         entity_attr = EntityAttr.objects.create(
             name="attr_ref",
-            type=AttrTypeValue["object"],
+            type=AttrType.OBJECT,
             created_user=user,
             parent_entity=entity,
         )
@@ -1140,7 +1140,7 @@ class ViewTest(AironeViewTest):
 
             test_val = None
 
-            if case[0].TYPE & AttrTypeValue["array"] == 0:
+            if case[0].TYPE & AttrType._ARRAY == 0:
                 if case[0] == AttrTypeStr:
                     test_val = AttributeValue.create(user=user, attr=test_attr, value=case[1])
                 elif case[0] == AttrTypeObj:
@@ -1212,48 +1212,48 @@ class ViewTest(AironeViewTest):
 
         attr_info = {
             "str": {
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "value": "foo",
                 "invalid_values": [123, entry_ref, True],
             },
-            "obj": {"type": AttrTypeValue["object"], "value": str(entry_ref.id)},
+            "obj": {"type": AttrType.OBJECT, "value": str(entry_ref.id)},
             "name": {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "value": {"name": "bar", "id": str(entry_ref.id)},
             },
-            "bool": {"type": AttrTypeValue["boolean"], "value": False},
+            "bool": {"type": AttrType.BOOLEAN, "value": False},
             "arr_str": {
-                "type": AttrTypeValue["array_string"],
+                "type": AttrType.ARRAY_STRING,
                 "value": ["foo", "bar", "baz"],
             },
             "arr_obj": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "value": [str(entry_ref.id)],
             },
             "arr_name": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "value": [
                     {"name": "hoge", "id": str(entry_ref.id)},
                     {"name": "fuga", "boolean": False},  # specify boolean parameter
                 ],
             },
             "group": {
-                "type": AttrTypeValue["group"],
+                "type": AttrType.GROUP,
                 "value": str(entry_group.id),
             },
             "arr_group": {
-                "type": AttrTypeValue["array_group"],
+                "type": AttrType.ARRAY_GROUP,
                 "value": [str(entry_group.id)],
             },
             "role": {
-                "type": AttrTypeValue["role"],
+                "type": AttrType.ROLE,
                 "value": str(entry_role.id),
             },
             "arr_role": {
-                "type": AttrTypeValue["array_role"],
+                "type": AttrType.ARRAY_ROLE,
                 "value": [str(entry_role.id)],
             },
-            "date": {"type": AttrTypeValue["date"], "value": date(2020, 1, 1)},
+            "date": {"type": AttrType.DATE, "value": date(2020, 1, 1)},
         }
         entities = []
         for index in range(2):
@@ -1266,7 +1266,7 @@ class ViewTest(AironeViewTest):
                     parent_entity=entity,
                 )
 
-                if info["type"] & AttrTypeValue["object"]:
+                if info["type"] & AttrType.OBJECT:
                     attr.referral.add(entity_ref)
 
                 entity.attrs.add(attr)
@@ -1498,7 +1498,7 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.create(name="entity", created_user=user)
         entity_attr = EntityAttr.objects.create(
             name="attr_ref",
-            type=AttrTypeValue["object"],
+            type=AttrType.OBJECT,
             created_user=user,
             parent_entity=entity,
         )

--- a/entity/api_v2/serializers.py
+++ b/entity/api_v2/serializers.py
@@ -15,7 +15,7 @@ from airone.lib import drf
 from airone.lib.acl import ACLType
 from airone.lib.drf import DuplicatedObjectExistsError, ObjectNotExistsError, RequiredParameterError
 from airone.lib.log import Logger
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType, AttrTypeValue
 from entity.admin import EntityAttrResource, EntityResource
 from entity.models import Entity, EntityAttr
 from user.models import History, User
@@ -104,7 +104,7 @@ class EntityAttrCreateSerializer(serializers.ModelSerializer):
     def validate(self, attr: dict):
         referral = attr.get("referral", [])
 
-        if attr["type"] & AttrTypeValue["object"] and not len(referral):
+        if attr["type"] & AttrType.OBJECT and not len(referral):
             raise RequiredParameterError("When specified object type, referral field is required")
 
         return attr
@@ -163,7 +163,7 @@ class EntityAttrUpdateSerializer(serializers.ModelSerializer):
                 raise RequiredParameterError("id or (name and type) field is required")
 
             referral = attr.get("referral", [])
-            if attr["type"] & AttrTypeValue["object"] and not len(referral):
+            if attr["type"] & AttrType.OBJECT and not len(referral):
                 raise RequiredParameterError(
                     "When specified object type, referral field is required"
                 )
@@ -241,7 +241,7 @@ class EntitySerializer(serializers.ModelSerializer):
             )
 
             # set referrals if necessary
-            if entity_attr.type & AttrTypeValue["object"]:
+            if entity_attr.type & AttrType.OBJECT:
                 entity_attr.referral_clear()
                 [entity_attr.referral.add(x) for x in attr_referrals]
 

--- a/entity/tasks.py
+++ b/entity/tasks.py
@@ -3,7 +3,7 @@ import json
 import custom_view
 from airone.celery import app
 from airone.lib.job import may_schedule_until_job_is_ready
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.api_v2.serializers import EntityCreateSerializer, EntityUpdateSerializer
 from entity.models import Entity, EntityAttr
 from job.models import Job, JobStatus
@@ -40,7 +40,7 @@ def create_entity(self, job: Job) -> JobStatus:
             index=int(attr["row_index"]),
         )
 
-        if int(attr["type"]) & AttrTypeValue["object"]:
+        if int(attr["type"]) & AttrType.OBJECT:
             [attr_base.referral.add(Entity.objects.get(id=x)) for x in attr["ref_ids"]]
 
         # This is neccesary to summarize adding attribute history to one time
@@ -139,7 +139,7 @@ def edit_entity(self, job: Job) -> JobStatus:
 
                 attr_obj.save()
 
-            if (attr_obj.type & AttrTypeValue["object"]) and (
+            if (attr_obj.type & AttrType.OBJECT) and (
                 attr_obj.is_referral_updated([int(x) for x in attr["ref_ids"]])
             ):
                 # the case of an attribute that has referral entry
@@ -159,7 +159,7 @@ def edit_entity(self, job: Job) -> JobStatus:
             )
 
             # append referral objects
-            if int(attr["type"]) & AttrTypeValue["object"]:
+            if int(attr["type"]) & AttrType.OBJECT:
                 [attr_obj.referral.add(Entity.objects.get(id=x)) for x in attr["ref_ids"]]
 
             # add a new attribute on the existed Entries

--- a/entity/tests/test_api_v2.py
+++ b/entity/tests/test_api_v2.py
@@ -13,7 +13,7 @@ from acl.models import ACLBase
 from airone.lib import types as atype
 from airone.lib.log import Logger
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrType, AttrTypeArrStr, AttrTypeStr, AttrTypeText, AttrTypeValue
+from airone.lib.types import AttrType, AttrTypeArrStr, AttrTypeStr, AttrTypeText
 from entity import tasks
 from entity.models import Entity, EntityAttr
 from entry.models import Entry
@@ -90,7 +90,7 @@ class ViewTest(AironeViewTest):
                     "is_writable": True,
                     "name": "val",
                     "referral": [],
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "note": "",
                 },
                 {
@@ -101,7 +101,7 @@ class ViewTest(AironeViewTest):
                     "is_writable": True,
                     "name": "vals",
                     "referral": [],
-                    "type": AttrTypeValue["array_string"],
+                    "type": AttrType.ARRAY_STRING,
                     "note": "",
                 },
                 {
@@ -112,7 +112,7 @@ class ViewTest(AironeViewTest):
                     "is_writable": True,
                     "name": "ref",
                     "referral": [],
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "note": "",
                 },
                 {
@@ -123,7 +123,7 @@ class ViewTest(AironeViewTest):
                     "is_writable": True,
                     "name": "refs",
                     "referral": [],
-                    "type": AttrTypeValue["array_object"],
+                    "type": AttrType.ARRAY_OBJECT,
                     "note": "",
                 },
                 {
@@ -134,7 +134,7 @@ class ViewTest(AironeViewTest):
                     "is_writable": True,
                     "name": "name",
                     "referral": [],
-                    "type": AttrTypeValue["named_object"],
+                    "type": AttrType.NAMED_OBJECT,
                     "note": "",
                 },
                 {
@@ -145,7 +145,7 @@ class ViewTest(AironeViewTest):
                     "is_writable": True,
                     "name": "names",
                     "referral": [],
-                    "type": AttrTypeValue["array_named_object"],
+                    "type": AttrType.ARRAY_NAMED_OBJECT,
                     "note": "",
                 },
                 {
@@ -156,7 +156,7 @@ class ViewTest(AironeViewTest):
                     "is_writable": True,
                     "name": "group",
                     "referral": [],
-                    "type": AttrTypeValue["group"],
+                    "type": AttrType.GROUP,
                     "note": "",
                 },
                 {
@@ -167,7 +167,7 @@ class ViewTest(AironeViewTest):
                     "is_writable": True,
                     "name": "groups",
                     "referral": [],
-                    "type": AttrTypeValue["array_group"],
+                    "type": AttrType.ARRAY_GROUP,
                     "note": "",
                 },
                 {
@@ -178,7 +178,7 @@ class ViewTest(AironeViewTest):
                     "is_writable": True,
                     "name": "bool",
                     "referral": [],
-                    "type": AttrTypeValue["boolean"],
+                    "type": AttrType.BOOLEAN,
                     "note": "",
                 },
                 {
@@ -189,7 +189,7 @@ class ViewTest(AironeViewTest):
                     "is_writable": True,
                     "name": "text",
                     "referral": [],
-                    "type": AttrTypeValue["text"],
+                    "type": AttrType.TEXT,
                     "note": "",
                 },
                 {
@@ -200,7 +200,7 @@ class ViewTest(AironeViewTest):
                     "is_writable": True,
                     "name": "date",
                     "referral": [],
-                    "type": AttrTypeValue["date"],
+                    "type": AttrType.DATE,
                     "note": "",
                 },
                 {
@@ -211,7 +211,7 @@ class ViewTest(AironeViewTest):
                     "is_writable": True,
                     "name": "role",
                     "referral": [],
-                    "type": AttrTypeValue["role"],
+                    "type": AttrType.ROLE,
                     "note": "",
                 },
                 {
@@ -222,7 +222,7 @@ class ViewTest(AironeViewTest):
                     "is_writable": True,
                     "name": "roles",
                     "referral": [],
-                    "type": AttrTypeValue["array_role"],
+                    "type": AttrType.ARRAY_ROLE,
                     "note": "",
                 },
             ],
@@ -251,7 +251,7 @@ class ViewTest(AironeViewTest):
                         "name": "ref_entity",
                     }
                 ],
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "note": "",
             },
         )
@@ -377,7 +377,7 @@ class ViewTest(AironeViewTest):
                     "id": 0,
                     "name": "hoge",
                     "index": 11,
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "is_mandatory": False,
                     "is_delete_in_chain": False,
                     "referral": [],
@@ -400,7 +400,7 @@ class ViewTest(AironeViewTest):
                 "id": 0,
                 "name": "hoge",
                 "index": 11,
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "is_mandatory": False,
                 "is_delete_in_chain": False,
                 "referral": [],
@@ -486,7 +486,7 @@ class ViewTest(AironeViewTest):
                 {
                     "name": "attr1",
                     "index": 1,
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "referral": [self.ref_entity.id],
                     "is_mandatory": True,
                     "is_delete_in_chain": True,
@@ -517,7 +517,7 @@ class ViewTest(AironeViewTest):
         entity_attr: EntityAttr = entity.attrs.first()
         self.assertEqual(entity_attr.name, "attr1")
         self.assertEqual(entity_attr.index, 1)
-        self.assertEqual(entity_attr.type, AttrTypeValue["object"])
+        self.assertEqual(entity_attr.type, AttrType.OBJECT)
         self.assertEqual(entity_attr.referral.count(), 1)
         self.assertEqual(entity_attr.referral.first().id, self.ref_entity.id)
         self.assertEqual(entity_attr.is_mandatory, True)
@@ -690,7 +690,7 @@ class ViewTest(AironeViewTest):
         # name param
         params = {
             "name": "hoge",
-            "attrs": [{"name": ["hoge"], "type": AttrTypeValue["string"]}],
+            "attrs": [{"name": ["hoge"], "type": AttrType.STRING}],
         }
         resp = self.client.post("/entity/api/v2/", json.dumps(params), "application/json")
         self.assertEqual(resp.status_code, 400)
@@ -704,7 +704,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "a" * (EntityAttr._meta.get_field("name").max_length + 1),
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                 }
             ],
         }
@@ -731,11 +731,11 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "hoge",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                 },
                 {
                     "name": "hoge",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                 },
             ],
         }
@@ -800,7 +800,7 @@ class ViewTest(AironeViewTest):
         # index param
         params = {
             "name": "hoge",
-            "attrs": [{"name": "hoge", "type": AttrTypeValue["object"], "index": "hoge"}],
+            "attrs": [{"name": "hoge", "type": AttrType.OBJECT, "index": "hoge"}],
         }
         resp = self.client.post("/entity/api/v2/", json.dumps(params), "application/json")
         self.assertEqual(resp.status_code, 400)
@@ -820,7 +820,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "hoge",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "index": 2**32,
                 }
             ],
@@ -850,7 +850,7 @@ class ViewTest(AironeViewTest):
                 "attrs": [
                     {
                         "name": "hoge",
-                        "type": AttrTypeValue["object"],
+                        "type": AttrType.OBJECT,
                         param: "hoge",
                     }
                 ],
@@ -872,7 +872,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "hoge",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "referral": "hoge",
                 }
             ],
@@ -900,7 +900,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "hoge",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "referral": ["hoge"],
                 }
             ],
@@ -928,7 +928,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "hoge",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "referral": [9999],
                 }
             ],
@@ -965,7 +965,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 400)
         attrs = {}
         for index, all_attr in enumerate(self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY):
-            if all_attr["type"] & AttrTypeValue["object"]:
+            if all_attr["type"] & AttrType.OBJECT:
                 attrs[str(index)] = {
                     "non_field_errors": [
                         {
@@ -994,7 +994,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 400)
         attrs = {}
         for index, all_attr in enumerate(self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY):
-            if all_attr["type"] & AttrTypeValue["object"]:
+            if all_attr["type"] & AttrType.OBJECT:
                 attrs[str(index)] = {
                     "non_field_errors": [
                         {
@@ -1273,7 +1273,7 @@ class ViewTest(AironeViewTest):
 
         entity: Entity = Entity.objects.get(name=params["name"])
         for entity_attr in entity.attrs.all():
-            if entity_attr.type & AttrTypeValue["object"]:
+            if entity_attr.type & AttrType.OBJECT:
                 self.assertEqual([x.id for x in entity_attr.referral.all()], [self.ref_entity.id])
             else:
                 self.assertEqual([x.id for x in entity_attr.referral.all()], [])
@@ -1368,7 +1368,7 @@ class ViewTest(AironeViewTest):
                 "attrs": [
                     {
                         "name": "attr1",
-                        "type": AttrTypeValue["object"],
+                        "type": AttrType.OBJECT,
                     }
                 ],
                 "webhooks": [
@@ -1390,7 +1390,7 @@ class ViewTest(AironeViewTest):
                     "id": entity_attr.id,
                     "name": "change-attr1",
                     "index": 1,
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "referral": [self.ref_entity.id],
                     "is_mandatory": True,
                     "is_delete_in_chain": True,
@@ -1424,7 +1424,7 @@ class ViewTest(AironeViewTest):
         entity_attr.refresh_from_db()
         self.assertEqual(entity_attr.name, "change-attr1")
         self.assertEqual(entity_attr.index, 1)
-        self.assertEqual(entity_attr.type, AttrTypeValue["object"])
+        self.assertEqual(entity_attr.type, AttrType.OBJECT)
         self.assertEqual(entity_attr.referral.count(), 1)
         self.assertEqual(entity_attr.referral.first().id, self.ref_entity.id)
         self.assertEqual(entity_attr.is_mandatory, True)
@@ -1708,7 +1708,7 @@ class ViewTest(AironeViewTest):
 
         # name param
         params = {
-            "attrs": [{"name": ["hoge"], "type": AttrTypeValue["string"]}],
+            "attrs": [{"name": ["hoge"], "type": AttrType.STRING}],
         }
         resp = self.client.put(
             "/entity/api/v2/%d/" % self.entity.id, json.dumps(params), "application/json"
@@ -1723,7 +1723,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "a" * (EntityAttr._meta.get_field("name").max_length + 1),
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                 }
             ],
         }
@@ -1751,11 +1751,11 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "hoge",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                 },
                 {
                     "name": "hoge",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                 },
             ],
         }
@@ -1776,7 +1776,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "val",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                 },
             ],
         }
@@ -1843,7 +1843,7 @@ class ViewTest(AironeViewTest):
         )
 
         params = {
-            "attrs": [{"id": entity_attr.id, "type": AttrTypeValue["array_string"]}],
+            "attrs": [{"id": entity_attr.id, "type": AttrType.ARRAY_STRING}],
         }
         resp = self.client.put(
             "/entity/api/v2/%d/" % self.entity.id, json.dumps(params), "application/json"
@@ -1864,7 +1864,7 @@ class ViewTest(AironeViewTest):
 
         # index param
         params = {
-            "attrs": [{"name": "hoge", "type": AttrTypeValue["object"], "index": "hoge"}],
+            "attrs": [{"name": "hoge", "type": AttrType.OBJECT, "index": "hoge"}],
         }
         resp = self.client.put(
             "/entity/api/v2/%d/" % self.entity.id, json.dumps(params), "application/json"
@@ -1885,7 +1885,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "hoge",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "index": 2**32,
                 }
             ],
@@ -1916,7 +1916,7 @@ class ViewTest(AironeViewTest):
                 "attrs": [
                     {
                         "name": "hoge",
-                        "type": AttrTypeValue["object"],
+                        "type": AttrType.OBJECT,
                         param: "hoge",
                     }
                 ],
@@ -1939,7 +1939,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "hoge",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "referral": "hoge",
                 }
             ],
@@ -1968,7 +1968,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "hoge",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "referral": ["hoge"],
                 }
             ],
@@ -1997,7 +1997,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "hoge",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "referral": [9999],
                 }
             ],
@@ -2037,7 +2037,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 400)
         attrs = {}
         for index, all_attr in enumerate(self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY):
-            if all_attr["type"] & AttrTypeValue["object"]:
+            if all_attr["type"] & AttrType.OBJECT:
                 attrs[str(index)] = {
                     "non_field_errors": [
                         {
@@ -2067,7 +2067,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 400)
         attrs = {}
         for index, all_attr in enumerate(self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY):
-            if all_attr["type"] & AttrTypeValue["object"]:
+            if all_attr["type"] & AttrType.OBJECT:
                 attrs[str(index)] = {
                     "non_field_errors": [
                         {
@@ -2087,7 +2087,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "hoge",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "is_deleted": True,
                 }
             ],
@@ -2133,7 +2133,7 @@ class ViewTest(AironeViewTest):
                 },
                 {
                     "name": entity_attr.name,
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                 },
             ],
         }
@@ -2457,7 +2457,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED)
 
         for entity_attr in self.entity.attrs.all():
-            if entity_attr.type & AttrTypeValue["object"]:
+            if entity_attr.type & AttrType.OBJECT:
                 self.assertEqual([x.id for x in entity_attr.referral.all()], [self.ref_entity.id])
             else:
                 self.assertEqual([x.id for x in entity_attr.referral.all()], [])
@@ -3307,21 +3307,21 @@ class ViewTest(AironeViewTest):
                 },
                 {
                     "name": "attr_bool",
-                    "type": str(AttrTypeValue["boolean"]),
+                    "type": str(AttrType.BOOLEAN),
                     "is_delete_in_chain": False,
                     "is_mandatory": False,
                     "row_index": "4",
                 },
                 {
                     "name": "attr_group",
-                    "type": str(AttrTypeValue["group"]),
+                    "type": str(AttrType.GROUP),
                     "is_delete_in_chain": False,
                     "is_mandatory": False,
                     "row_index": "5",
                 },
                 {
                     "name": "attr_date",
-                    "type": str(AttrTypeValue["date"]),
+                    "type": str(AttrType.DATE),
                     "is_delete_in_chain": False,
                     "is_mandatory": False,
                     "row_index": "6",
@@ -3508,7 +3508,7 @@ class ViewTest(AironeViewTest):
             [
                 {
                     "name": "puyo",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "ref": entities.first(),
                 }
             ],

--- a/entity/tests/test_complex_view.py
+++ b/entity/tests/test_complex_view.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from airone.lib.acl import ACLType
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrTypeArrObj, AttrTypeArrStr, AttrTypeStr, AttrTypeValue
+from airone.lib.types import AttrType, AttrTypeArrObj, AttrTypeArrStr, AttrTypeStr
 from entity import tasks as entity_tasks
 from entity.models import Entity, EntityAttr
 from entry import tasks as entry_tasks
@@ -298,7 +298,7 @@ class ComplexViewTest(AironeViewTest):
             attrs=[
                 {
                     "name": "ref",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "ref": ref_entity,
                 }
             ],
@@ -349,7 +349,7 @@ class ComplexViewTest(AironeViewTest):
         entity.attrs.add(
             EntityAttr.objects.create(
                 name="ref",
-                type=AttrTypeValue["object"],
+                type=AttrType.OBJECT,
                 parent_entity=entity,
                 created_user=user,
             )
@@ -379,7 +379,7 @@ class ComplexViewTest(AironeViewTest):
                 {
                     "id": entity_attr.id,
                     "name": entity_attr.name,
-                    "type": str(AttrTypeValue["string"]),
+                    "type": str(AttrType.STRING),
                     "is_mandatory": entity_attr.is_mandatory,
                     "is_delete_in_chain": False,
                     "row_index": "1",

--- a/entity/tests/test_model.py
+++ b/entity/tests/test_model.py
@@ -3,7 +3,7 @@ from copy import copy
 from django.conf import settings
 from django.test import TestCase
 
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.admin import EntityAttrResource, EntityResource
 from entity.models import Entity, EntityAttr
 from user.models import User
@@ -20,7 +20,7 @@ class ModelTest(TestCase):
 
         attr_base = EntityAttr(
             name="hoge",
-            type=AttrTypeValue["object"],
+            type=AttrType.OBJECT,
             created_user=self._test_user,
             parent_entity=entity,
         )
@@ -44,7 +44,7 @@ class ModelTest(TestCase):
 
         attr_base = EntityAttr(
             name="hoge",
-            type=AttrTypeValue["object"],
+            type=AttrType.OBJECT,
             created_user=self._test_user,
             parent_entity=entity,
         )
@@ -166,7 +166,7 @@ class ModelTest(TestCase):
         entity_attr = EntityAttr.objects.create(
             **{
                 "name": "attr",
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "created_user": user,
                 "parent_entity": entity,
             }
@@ -177,7 +177,7 @@ class ModelTest(TestCase):
             {
                 "id": entity_attr.id,
                 "name": "changed-attr",
-                "type": AttrTypeValue["array_string"],
+                "type": AttrType.ARRAY_STRING,
                 "entity": entity.name,
                 "created_user": user.username,
             },
@@ -186,7 +186,7 @@ class ModelTest(TestCase):
 
         entity_attr.refresh_from_db()
         self.assertEqual(entity_attr.name, "changed-attr")
-        self.assertEqual(entity_attr.type, AttrTypeValue["string"])
+        self.assertEqual(entity_attr.type, AttrType.STRING)
 
     def test_import_entity_attr_without_specifying_type(self):
         """
@@ -197,7 +197,7 @@ class ModelTest(TestCase):
         entity_attr = EntityAttr.objects.create(
             **{
                 "name": "attr",
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "created_user": user,
                 "parent_entity": entity,
             }
@@ -216,7 +216,7 @@ class ModelTest(TestCase):
 
         entity_attr.refresh_from_db()
         self.assertEqual(entity_attr.name, "changed-attr")
-        self.assertEqual(entity_attr.type, AttrTypeValue["string"])
+        self.assertEqual(entity_attr.type, AttrType.STRING)
 
     def test_import_entity_attr_without_specifying_id(self):
         """
@@ -228,7 +228,7 @@ class ModelTest(TestCase):
         EntityAttrResource.import_data_from_request(
             {
                 "name": "attr",
-                "type": AttrTypeValue["array_string"],
+                "type": AttrType.ARRAY_STRING,
                 "entity": entity.name,
                 "created_user": user.username,
             },
@@ -238,7 +238,7 @@ class ModelTest(TestCase):
         entity.refresh_from_db()
         self.assertEqual(
             [(x.name, x.type) for x in entity.attrs.all()],
-            [("attr", AttrTypeValue["array_string"])],
+            [("attr", AttrType.ARRAY_STRING)],
         )
 
     def test_import_entity_attr_without_specifying_id_and_type(self):
@@ -272,7 +272,7 @@ class ModelTest(TestCase):
         entity = Entity.objects.create(name="entity", created_user=user)
         attr = EntityAttr.objects.create(
             name="attr",
-            type=AttrTypeValue["object"],
+            type=AttrType.OBJECT,
             created_user=user,
             parent_entity=entity,
         )
@@ -323,7 +323,7 @@ class ModelTest(TestCase):
         entity = Entity.objects.create(name="entity", created_user=self._test_user)
         attr = EntityAttr.objects.create(
             name="attr",
-            type=AttrTypeValue["object"],
+            type=AttrType.OBJECT,
             created_user=self._test_user,
             parent_entity=entity,
         )
@@ -380,7 +380,7 @@ class ModelTest(TestCase):
         for i in range(max_attributes_per_entity):
             EntityAttr.objects.create(
                 name="entity_attr-%d" % i,
-                type=AttrTypeValue["string"],
+                type=AttrType.STRING,
                 created_user=self._test_user,
                 parent_entity=entity,
             )
@@ -390,7 +390,7 @@ class ModelTest(TestCase):
         with self.assertRaises(RuntimeError):
             EntityAttr.objects.create(
                 name="entity_attr-%d" % max_attributes_per_entity,
-                type=AttrTypeValue["string"],
+                type=AttrType.STRING,
                 created_user=self._test_user,
                 parent_entity=entity,
             )
@@ -399,7 +399,7 @@ class ModelTest(TestCase):
         settings.MAX_ATTRIBUTES_PER_ENTITY = None
         EntityAttr.objects.create(
             name="entity_attr-%d" % max_attributes_per_entity,
-            type=AttrTypeValue["string"],
+            type=AttrType.STRING,
             created_user=self._test_user,
             parent_entity=entity,
         )

--- a/entity/tests/test_view.py
+++ b/entity/tests/test_view.py
@@ -7,12 +7,12 @@ from django.urls import reverse
 
 from airone.lib.test import AironeViewTest
 from airone.lib.types import (
+    AttrType,
     AttrTypeArrObj,
     AttrTypeArrStr,
     AttrTypeObj,
     AttrTypeStr,
     AttrTypeText,
-    AttrTypeValue,
 )
 from entity import tasks
 from entity.models import Entity, EntityAttr
@@ -139,21 +139,21 @@ class ViewTest(AironeViewTest):
                 },
                 {
                     "name": "attr_bool",
-                    "type": str(AttrTypeValue["boolean"]),
+                    "type": str(AttrType.BOOLEAN),
                     "is_delete_in_chain": False,
                     "is_mandatory": False,
                     "row_index": "4",
                 },
                 {
                     "name": "attr_group",
-                    "type": str(AttrTypeValue["group"]),
+                    "type": str(AttrType.GROUP),
                     "is_delete_in_chain": False,
                     "is_mandatory": False,
                     "row_index": "5",
                 },
                 {
                     "name": "attr_date",
-                    "type": str(AttrTypeValue["date"]),
+                    "type": str(AttrType.DATE),
                     "is_delete_in_chain": False,
                     "is_mandatory": False,
                     "row_index": "6",
@@ -586,8 +586,8 @@ class ViewTest(AironeViewTest):
             user,
             "Old-Entity",
             attrs=[
-                {"name": "puyo", "type": AttrTypeValue["string"]},
-                {"name": "ref", "type": AttrTypeValue["object"], "ref": ref_entity},
+                {"name": "puyo", "type": AttrType.STRING},
+                {"name": "ref", "type": AttrType.OBJECT, "ref": ref_entity},
             ],
         )
 
@@ -911,8 +911,8 @@ class ViewTest(AironeViewTest):
             user,
             "old-Entity",
             attrs=[
-                {"name": "foo", "type": AttrTypeValue["string"]},
-                {"name": "ref", "type": AttrTypeValue["object"], "ref": ref_entity},
+                {"name": "foo", "type": AttrType.STRING},
+                {"name": "ref", "type": AttrType.OBJECT, "ref": ref_entity},
             ],
         )
 
@@ -941,7 +941,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "name": "foo",
-                    "type": str(AttrTypeValue["string"]),
+                    "type": str(AttrType.STRING),
                     "id": entity.attrs.first().id,
                     "is_delete_in_chain": True,
                     "is_mandatory": False,
@@ -949,7 +949,7 @@ class ViewTest(AironeViewTest):
                 },
                 {
                     "name": attr.name,
-                    "type": str(AttrTypeValue["string"]),
+                    "type": str(AttrType.STRING),
                     "id": entity.attrs.last().id,
                     "is_delete_in_chain": True,
                     "is_mandatory": False,
@@ -1364,7 +1364,7 @@ class ViewTest(AironeViewTest):
                 # change only attribute type
                 {
                     "name": attr2.name,
-                    "type": str(AttrTypeValue["object"]),
+                    "type": str(AttrType.OBJECT),
                     "id": attr2.id,
                     "is_delete_in_chain": True,
                     "is_mandatory": attr2.is_mandatory,
@@ -1388,8 +1388,8 @@ class ViewTest(AironeViewTest):
         # This checks data type of EntityAttr and AttributeValue wouldn't be changed.
         attrv = entry.attrs.get(schema=attr2).get_latest_value()
         self.assertEqual(attrv.value, "fuga")
-        self.assertEqual(attrv.data_type, AttrTypeValue["string"])
-        self.assertEqual(EntityAttr.objects.get(name=attr2.name).type, AttrTypeValue["string"])
+        self.assertEqual(attrv.data_type, AttrType.STRING)
+        self.assertEqual(EntityAttr.objects.get(name=attr2.name).type, AttrType.STRING)
 
     def test_show_dashboard(self):
         user = self.admin_login()
@@ -1415,7 +1415,7 @@ class ViewTest(AironeViewTest):
             created_user=user,
             is_summarized=True,
             parent_entity=entity,
-            type=AttrTypeValue["object"],
+            type=AttrType.OBJECT,
         )
         attr.referral.add(ref_entity)
         entity.attrs.add(attr)
@@ -1500,7 +1500,7 @@ class ViewTest(AironeViewTest):
 
         entity = Entity.objects.create(name="entity", created_user=user)
         attr = EntityAttr.objects.create(
-            name="attr", type=AttrTypeValue["object"], created_user=user, parent_entity=entity
+            name="attr", type=AttrType.OBJECT, created_user=user, parent_entity=entity
         )
         entity.attrs.add(attr)
 

--- a/entity/views.py
+++ b/entity/views.py
@@ -17,7 +17,7 @@ from airone.lib.http import (
     http_post,
     render,
 )
-from airone.lib.types import AttrTypes, AttrTypeValue
+from airone.lib.types import AttrType, AttrTypes
 from entry.models import AttributeValue, Entry
 from job.models import Job
 from user.models import History
@@ -156,7 +156,7 @@ def do_edit(request, entity_id, recv_data):
         if "ref_ids" not in attr:
             attr["ref_ids"] = []
 
-        if int(attr["type"]) & AttrTypeValue["object"] and not attr["ref_ids"]:
+        if int(attr["type"]) & AttrType.OBJECT and not attr["ref_ids"]:
             return HttpResponse("Need to specify enabled referral ids", status=400)
 
         if any([not Entity.objects.filter(id=x).exists() for x in attr["ref_ids"]]):
@@ -256,7 +256,7 @@ def do_create(request, recv_data):
         if "ref_ids" not in attr:
             attr["ref_ids"] = []
 
-        if int(attr["type"]) & AttrTypeValue["object"] and not attr["ref_ids"]:
+        if int(attr["type"]) & AttrType.OBJECT and not attr["ref_ids"]:
             return HttpResponse("Need to specify enabled referral ids", status=400)
 
         if any([not Entity.objects.filter(id=x).exists() for x in attr["ref_ids"]]):
@@ -487,7 +487,7 @@ def conf_dashboard(request, entity_id):
     context = {
         "entity": entity,
         "ref_attrs": EntityAttr.objects.filter(
-            parent_entity=entity, type=AttrTypeValue["object"], is_active=True
+            parent_entity=entity, type=AttrType.OBJECT, is_active=True
         ),
         "redirect_url": "/entity/dashboard/config/register/%s" % entity_id,
     }

--- a/entry/admin.py
+++ b/entry/admin.py
@@ -5,7 +5,7 @@ from import_export.instance_loaders import CachedInstanceLoader
 
 from acl.models import ACLBase
 from airone.lib.resources import AironeModelResource
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity, EntityAttr
 from user.models import User
 
@@ -80,9 +80,9 @@ class AttrValueResource(AironeModelResource):
             instance.data_type = attr.schema.type
 
             if not attr.values.filter(id=instance.id).exists() and (
-                not attr.schema.type & AttrTypeValue["array"]
+                not attr.schema.type & AttrType._ARRAY
                 or (
-                    attr.schema.type & AttrTypeValue["array"]
+                    attr.schema.type & AttrType._ARRAY
                     and instance.get_status(AttributeValue.STATUS_DATA_ARRAY_PARENT)
                 )
             ):
@@ -92,7 +92,7 @@ class AttrValueResource(AironeModelResource):
                 attr.unset_latest_flag(exclude_id=instance.id)
 
             # the case of leaf AttributeValue
-            elif attr.schema.type & AttrTypeValue["array"] and not instance.get_status(
+            elif attr.schema.type & AttrType._ARRAY and not instance.get_status(
                 AttributeValue.STATUS_DATA_ARRAY_PARENT
             ):
                 # For a leaf AttributeValue, 'is_latest' flag will not be set.

--- a/entry/api_v1/views.py
+++ b/entry/api_v1/views.py
@@ -12,7 +12,7 @@ from acl.models import ACLBase
 from airone.lib.acl import ACLType
 from airone.lib.elasticsearch import prepend_escape_character
 from airone.lib.http import http_get, http_post
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity, EntityAttr
 from entry.models import Attribute, Entry
 from entry.settings import CONFIG
@@ -98,8 +98,8 @@ def search_entries(request, entity_ids, recv_data):
 
         for attr in attrs:
             # The case specified condition doesn't match with attribute type
-            if (cond["type"] == "text" and not attr.schema.type & AttrTypeValue["string"]) or (
-                cond["type"] == "entry" and not attr.schema.type & AttrTypeValue["object"]
+            if (cond["type"] == "text" and not attr.schema.type & AttrType.STRING) or (
+                cond["type"] == "entry" and not attr.schema.type & AttrType.OBJECT
             ):
                 continue
 
@@ -108,7 +108,7 @@ def search_entries(request, entity_ids, recv_data):
             if not attrv:
                 continue
 
-            if attr.schema.type & AttrTypeValue["array"]:
+            if attr.schema.type & AttrType._ARRAY:
                 ret = any([_is_match_value(x, cond) for x in attrv.data_array.all()])
             else:
                 ret = _is_match_value(attrv, cond)
@@ -229,11 +229,11 @@ def get_attr_referrals(request, attr_id):
     else:
         attr = EntityAttr.objects.get(id=attr_id)
 
-    if attr.type & AttrTypeValue["object"]:
+    if attr.type & AttrType.OBJECT:
         results = _get_referral_entries(attr)
-    elif attr.type & AttrTypeValue["group"]:
+    elif attr.type & AttrType.GROUP:
         results = _get_referral_groups(attr)
-    elif attr.type & AttrTypeValue["role"]:
+    elif attr.type & AttrType.ROLE:
         results = _get_referral_roles(attr)
     else:
         return HttpResponse("Target Attribute does not referring type", status=400)

--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -20,7 +20,7 @@ from airone.lib.drf import (
 )
 from airone.lib.elasticsearch import FilterKey
 from airone.lib.log import Logger
-from airone.lib.types import AttrDefaultValue, AttrType, AttrTypeValue
+from airone.lib.types import AttrDefaultValue, AttrType
 from entity.api_v2.serializers import EntitySerializer
 from entity.models import Entity, EntityAttr
 from entry.models import Attribute, AttributeValue, Entry
@@ -837,12 +837,12 @@ class EntryImportEntitySerializer(serializers.Serializer):
                     return ref_group.id if ref_group else 0
                 return None
 
-            if entity_attrs[attr_data["name"]]["type"] & AttrTypeValue["array"]:
+            if entity_attrs[attr_data["name"]]["type"] & AttrType._ARRAY:
                 if not isinstance(attr_data["value"], list):
                     return
                 for i, child_value in enumerate(attr_data["value"]):
-                    if entity_attrs[attr_data["name"]]["type"] & AttrTypeValue["object"]:
-                        if entity_attrs[attr_data["name"]]["type"] & AttrTypeValue["named"]:
+                    if entity_attrs[attr_data["name"]]["type"] & AttrType.OBJECT:
+                        if entity_attrs[attr_data["name"]]["type"] & AttrType._NAMED:
                             if not isinstance(child_value, dict):
                                 return
                             attr_data["value"][i] = {
@@ -856,11 +856,11 @@ class EntryImportEntitySerializer(serializers.Serializer):
                             attr_data["value"][i] = _object(
                                 child_value, entity_attrs[attr_data["name"]]["refs"]
                             )
-                    if entity_attrs[attr_data["name"]]["type"] & AttrTypeValue["group"]:
+                    if entity_attrs[attr_data["name"]]["type"] & AttrType.GROUP:
                         attr_data["value"][i] = _group(child_value)
             else:
-                if entity_attrs[attr_data["name"]]["type"] & AttrTypeValue["object"]:
-                    if entity_attrs[attr_data["name"]]["type"] & AttrTypeValue["named"]:
+                if entity_attrs[attr_data["name"]]["type"] & AttrType.OBJECT:
+                    if entity_attrs[attr_data["name"]]["type"] & AttrType._NAMED:
                         if not isinstance(attr_data["value"], dict):
                             return
                         attr_data["value"] = (
@@ -878,7 +878,7 @@ class EntryImportEntitySerializer(serializers.Serializer):
                         attr_data["value"] = _object(
                             attr_data["value"], entity_attrs[attr_data["name"]]["refs"]
                         )
-                if entity_attrs[attr_data["name"]]["type"] & AttrTypeValue["group"]:
+                if entity_attrs[attr_data["name"]]["type"] & AttrType.GROUP:
                     attr_data["value"] = _group(attr_data["value"])
 
         entity: Entity | None = Entity.objects.filter(name=params["entity"], is_active=True).first()

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -23,7 +23,7 @@ from airone.lib.drf import (
     RequiredParameterError,
     YAMLParser,
 )
-from airone.lib.types import AttrType, AttrTypeValue
+from airone.lib.types import AttrType
 from api_v1.entry.serializer import EntrySearchChainSerializer
 from entity.models import Entity, EntityAttr
 from entry.api_v2.pagination import EntryReferralPagination
@@ -442,30 +442,30 @@ class AdvancedSearchAPI(generics.GenericAPIView):
             for name, attr in entry["attrs"].items():
 
                 def _get_typed_value(type: int) -> str:
-                    if type & AttrTypeValue["array"]:
-                        if type & AttrTypeValue["string"]:
+                    if type & AttrType._ARRAY:
+                        if type & AttrType.STRING:
                             return "as_array_string"
-                        elif type & AttrTypeValue["named"]:
+                        elif type & AttrType._NAMED:
                             return "as_array_named_object"
-                        elif type & AttrTypeValue["object"]:
+                        elif type & AttrType.OBJECT:
                             return "as_array_object"
-                        elif type & AttrTypeValue["group"]:
+                        elif type & AttrType.GROUP:
                             return "as_array_group"
-                        elif type & AttrTypeValue["role"]:
+                        elif type & AttrType.ROLE:
                             return "as_array_role"
-                    elif type & AttrTypeValue["string"] or type & AttrTypeValue["text"]:
+                    elif type & AttrType.STRING or type & AttrType.TEXT:
                         return "as_string"
-                    elif type & AttrTypeValue["named"]:
+                    elif type & AttrType._NAMED:
                         return "as_named_object"
-                    elif type & AttrTypeValue["object"]:
+                    elif type & AttrType.OBJECT:
                         return "as_object"
-                    elif type & AttrTypeValue["boolean"]:
+                    elif type & AttrType.BOOLEAN:
                         return "as_boolean"
-                    elif type & AttrTypeValue["date"]:
+                    elif type & AttrType.DATE:
                         return "as_string"
-                    elif type & AttrTypeValue["group"]:
+                    elif type & AttrType.GROUP:
                         return "as_group"
-                    elif type & AttrTypeValue["role"]:
+                    elif type & AttrType.ROLE:
                         return "as_role"
                     raise IncorrectTypeError(f"unexpected type: {type}")
 
@@ -667,15 +667,15 @@ class EntryAttrReferralsAPI(viewsets.ReadOnlyModelViewSet):
             conditions["name__icontains"] = keyword
 
         # TODO support natural sort?
-        if entity_attr.type & AttrTypeValue["object"]:
+        if entity_attr.type & AttrType.OBJECT:
             return Entry.objects.filter(
                 **conditions, schema__in=entity_attr.referral.all()
             ).order_by("name")[0 : CONFIG.MAX_LIST_REFERRALS]
-        elif entity_attr.type & AttrTypeValue["group"]:
+        elif entity_attr.type & AttrType.GROUP:
             return Group.objects.filter(**conditions).order_by("name")[
                 0 : CONFIG.MAX_LIST_REFERRALS
             ]
-        elif entity_attr.type & AttrTypeValue["role"]:
+        elif entity_attr.type & AttrType.ROLE:
             return Role.objects.filter(**conditions).order_by("name")[0 : CONFIG.MAX_LIST_REFERRALS]
         else:
             raise IncorrectTypeError(f"unsupported attr type: {entity_attr.type}")

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -19,7 +19,7 @@ from airone.lib.event_notification import (
 from airone.lib.http import DRFRequest
 from airone.lib.job import may_schedule_until_job_is_ready
 from airone.lib.log import Logger
-from airone.lib.types import AttrType, AttrTypeValue
+from airone.lib.types import AttrType
 from dashboard.tasks import _csv_export
 from entity.models import Entity, EntityAttr
 from entry.api_v2.serializers import (
@@ -79,7 +79,7 @@ def _convert_data_value(attr, info):
         if "value" in info and info["value"]:
             recv_value = [x["data"] for x in info["value"] if "data" in x]
 
-        if attr.schema.type & AttrTypeValue["named"]:
+        if attr.schema.type & AttrType._NAMED:
             return _merge_referrals_by_index(info["value"], info["referral_key"]).values()
         else:
             return recv_value
@@ -275,8 +275,8 @@ def _yaml_export_v2(job: Job, values, recv_data: dict, has_referral: bool) -> io
 
     def _get_attr_value(atype: int, value: dict) -> ExportedEntryAttributeValue:
         match atype:
-            case _ if atype & AttrTypeValue["array"]:
-                return [_get_attr_primitive_value(atype ^ AttrTypeValue["array"], x) for x in value]
+            case _ if atype & AttrType._ARRAY:
+                return [_get_attr_primitive_value(atype ^ AttrType._ARRAY, x) for x in value]
             case _:
                 return _get_attr_primitive_value(atype, value)
 

--- a/entry/tests/test_api_v1.py
+++ b/entry/tests/test_api_v1.py
@@ -2,7 +2,7 @@ import json
 from datetime import date
 
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType, AttrTypeValue
 from entity.models import Entity, EntityAttr
 from entry.models import Entry
 from entry.settings import CONFIG
@@ -206,7 +206,7 @@ class ViewTest(AironeViewTest):
             EntityAttr.objects.create(
                 **{
                     "name": "Refer",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "created_user": admin,
                     "parent_entity": entity,
                 }
@@ -305,7 +305,7 @@ class ViewTest(AironeViewTest):
         entity_attr = EntityAttr.objects.create(
             **{
                 "name": "Refer",
-                "type": AttrTypeValue["object"],
+                "type": AttrType.OBJECT,
                 "created_user": admin,
                 "parent_entity": entity,
             }
@@ -391,7 +391,7 @@ class ViewTest(AironeViewTest):
         entity_attr = EntityAttr.objects.create(
             **{
                 "name": "Refer",
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "created_user": admin,
                 "parent_entity": entity,
             }
@@ -418,8 +418,8 @@ class ViewTest(AironeViewTest):
             Entry.objects.create(name="r-%s" % index, schema=ref_entity, created_user=admin)
 
         attr_infos = [
-            {"name": "attr_ref", "type": AttrTypeValue["object"], "ref": ref_entity},
-            {"name": "attr_val", "type": AttrTypeValue["string"]},
+            {"name": "attr_ref", "type": AttrType.OBJECT, "ref": ref_entity},
+            {"name": "attr_val", "type": AttrType.STRING},
         ]
         entity = Entity.objects.create(name="Entity", created_user=admin)
 
@@ -443,10 +443,10 @@ class ViewTest(AironeViewTest):
             for attr_name in ["attr_ref", "attr_val"]:
                 attr = entry.attrs.get(name=attr_name)
 
-                if attr.schema.type & AttrTypeValue["string"]:
+                if attr.schema.type & AttrType.STRING:
                     attr.add_value(admin, str(index))
 
-                elif attr.schema.type & AttrTypeValue["object"]:
+                elif attr.schema.type & AttrType.OBJECT:
                     attr.add_value(admin, Entry.objects.get(name="r-%d" % index))
 
         # checks the the API request to get entries with 'or' cond_link parameter
@@ -577,7 +577,7 @@ class ViewTest(AironeViewTest):
 
     def test_get_entry_history(self):
         def _get_exp_value(attr, attr_value):
-            if attr.schema.type & AttrTypeValue["named"]:
+            if attr.schema.type & AttrType._NAMED:
                 return {
                     "value": attr_value["name"],
                     "referral": {
@@ -586,12 +586,12 @@ class ViewTest(AironeViewTest):
                     },
                 }
             elif (
-                attr.schema.type & AttrTypeValue["object"]
-                or attr.schema.type & AttrTypeValue["group"]
-                or attr.schema.type & AttrTypeValue["role"]
+                attr.schema.type & AttrType.OBJECT
+                or attr.schema.type & AttrType.GROUP
+                or attr.schema.type & AttrType.ROLE
             ):
                 return {"id": attr_value.id, "name": attr_value.name}
-            elif attr.schema.type & AttrTypeValue["date"]:
+            elif attr.schema.type & AttrType.DATE:
                 return str(attr_value)
             else:
                 return attr_value
@@ -660,7 +660,7 @@ class ViewTest(AironeViewTest):
             attr = entry.attrs.get(schema__name=attrname)
             attr_value_history = [x for x in resp_data if x["attr_name"] == attrname]
 
-            if attr.schema.type & AttrTypeValue["array"]:
+            if attr.schema.type & AttrType._ARRAY:
                 exp_curr_value = [_get_exp_value(attr, x) for x in info["values"][1]]
                 exp_prev_value = [_get_exp_value(attr, x) for x in info["values"][0]]
             else:
@@ -672,7 +672,7 @@ class ViewTest(AironeViewTest):
             # check order of former value and previous value
             for index, history_value in enumerate(attr_value_history):
                 if (
-                    attr.schema.type & AttrTypeValue["array"]
+                    attr.schema.type & AttrType._ARRAY
                     and not history_value["curr"]["value"]
                     and not history_value["prev"]
                 ):
@@ -681,7 +681,7 @@ class ViewTest(AironeViewTest):
                 if not history_value["prev"] or not history_value["prev"]["value"]:
                     # The oldest update history
                     self.assertEqual(history_value["curr"]["value"], exp_prev_value)
-                    if attr.schema.type & AttrTypeValue["array"]:
+                    if attr.schema.type & AttrType._ARRAY:
                         self.assertEqual(history_value["prev"]["value"], [])
                     else:
                         self.assertEqual(history_value["prev"], None)
@@ -699,7 +699,7 @@ class ViewTest(AironeViewTest):
         entity_attr = EntityAttr.objects.create(
             **{
                 "name": "attr",
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "created_user": user,
                 "parent_entity": entity,
             }
@@ -737,7 +737,7 @@ class ViewTest(AironeViewTest):
         entity_attr = EntityAttr.objects.create(
             **{
                 "name": "attr",
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "created_user": user,
                 "parent_entity": entity,
             }

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -13,6 +13,7 @@ from rest_framework.exceptions import ValidationError
 from airone.lib.log import Logger
 from airone.lib.test import AironeViewTest
 from airone.lib.types import (
+    AttrType,
     AttrTypeArrNamedObj,
     AttrTypeArrObj,
     AttrTypeArrStr,
@@ -48,7 +49,7 @@ class BaseViewTest(AironeViewTest):
             attrs=self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY,
         )
         for attr in self.ref_entity.attrs.all():
-            if attr.type & AttrTypeValue["object"]:
+            if attr.type & AttrType.OBJECT:
                 attr.referral.add(self.ref_entity)
 
         self.ref_entry: Entry = self.add_entry(self.user, "r-0", self.ref_entity)
@@ -57,7 +58,7 @@ class BaseViewTest(AironeViewTest):
 
         attrs = []
         for attr_info in self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY:
-            if attr_info["type"] & AttrTypeValue["object"]:
+            if attr_info["type"] & AttrType.OBJECT:
                 attr_info["ref"] = self.ref_entity
             attrs.append(attr_info)
         self.entity: Entity = self.create_entity(
@@ -116,7 +117,7 @@ class ViewTest(BaseViewTest):
         optional_attr = EntityAttr.objects.create(
             **{
                 "name": "opt",
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "is_mandatory": False,
                 "parent_entity": self.entity,
                 "created_user": self.user,
@@ -138,7 +139,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "val", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "value": {"as_string": "hoge"},
                 "id": entry.attrs.get(schema__name="val").id,
                 "is_mandatory": False,
@@ -152,7 +153,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "ref", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["object"],
+                "type": AttrType.OBJECT,
                 "value": {
                     "as_object": {
                         "id": self.ref_entry.id,
@@ -175,7 +176,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "name", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "value": {
                     "as_named_object": {
                         "name": "hoge",
@@ -201,7 +202,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "bool", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["boolean"],
+                "type": AttrType.BOOLEAN,
                 "value": {"as_boolean": False},
                 "id": entry.attrs.get(schema__name="bool").id,
                 "is_mandatory": False,
@@ -215,7 +216,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "date", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["date"],
+                "type": AttrType.DATE,
                 "value": {"as_string": "2018-12-31"},
                 "id": entry.attrs.get(schema__name="date").id,
                 "is_mandatory": False,
@@ -229,7 +230,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "group", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["group"],
+                "type": AttrType.GROUP,
                 "value": {
                     "as_group": {
                         "id": self.group.id,
@@ -248,7 +249,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "groups", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["array_group"],
+                "type": AttrType.ARRAY_GROUP,
                 "value": {
                     "as_array_group": [
                         {
@@ -269,7 +270,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "role", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["role"],
+                "type": AttrType.ROLE,
                 "value": {
                     "as_role": {
                         "id": self.role.id,
@@ -288,7 +289,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "roles", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["array_role"],
+                "type": AttrType.ARRAY_ROLE,
                 "value": {
                     "as_array_role": [
                         {
@@ -309,7 +310,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "text", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["text"],
+                "type": AttrType.TEXT,
                 "value": {"as_string": "fuga"},
                 "id": entry.attrs.get(schema__name="text").id,
                 "is_mandatory": False,
@@ -323,7 +324,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "vals", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["array_string"],
+                "type": AttrType.ARRAY_STRING,
                 "value": {"as_array_string": ["foo", "bar"]},
                 "id": entry.attrs.get(schema__name="vals").id,
                 "is_mandatory": False,
@@ -337,7 +338,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "refs", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "value": {
                     "as_array_object": [
                         {
@@ -362,7 +363,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "names", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "value": {
                     "as_array_named_object": [
                         {
@@ -401,7 +402,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "opt", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "value": {"as_string": AttrTypeStr.DEFAULT_VALUE},
                 "id": None,
                 "is_mandatory": False,
@@ -462,7 +463,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "val", resp.json()["attrs"])),
             {
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "value": {"as_string": ""},
                 "id": entry.attrs.get(schema__name="val").id,
                 "is_mandatory": False,
@@ -481,7 +482,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "val", resp.json()["attrs"])),
             {
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "value": {"as_string": ""},
                 "id": entry.attrs.get(schema__name="val").id,
                 "is_mandatory": False,
@@ -502,7 +503,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "val", resp.json()["attrs"])),
             {
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "value": {"as_string": ""},
                 "id": entry.attrs.get(schema__name="val").id,
                 "is_mandatory": False,
@@ -521,7 +522,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "val", resp.json()["attrs"])),
             {
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "value": {"as_string": ""},
                 "id": entry.attrs.get(schema__name="val").id,
                 "is_mandatory": False,
@@ -557,7 +558,7 @@ class ViewTest(BaseViewTest):
             entry_attrs.append(
                 {
                     "id": 0,
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "value": "hoge",
                     "schema": {
                         "id": 0,
@@ -581,7 +582,7 @@ class ViewTest(BaseViewTest):
             resp.json()["attrs"][-1],
             {
                 "id": 0,
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "value": "hoge",
                 "schema": {
                     "id": 0,
@@ -622,7 +623,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "ref", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["object"],
+                "type": AttrType.OBJECT,
                 "value": {
                     "as_object": None,
                 },
@@ -638,7 +639,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "name", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "value": {
                     "as_named_object": {
                         "name": "hoge",
@@ -657,7 +658,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "refs", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "value": {"as_array_object": []},
                 "id": entry.attrs.get(schema__name="refs").id,
                 "is_mandatory": False,
@@ -671,7 +672,7 @@ class ViewTest(BaseViewTest):
         self.assertEqual(
             next(filter(lambda x: x["schema"]["name"] == "names", resp_data["attrs"])),
             {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "value": {"as_array_named_object": []},
                 "id": entry.attrs.get(schema__name="names").id,
                 "is_mandatory": False,
@@ -1970,7 +1971,7 @@ class ViewTest(BaseViewTest):
                 EntityAttr.objects.create(
                     **{
                         "name": name,
-                        "type": AttrTypeValue["string"],
+                        "type": AttrType.STRING,
                         "created_user": user,
                         "parent_entity": entity,
                     }
@@ -2027,7 +2028,7 @@ class ViewTest(BaseViewTest):
             EntityAttr.objects.create(
                 **{
                     "name": "new_attr",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "created_user": user,
                     "parent_entity": entity,
                     "is_public": False,
@@ -2085,7 +2086,7 @@ class ViewTest(BaseViewTest):
         entity_attr_object = EntityAttr.objects.create(
             **{
                 "name": "object",
-                "type": AttrTypeValue["object"],
+                "type": AttrType.OBJECT,
                 "created_user": user,
                 "parent_entity": entity,
             }
@@ -2095,7 +2096,7 @@ class ViewTest(BaseViewTest):
         entity_attr_array_object = EntityAttr.objects.create(
             **{
                 "name": "array_object",
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "created_user": user,
                 "parent_entity": entity,
             }
@@ -2105,7 +2106,7 @@ class ViewTest(BaseViewTest):
         entity_attr_named_object = EntityAttr.objects.create(
             **{
                 "name": "named_object",
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "created_user": user,
                 "parent_entity": entity,
             }
@@ -2115,7 +2116,7 @@ class ViewTest(BaseViewTest):
         entity_attr_named_object_without_key = EntityAttr.objects.create(
             **{
                 "name": "named_object_without_key",
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "created_user": user,
                 "parent_entity": entity,
             }
@@ -2125,7 +2126,7 @@ class ViewTest(BaseViewTest):
         entity_attr_array_named_object = EntityAttr.objects.create(
             **{
                 "name": "array_named_object",
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "created_user": user,
                 "parent_entity": entity,
             }
@@ -2263,7 +2264,7 @@ class ViewTest(BaseViewTest):
 
             test_val = None
 
-            if case[0].TYPE & AttrTypeValue["array"] == 0:
+            if case[0].TYPE & AttrType._ARRAY == 0:
                 if case[0] == AttrTypeStr:
                     test_val = AttributeValue.create(user=user, attr=test_attr, value=case[1])
                 elif case[0] == AttrTypeObj:
@@ -2316,8 +2317,8 @@ class ViewTest(BaseViewTest):
             self.user,
             "Entity",
             attrs=[
-                {"name": "role", "type": AttrTypeValue["role"]},
-                {"name": "roles", "type": AttrTypeValue["array_role"]},
+                {"name": "role", "type": AttrType.ROLE},
+                {"name": "roles", "type": AttrType.ARRAY_ROLE},
             ],
         )
 
@@ -2387,7 +2388,7 @@ class ViewTest(BaseViewTest):
         entity_attr = EntityAttr.objects.create(
             **{
                 "name": "Refer",
-                "type": AttrTypeValue["object"],
+                "type": AttrType.OBJECT,
                 "created_user": admin,
                 "parent_entity": entity,
             }
@@ -2470,7 +2471,7 @@ class ViewTest(BaseViewTest):
         entity_attr = EntityAttr.objects.create(
             **{
                 "name": "Refer",
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "created_user": admin,
                 "parent_entity": entity,
             }
@@ -3206,23 +3207,23 @@ class ViewTest(BaseViewTest):
         grp_entry = Group.objects.create(name="group_entry")
         role_entry = Role.objects.create(name="role_entry")
         attr_info = {
-            "str": {"type": AttrTypeValue["string"], "value": "foo"},
-            "text": {"type": AttrTypeValue["text"], "value": "foo"},
-            "bool": {"type": AttrTypeValue["boolean"], "value": True},
-            "date": {"type": AttrTypeValue["date"], "value": "2020-01-01"},
-            "obj": {"type": AttrTypeValue["object"], "value": ref_entry},
-            "grp": {"type": AttrTypeValue["group"], "value": grp_entry},
-            "role": {"type": AttrTypeValue["role"], "value": role_entry},
+            "str": {"type": AttrType.STRING, "value": "foo"},
+            "text": {"type": AttrType.TEXT, "value": "foo"},
+            "bool": {"type": AttrType.BOOLEAN, "value": True},
+            "date": {"type": AttrType.DATE, "value": "2020-01-01"},
+            "obj": {"type": AttrType.OBJECT, "value": ref_entry},
+            "grp": {"type": AttrType.GROUP, "value": grp_entry},
+            "role": {"type": AttrType.ROLE, "value": role_entry},
             "name": {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "value": {"name": "bar", "id": ref_entry.id},
             },
-            "arr_str": {"type": AttrTypeValue["array_string"], "value": ["foo"]},
-            "arr_obj": {"type": AttrTypeValue["array_object"], "value": [ref_entry]},
-            "arr_grp": {"type": AttrTypeValue["array_group"], "value": [grp_entry]},
-            "arr_role": {"type": AttrTypeValue["array_role"], "value": [role_entry]},
+            "arr_str": {"type": AttrType.ARRAY_STRING, "value": ["foo"]},
+            "arr_obj": {"type": AttrType.ARRAY_OBJECT, "value": [ref_entry]},
+            "arr_grp": {"type": AttrType.ARRAY_GROUP, "value": [grp_entry]},
+            "arr_role": {"type": AttrType.ARRAY_ROLE, "value": [role_entry]},
             "arr_name": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "value": [{"name": "hoge", "id": ref_entry.id}],
             },
         }
@@ -3586,7 +3587,7 @@ class ViewTest(BaseViewTest):
         entity = Entity.objects.create(name="entity", created_user=user)
         entity_attr = EntityAttr.objects.create(
             name="attr_ref",
-            type=AttrTypeValue["object"],
+            type=AttrType.OBJECT,
             created_user=user,
             parent_entity=entity,
         )
@@ -3725,7 +3726,7 @@ class ViewTest(BaseViewTest):
 
             test_val = None
 
-            if case[0].TYPE & AttrTypeValue["array"] == 0:
+            if case[0].TYPE & AttrType._ARRAY == 0:
                 if case[0] == AttrTypeStr:
                     test_val = AttributeValue.create(user=user, attr=test_attr, value=case[1])
                 elif case[0] == AttrTypeObj:
@@ -3796,48 +3797,48 @@ class ViewTest(BaseViewTest):
 
         attr_info = {
             "str": {
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "value": "foo",
                 "invalid_values": [123, entry_ref, True],
             },
-            "obj": {"type": AttrTypeValue["object"], "value": str(entry_ref.id)},
+            "obj": {"type": AttrType.OBJECT, "value": str(entry_ref.id)},
             "name": {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "value": {"name": "bar", "id": str(entry_ref.id)},
             },
-            "bool": {"type": AttrTypeValue["boolean"], "value": False},
+            "bool": {"type": AttrType.BOOLEAN, "value": False},
             "arr_str": {
-                "type": AttrTypeValue["array_string"],
+                "type": AttrType.ARRAY_STRING,
                 "value": ["foo", "bar", "baz"],
             },
             "arr_obj": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "value": [str(entry_ref.id)],
             },
             "arr_name": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "value": [
                     {"name": "hoge", "id": str(entry_ref.id)},
                     {"name": "fuga", "boolean": False},  # specify boolean parameter
                 ],
             },
             "group": {
-                "type": AttrTypeValue["group"],
+                "type": AttrType.GROUP,
                 "value": str(entry_group.id),
             },
             "arr_group": {
-                "type": AttrTypeValue["array_group"],
+                "type": AttrType.ARRAY_GROUP,
                 "value": [str(entry_group.id)],
             },
             "role": {
-                "type": AttrTypeValue["role"],
+                "type": AttrType.ROLE,
                 "value": str(entry_role.id),
             },
             "arr_role": {
-                "type": AttrTypeValue["array_role"],
+                "type": AttrType.ARRAY_ROLE,
                 "value": [str(entry_role.id)],
             },
-            "date": {"type": AttrTypeValue["date"], "value": date(2020, 1, 1)},
+            "date": {"type": AttrType.DATE, "value": date(2020, 1, 1)},
         }
         entities = []
         for index in range(2):
@@ -3850,7 +3851,7 @@ class ViewTest(BaseViewTest):
                     parent_entity=entity,
                 )
 
-                if info["type"] & AttrTypeValue["object"]:
+                if info["type"] & AttrType.OBJECT:
                     attr.referral.add(entity_ref)
 
                 entity.attrs.add(attr)
@@ -4099,7 +4100,7 @@ class ViewTest(BaseViewTest):
         entity = Entity.objects.create(name="entity", created_user=user)
         entity_attr = EntityAttr.objects.create(
             name="attr_ref",
-            type=AttrTypeValue["object"],
+            type=AttrType.OBJECT,
             created_user=user,
             parent_entity=entity,
         )

--- a/entry/tests/test_api_v2_serializer.py
+++ b/entry/tests/test_api_v2_serializer.py
@@ -1,7 +1,7 @@
 from airone.lib.acl import ACLType
 from airone.lib.http import DRFRequest
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entry.api_v2.serializers import (
     PrivilegedEntryCreateSerializer,
     PrivilegedEntryUpdateSerializer,
@@ -20,7 +20,7 @@ class ViewTest(AironeViewTest):
             user,
             "Entity",
             attrs=[
-                {"name": "secret", "type": AttrTypeValue["string"]},
+                {"name": "secret", "type": AttrType.STRING},
             ],
         )
         attr = self.schema.attrs.last()

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -10,7 +10,7 @@ from airone.lib.drf import ExceedLimitError
 from airone.lib.elasticsearch import FilterKey
 from airone.lib.log import Logger
 from airone.lib.test import AironeTestCase
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType, AttrTypeValue
 from entity.models import Entity, EntityAttr
 from entry.models import Attribute, AttributeValue, Entry
 from entry.settings import CONFIG
@@ -93,33 +93,33 @@ class ModelTest(AironeTestCase):
         """
         entity = Entity.objects.create(name="all_attr_entity", created_user=user)
         attr_info = {
-            "str": AttrTypeValue["string"],
-            "text": AttrTypeValue["text"],
-            "obj": AttrTypeValue["object"],
-            "name": AttrTypeValue["named_object"],
-            "bool": AttrTypeValue["boolean"],
-            "group": AttrTypeValue["group"],
-            "date": AttrTypeValue["date"],
-            "role": AttrTypeValue["role"],
-            "arr_str": AttrTypeValue["array_string"],
-            "arr_obj": AttrTypeValue["array_object"],
-            "arr_name": AttrTypeValue["array_named_object"],
-            "arr_group": AttrTypeValue["array_group"],
-            "arr_role": AttrTypeValue["array_role"],
+            "str": AttrType.STRING,
+            "text": AttrType.TEXT,
+            "obj": AttrType.OBJECT,
+            "name": AttrType.NAMED_OBJECT,
+            "bool": AttrType.BOOLEAN,
+            "group": AttrType.GROUP,
+            "date": AttrType.DATE,
+            "role": AttrType.ROLE,
+            "arr_str": AttrType.ARRAY_STRING,
+            "arr_obj": AttrType.ARRAY_OBJECT,
+            "arr_name": AttrType.ARRAY_NAMED_OBJECT,
+            "arr_group": AttrType.ARRAY_GROUP,
+            "arr_role": AttrType.ARRAY_ROLE,
         }
         for attr_name, attr_type in attr_info.items():
             attr = EntityAttr.objects.create(
                 name=attr_name, type=attr_type, created_user=user, parent_entity=entity
             )
 
-            if attr_type & AttrTypeValue["object"] and ref_entity:
+            if attr_type & AttrType.OBJECT and ref_entity:
                 attr.referral.add(ref_entity)
 
             entity.attrs.add(attr)
 
         return entity
 
-    def make_attr(self, name, attrtype=AttrTypeValue["string"], user=None, entity=None, entry=None):
+    def make_attr(self, name, attrtype=AttrType.STRING, user=None, entity=None, entry=None):
         entity_attr = EntityAttr.objects.create(
             name=name,
             type=attrtype,
@@ -176,7 +176,7 @@ class ModelTest(AironeTestCase):
 
         entity = Entity.objects.create(name="entity", created_user=user)
         attrbase = EntityAttr.objects.create(
-            name="attr", type=AttrTypeValue["object"], created_user=user, parent_entity=entity
+            name="attr", type=AttrType.OBJECT, created_user=user, parent_entity=entity
         )
 
         # update acl metadata
@@ -201,7 +201,7 @@ class ModelTest(AironeTestCase):
 
         entity = Entity.objects.create(name="entity", created_user=user)
         attrbase = EntityAttr.objects.create(
-            name="attr", type=AttrTypeValue["object"], created_user=user, parent_entity=entity
+            name="attr", type=AttrType.OBJECT, created_user=user, parent_entity=entity
         )
 
         # set a permission to the user
@@ -222,7 +222,7 @@ class ModelTest(AironeTestCase):
 
         attrbase = EntityAttr.objects.create(
             name="attrbase",
-            type=AttrTypeValue["string"],
+            type=AttrType.STRING,
             created_user=user,
             parent_entity=entity,
         )
@@ -276,7 +276,7 @@ class ModelTest(AironeTestCase):
         entity = Entity.objects.create(name="e2", created_user=self._user)
         entry = Entry.objects.create(name="_E", created_user=self._user, schema=entity)
 
-        attr = self.make_attr("attr2", attrtype=AttrTypeValue["object"], entity=entity, entry=entry)
+        attr = self.make_attr("attr2", attrtype=AttrType.OBJECT, entity=entity, entry=entry)
         attr.values.add(
             AttributeValue.objects.create(referral=e1, created_user=self._user, parent_attr=attr)
         )
@@ -292,9 +292,7 @@ class ModelTest(AironeTestCase):
         entity = Entity.objects.create(name="e2", created_user=self._user)
         entry = Entry.objects.create(name="_E", created_user=self._user, schema=entity)
 
-        attr = self.make_attr(
-            "attr2", attrtype=AttrTypeValue["array_string"], entity=entity, entry=entry
-        )
+        attr = self.make_attr("attr2", attrtype=AttrType.ARRAY_STRING, entity=entity, entry=entry)
         attr_value = AttributeValue.objects.create(created_user=self._user, parent_attr=attr)
         attr_value.set_status(AttributeValue.STATUS_DATA_ARRAY_PARENT)
 
@@ -325,9 +323,7 @@ class ModelTest(AironeTestCase):
         entity = Entity.objects.create(name="e2", created_user=self._user)
         entry = Entry.objects.create(name="_E", created_user=self._user, schema=entity)
 
-        attr = self.make_attr(
-            "attr2", attrtype=AttrTypeValue["array_object"], entity=entity, entry=entry
-        )
+        attr = self.make_attr("attr2", attrtype=AttrType.ARRAY_OBJECT, entity=entity, entry=entry)
         attr_value = AttributeValue.objects.create(created_user=self._user, parent_attr=attr)
         attr_value.set_status(AttributeValue.STATUS_DATA_ARRAY_PARENT)
 
@@ -365,9 +361,7 @@ class ModelTest(AironeTestCase):
         entity = Entity.objects.create(name="e2", created_user=self._user)
         entry = Entry.objects.create(name="_E", created_user=self._user, schema=entity)
 
-        attr = self.make_attr(
-            "attr2", attrtype=AttrTypeValue["array_object"], entity=entity, entry=entry
-        )
+        attr = self.make_attr("attr2", attrtype=AttrType.ARRAY_OBJECT, entity=entity, entry=entry)
         attr_value = AttributeValue.objects.create(created_user=self._user, parent_attr=attr)
         attr_value.set_status(AttributeValue.STATUS_DATA_ARRAY_PARENT)
 
@@ -397,7 +391,7 @@ class ModelTest(AironeTestCase):
         entity = Entity.objects.create(name="entity", created_user=self._user)
         new_attr_params = {
             "name": "named_ref",
-            "type": AttrTypeValue["named_object"],
+            "type": AttrType.NAMED_OBJECT,
             "created_user": self._user,
             "parent_entity": entity,
         }
@@ -448,7 +442,7 @@ class ModelTest(AironeTestCase):
         entity = Entity.objects.create(name="entity", created_user=self._user)
         new_attr_params = {
             "name": "arr_named_ref",
-            "type": AttrTypeValue["array_named_object"],
+            "type": AttrType.ARRAY_NAMED_OBJECT,
             "created_user": self._user,
             "parent_entity": entity,
         }
@@ -532,7 +526,7 @@ class ModelTest(AironeTestCase):
         )
 
     def test_for_boolean_attr_and_value(self):
-        attr = self.make_attr("attr_bool", AttrTypeValue["boolean"])
+        attr = self.make_attr("attr_bool", AttrType.BOOLEAN)
 
         # Checks get_latest_value returns empty AttributeValue
         # even if target attribute doesn't have any value
@@ -559,7 +553,7 @@ class ModelTest(AironeTestCase):
         self.assertTrue(attr.is_updated(True))
 
     def test_for_date_attr_and_value(self):
-        attr = self.make_attr("attr_date", AttrTypeValue["date"])
+        attr = self.make_attr("attr_date", AttrType.DATE)
 
         attr.values.add(
             AttributeValue.objects.create(
@@ -592,7 +586,7 @@ class ModelTest(AironeTestCase):
         test_group = Group.objects.create(name="g0")
 
         # create test target Attribute and empty AttributeValue for it
-        attr = self.make_attr("attr_date", AttrTypeValue["group"])
+        attr = self.make_attr("attr_date", AttrType.GROUP)
         attr.add_value(self._user, None)
 
         # The cases when value will be updated
@@ -607,7 +601,7 @@ class ModelTest(AironeTestCase):
         test_groups = [Group.objects.create(name=x) for x in ["g0", "g1"]]
 
         # create test target Attribute and empty AttributeValue for it
-        attr = self.make_attr("attr_date", AttrTypeValue["array_group"])
+        attr = self.make_attr("attr_date", AttrType.ARRAY_GROUP)
         attr.add_value(self._user, None)
 
         # The cases when value will be updated
@@ -629,7 +623,7 @@ class ModelTest(AironeTestCase):
         entity.attrs.add(
             EntityAttr.objects.create(
                 name="attr",
-                type=AttrTypeValue["string"],
+                type=AttrType.STRING,
                 created_user=user,
                 parent_entity=entity,
             )
@@ -654,11 +648,11 @@ class ModelTest(AironeTestCase):
         entry1 = Entry.objects.create(name="r1", created_user=self._user, schema=entity)
         entry2 = Entry.objects.create(name="r2", created_user=self._user, schema=entity)
 
-        attr = self.make_attr("attr_ref", attrtype=AttrTypeValue["object"])
+        attr = self.make_attr("attr_ref", attrtype=AttrType.OBJECT)
 
         # this attribute is needed to check not only get referral from normal object attribute,
         # but also from an attribute that refers array referral objects
-        arr_attr = self.make_attr("attr_arr_ref", attrtype=AttrTypeValue["array_object"])
+        arr_attr = self.make_attr("attr_arr_ref", attrtype=AttrType.ARRAY_OBJECT)
 
         # make multiple value that refer 'entry' object
         [
@@ -701,7 +695,7 @@ class ModelTest(AironeTestCase):
             attrs=[
                 {
                     "name": "ref",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                 }
             ],
         )
@@ -725,7 +719,7 @@ class ModelTest(AironeTestCase):
 
             attr = self.make_attr(
                 "attr_ref" + str(i),
-                attrtype=AttrTypeValue["object"],
+                attrtype=AttrType.OBJECT,
                 entity=entity,
                 entry=entry,
             )
@@ -755,7 +749,7 @@ class ModelTest(AironeTestCase):
     def test_coordinating_attribute_with_dynamically_added_one(self):
         newattr = EntityAttr.objects.create(
             name="newattr",
-            type=AttrTypeValue["string"],
+            type=AttrType.STRING,
             created_user=self._user,
             parent_entity=self._entity,
         )
@@ -772,7 +766,7 @@ class ModelTest(AironeTestCase):
             EntityAttr.objects.create(
                 **{
                     "name": "attr",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "created_user": self._user,
                     "parent_entity": self._entity,
                 }
@@ -805,7 +799,7 @@ class ModelTest(AironeTestCase):
         entity = Entity.objects.create(name="ReferredEntity", created_user=self._user)
         entry = Entry.objects.create(name="entry", created_user=self._user, schema=entity)
 
-        attr = self.make_attr("attr_ref", attrtype=AttrTypeValue["object"])
+        attr = self.make_attr("attr_ref", attrtype=AttrType.OBJECT)
 
         self._entry.attrs.add(attr)
 
@@ -852,8 +846,8 @@ class ModelTest(AironeTestCase):
 
         # initialize EntityAttrs
         attr_info = {
-            "obj": {"type": AttrTypeValue["object"], "value": ref_entries[0]},
-            "arr_obj": {"type": AttrTypeValue["array_object"], "value": ref_entries},
+            "obj": {"type": AttrType.OBJECT, "value": ref_entries[0]},
+            "arr_obj": {"type": AttrType.ARRAY_OBJECT, "value": ref_entries},
         }
         for attr_name, info in attr_info.items():
             # create EntityAttr object with is_delete_in_chain object
@@ -865,7 +859,7 @@ class ModelTest(AironeTestCase):
                 parent_entity=self._entity,
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             self._entity.attrs.add(attr)
@@ -937,7 +931,7 @@ class ModelTest(AironeTestCase):
         entity = Entity.objects.create(name="entity", created_user=self._user)
         new_attr_params = {
             "name": "arr_named_ref",
-            "type": AttrTypeValue["array_named_object"],
+            "type": AttrType.ARRAY_NAMED_OBJECT,
             "created_user": self._user,
             "parent_entity": entity,
         }
@@ -1027,13 +1021,13 @@ class ModelTest(AironeTestCase):
     def test_clone_attribute_without_permission(self):
         unknown_user = User.objects.create(username="unknown")
 
-        attr = self.make_attr(name="attr", attrtype=AttrTypeValue["array_string"])
+        attr = self.make_attr(name="attr", attrtype=AttrType.ARRAY_STRING)
         attr.is_public = False
         attr.save()
         self.assertIsNone(attr.clone(unknown_user))
 
     def test_clone_attribute_typed_string(self):
-        attr = self.make_attr(name="attr", attrtype=AttrTypeValue["string"])
+        attr = self.make_attr(name="attr", attrtype=AttrType.STRING)
         attr.add_value(self._user, "hoge")
         copy_entry = Entry.objects.create(
             schema=self._entity, name="copy_entry", created_user=self._user
@@ -1049,7 +1043,7 @@ class ModelTest(AironeTestCase):
         self.assertNotEqual(cloned_attr.values.last(), attr.values.last())
 
     def test_clone_attribute_typed_array_string(self):
-        attr = self.make_attr(name="attr", attrtype=AttrTypeValue["array_string"])
+        attr = self.make_attr(name="attr", attrtype=AttrType.ARRAY_STRING)
         attr.add_value(self._user, [str(i) for i in range(10)])
         copy_entry = Entry.objects.create(
             schema=self._entity, name="copy_entry", created_user=self._user
@@ -1079,7 +1073,7 @@ class ModelTest(AironeTestCase):
             EntityAttr.objects.create(
                 **{
                     "name": "string",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "created_user": self._user,
                     "parent_entity": test_entity,
                 }
@@ -1090,7 +1084,7 @@ class ModelTest(AironeTestCase):
             EntityAttr.objects.create(
                 **{
                     "name": "arrobj",
-                    "type": AttrTypeValue["array_object"],
+                    "type": AttrType.ARRAY_OBJECT,
                     "created_user": self._user,
                     "parent_entity": test_entity,
                 }
@@ -1151,7 +1145,7 @@ class ModelTest(AironeTestCase):
             self._entity.attrs.add(
                 EntityAttr.objects.create(
                     **{
-                        "type": AttrTypeValue["string"],
+                        "type": AttrType.STRING,
                         "created_user": self._user,
                         "parent_entity": self._entity,
                         "name": info["name"],
@@ -1268,15 +1262,15 @@ class ModelTest(AironeTestCase):
                 attrinfo[info["name"]] = {}
 
             attrinfo[info["name"]]["attr"] = attr
-            if attr.schema.type == AttrTypeValue["named_object"]:
+            if attr.schema.type == AttrType.NAMED_OBJECT:
                 attrinfo[info["name"]]["exp_val"] = {
                     "value": "bar",
                     "id": aclbase_ref.id,
                     "name": aclbase_ref.name,
                 }
-            elif attr.schema.type == AttrTypeValue["object"]:
+            elif attr.schema.type == AttrType.OBJECT:
                 attrinfo[info["name"]]["exp_val"] = aclbase_ref
-            elif attr.schema.type == AttrTypeValue["array_named_object"]:
+            elif attr.schema.type == AttrType.ARRAY_NAMED_OBJECT:
                 attrinfo[info["name"]]["exp_val"] = [
                     {
                         "value": "hoge",
@@ -1284,11 +1278,11 @@ class ModelTest(AironeTestCase):
                         "name": aclbase_ref.name,
                     }
                 ]
-            elif attr.schema.type == AttrTypeValue["array_object"]:
+            elif attr.schema.type == AttrType.ARRAY_OBJECT:
                 attrinfo[info["name"]]["exp_val"] = [aclbase_ref]
-            elif attr.schema.type == AttrTypeValue["group"]:
+            elif attr.schema.type == AttrType.GROUP:
                 attrinfo[info["name"]]["exp_val"] = test_group
-            elif attr.schema.type == AttrTypeValue["array_group"]:
+            elif attr.schema.type == AttrType.ARRAY_GROUP:
                 attrinfo[info["name"]]["exp_val"] = [test_group]
             else:
                 attrinfo[info["name"]]["exp_val"] = info["exp_val"]
@@ -1330,7 +1324,7 @@ class ModelTest(AironeTestCase):
             EntityAttr.objects.create(
                 **{
                     "name": "attr",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "created_user": user,
                     "parent_entity": entity,
                 }
@@ -1370,7 +1364,7 @@ class ModelTest(AironeTestCase):
             EntityAttr.objects.create(
                 **{
                     "name": "attr",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "created_user": user,
                     "parent_entity": entity,
                 }
@@ -1391,7 +1385,7 @@ class ModelTest(AironeTestCase):
         results = entry.get_available_attrs(self._user)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["last_value"], "")
-        self.assertEqual(AttributeValue.objects.get(id=attrv.id).data_type, AttrTypeValue["string"])
+        self.assertEqual(AttributeValue.objects.get(id=attrv.id).data_type, AttrType.STRING)
 
     def test_get_deleted_referred_attrs(self):
         user = User.objects.create(username="hoge")
@@ -1401,14 +1395,14 @@ class ModelTest(AironeTestCase):
         ref_entry = Entry.objects.create(name="ReferredEntry", schema=ref_entity, created_user=user)
 
         attr_info = {
-            "obj": {"type": AttrTypeValue["object"], "value": ref_entry},
+            "obj": {"type": AttrType.OBJECT, "value": ref_entry},
             "name": {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "value": {"name": "hoge", "id": ref_entry},
             },
-            "arr_obj": {"type": AttrTypeValue["array_object"], "value": [ref_entry]},
+            "arr_obj": {"type": AttrType.ARRAY_OBJECT, "value": [ref_entry]},
             "arr_name": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "value": [{"name": "hoge", "id": ref_entry}],
             },
         }
@@ -1469,14 +1463,14 @@ class ModelTest(AironeTestCase):
         ref_entity = Entity.objects.create(name="ReferredEntity", created_user=user)
         entity = Entity.objects.create(name="entity", created_user=user)
         attr_info = {
-            "obj": {"type": AttrTypeValue["object"], "value": None},
+            "obj": {"type": AttrType.OBJECT, "value": None},
             "name": {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "value": {"name": "hoge", "id": None},
             },
-            "arr_obj": {"type": AttrTypeValue["array_object"], "value": []},
+            "arr_obj": {"type": AttrType.ARRAY_OBJECT, "value": []},
             "arr_name": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "value": [{"name": "hoge", "id": None}],
             },
         }
@@ -1609,22 +1603,22 @@ class ModelTest(AironeTestCase):
             # test return value of get_value method with 'with_metainfo' parameter
             expected_value = {"type": attr.schema.type, "value": info["exp_val"]}
             if attr.is_array():
-                if attr.schema.type & AttrTypeValue["named"]:
+                if attr.schema.type & AttrType._NAMED:
                     expected_value["value"] = [{"hoge": {"id": test_ref.id, "name": test_ref.name}}]
-                elif attr.schema.type & AttrTypeValue["object"]:
+                elif attr.schema.type & AttrType.OBJECT:
                     expected_value["value"] = [{"id": test_ref.id, "name": test_ref.name}]
-                elif attr.schema.type & AttrTypeValue["group"]:
+                elif attr.schema.type & AttrType.GROUP:
                     expected_value["value"] = [{"id": test_grp.id, "name": test_grp.name}]
-                elif attr.schema.type & AttrTypeValue["role"]:
+                elif attr.schema.type & AttrType.ROLE:
                     expected_value["value"] = [{"id": test_role.id, "name": test_role.name}]
 
-            elif attr.schema.type & AttrTypeValue["named"]:
+            elif attr.schema.type & AttrType._NAMED:
                 expected_value["value"] = {"bar": {"id": test_ref.id, "name": test_ref.name}}
-            elif attr.schema.type & AttrTypeValue["object"]:
+            elif attr.schema.type & AttrType.OBJECT:
                 expected_value["value"] = {"id": test_ref.id, "name": test_ref.name}
-            elif attr.schema.type & AttrTypeValue["group"]:
+            elif attr.schema.type & AttrType.GROUP:
                 expected_value["value"] = {"id": test_grp.id, "name": test_grp.name}
-            elif attr.schema.type & AttrTypeValue["role"]:
+            elif attr.schema.type & AttrType.ROLE:
                 expected_value["value"] = {"id": test_role.id, "name": test_role.name}
 
             self.assertEqual(attrv.get_value(with_metainfo=True), expected_value)
@@ -1632,7 +1626,7 @@ class ModelTest(AironeTestCase):
     def test_get_value_with_serialize_parameter(self):
         # Craete Attribute instance and set test Date value
         date_value = date(2021, 6, 8)
-        attr_date = self.make_attr("date", attrtype=AttrTypeValue["date"])
+        attr_date = self.make_attr("date", attrtype=AttrType.DATE)
         attr_date.add_value(self._user, date_value)
 
         # test retrieved value by get_value method with serialize parameter is expected
@@ -1802,10 +1796,10 @@ class ModelTest(AironeTestCase):
 
         ref_entity = Entity.objects.create(name="Referred Entity", created_user=user)
         attr_info = {
-            "str1": {"type": AttrTypeValue["string"], "is_public": True},
-            "str2": {"type": AttrTypeValue["string"], "is_public": True},
-            "obj": {"type": AttrTypeValue["object"], "is_public": True},
-            "invisible": {"type": AttrTypeValue["string"], "is_public": False},
+            "str1": {"type": AttrType.STRING, "is_public": True},
+            "str2": {"type": AttrType.STRING, "is_public": True},
+            "obj": {"type": AttrType.OBJECT, "is_public": True},
+            "invisible": {"type": AttrType.STRING, "is_public": False},
         }
 
         entity = Entity.objects.create(name="entity", created_user=user)
@@ -1818,7 +1812,7 @@ class ModelTest(AironeTestCase):
                 is_public=info["is_public"],
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             entity.attrs.add(attr)
@@ -1857,7 +1851,7 @@ class ModelTest(AironeTestCase):
             EntityAttr.objects.create(
                 **{
                     "name": "new_attr",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "created_user": user,
                     "parent_entity": entity,
                 }
@@ -1871,10 +1865,10 @@ class ModelTest(AironeTestCase):
 
         ref_entity = Entity.objects.create(name="Referred Entity", created_user=user)
         attr_info = {
-            "str1": {"type": AttrTypeValue["string"], "is_public": True},
-            "str2": {"type": AttrTypeValue["string"], "is_public": True},
-            "obj": {"type": AttrTypeValue["object"], "is_public": True},
-            "invisible": {"type": AttrTypeValue["string"], "is_public": False},
+            "str1": {"type": AttrType.STRING, "is_public": True},
+            "str2": {"type": AttrType.STRING, "is_public": True},
+            "obj": {"type": AttrType.OBJECT, "is_public": True},
+            "invisible": {"type": AttrType.STRING, "is_public": False},
         }
 
         entity = Entity.objects.create(name="entity", created_user=user)
@@ -1887,7 +1881,7 @@ class ModelTest(AironeTestCase):
                 is_public=info["is_public"],
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             entity.attrs.add(attr)
@@ -1925,7 +1919,7 @@ class ModelTest(AironeTestCase):
             EntityAttr.objects.create(
                 **{
                     "name": "new_attr",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "created_user": user,
                     "parent_entity": entity,
                 }
@@ -1946,31 +1940,31 @@ class ModelTest(AironeTestCase):
         ref_role = Role.objects.create(name="role")
 
         attr_info = {
-            "str": {"type": AttrTypeValue["string"], "value": "foo-%d"},
-            "str2": {"type": AttrTypeValue["string"], "value": "foo-%d"},
-            "obj": {"type": AttrTypeValue["object"], "value": str(ref_entry.id)},
+            "str": {"type": AttrType.STRING, "value": "foo-%d"},
+            "str2": {"type": AttrType.STRING, "value": "foo-%d"},
+            "obj": {"type": AttrType.OBJECT, "value": str(ref_entry.id)},
             "name": {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "value": {"name": "bar", "id": str(ref_entry.id)},
             },
-            "bool": {"type": AttrTypeValue["boolean"], "value": True},
-            "group": {"type": AttrTypeValue["group"], "value": str(ref_group.id)},
-            "date": {"type": AttrTypeValue["date"], "value": date(2018, 12, 31)},
-            "role": {"type": AttrTypeValue["role"], "value": str(ref_role.id)},
+            "bool": {"type": AttrType.BOOLEAN, "value": True},
+            "group": {"type": AttrType.GROUP, "value": str(ref_group.id)},
+            "date": {"type": AttrType.DATE, "value": date(2018, 12, 31)},
+            "role": {"type": AttrType.ROLE, "value": str(ref_role.id)},
             "arr_str": {
-                "type": AttrTypeValue["array_string"],
+                "type": AttrType.ARRAY_STRING,
                 "value": ["foo", "bar", "baz"],
             },
             "arr_obj": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "value": [str(x.id) for x in Entry.objects.filter(schema=ref_entity)],
             },
             "arr_name": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "value": [{"name": "hoge", "id": str(ref_entry.id)}],
             },
-            "arr_group": {"type": AttrTypeValue["array_group"], "value": [ref_group]},
-            "arr_role": {"type": AttrTypeValue["array_role"], "value": [ref_role]},
+            "arr_group": {"type": AttrType.ARRAY_GROUP, "value": [ref_group]},
+            "arr_role": {"type": AttrType.ARRAY_ROLE, "value": [ref_role]},
         }
 
         entity = Entity.objects.create(name="entity", created_user=user)
@@ -1982,7 +1976,7 @@ class ModelTest(AironeTestCase):
                 parent_entity=entity,
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             entity.attrs.add(attr)
@@ -2169,7 +2163,7 @@ class ModelTest(AironeTestCase):
         self.assertEqual(ret["ret_values"][0]["entry"]["name"], "e-10")
 
         def _assert_result_full(attr, result):
-            if attr.type != AttrTypeValue["boolean"]:
+            if attr.type != AttrType.BOOLEAN:
                 # confirm "entry-black" Entry, which doesn't have any substantial Attribute values,
                 # doesn't exist on the result.
                 isin_entry_blank = any(
@@ -2231,7 +2225,7 @@ class ModelTest(AironeTestCase):
                     }
                 ],
             )
-            if attr.type == AttrTypeValue["boolean"]:
+            if attr.type == AttrType.BOOLEAN:
                 self.assertEqual(result["ret_count"], 0)
             else:
                 self.assertEqual(result["ret_count"], 1)
@@ -2334,7 +2328,7 @@ class ModelTest(AironeTestCase):
             attrs=[
                 {
                     "name": "ref",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                 }
             ],
         )
@@ -2359,7 +2353,7 @@ class ModelTest(AironeTestCase):
         entity = Entity.objects.create(name="Entity", created_user=user)
         entity_attr = EntityAttr.objects.create(
             name="attr_ref",
-            type=AttrTypeValue["object"],
+            type=AttrType.OBJECT,
             created_user=user,
             parent_entity=entity,
         )
@@ -2419,8 +2413,8 @@ class ModelTest(AironeTestCase):
     def test_search_entries_with_exclusive_attrs(self):
         user = User.objects.create(username="hoge")
         entity_info = {
-            "E1": [{"type": AttrTypeValue["string"], "name": "foo"}],
-            "E2": [{"type": AttrTypeValue["string"], "name": "bar"}],
+            "E1": [{"type": AttrType.STRING, "name": "foo"}],
+            "E2": [{"type": AttrType.STRING, "name": "bar"}],
         }
 
         entity_ids = []
@@ -2512,22 +2506,22 @@ class ModelTest(AironeTestCase):
         entity = Entity.objects.create(name="Entity", created_user=self._user)
         ref_info = {
             "ref": {
-                "type": AttrTypeValue["object"],
+                "type": AttrType.OBJECT,
                 "value": ref_entries[0],
                 "expected_value": {"name": "", "id": ""},
             },
             "name": {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "value": {"name": "hoge", "id": ref_entries[1]},
                 "expected_value": {"hoge": {"name": "", "id": ""}},
             },
             "arr_ref": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "value": [ref_entries[2]],
                 "expected_value": [],
             },
             "arr_name": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "value": [{"name": "hoge", "id": ref_entries[3]}],
                 "expected_value": [],
             },
@@ -2584,7 +2578,7 @@ class ModelTest(AironeTestCase):
             attrs=[
                 {
                     "name": "ref",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                 }
             ],
             is_public=False,
@@ -2611,7 +2605,7 @@ class ModelTest(AironeTestCase):
         entity = Entity.objects.create(name="entity", created_user=user)
         attr = EntityAttr.objects.create(
             name="attr",
-            type=AttrTypeValue["string"],
+            type=AttrType.STRING,
             created_user=user,
             parent_entity=entity,
         )
@@ -2646,39 +2640,39 @@ class ModelTest(AironeTestCase):
 
         attr_info = {
             "str": {
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "value": "foo",
             },
             "obj": {
-                "type": AttrTypeValue["object"],
+                "type": AttrType.OBJECT,
                 "value": str(ref_entry1.id),
             },
             "name": {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "value": {"name": "bar", "id": str(ref_entry1.id)},
             },
             "bool": {
-                "type": AttrTypeValue["boolean"],
+                "type": AttrType.BOOLEAN,
                 "value": False,
             },
             "date": {
-                "type": AttrTypeValue["date"],
+                "type": AttrType.DATE,
                 "value": date(2018, 1, 1),
             },
             "group": {
-                "type": AttrTypeValue["group"],
+                "type": AttrType.GROUP,
                 "value": str(ref_group.id),
             },
             "arr_str": {
-                "type": AttrTypeValue["array_string"],
+                "type": AttrType.ARRAY_STRING,
                 "value": ["foo", "bar", "baz"],
             },
             "arr_obj": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "value": [str(x.id) for x in Entry.objects.filter(schema=ref_entity)],
             },
             "arr_name": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "value": [
                     {"name": "hoge", "id": str(x.id)}
                     for x in Entry.objects.filter(schema=ref_entity)
@@ -2695,7 +2689,7 @@ class ModelTest(AironeTestCase):
                 parent_entity=entity,
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             entity.attrs.add(attr)
@@ -2831,7 +2825,7 @@ class ModelTest(AironeTestCase):
         entity = Entity.objects.create(name="entity", created_user=user)
         entity_attr = EntityAttr.objects.create(
             name="attr",
-            type=AttrTypeValue["string"],
+            type=AttrType.STRING,
             created_user=user,
             parent_entity=entity,
         )
@@ -2872,7 +2866,7 @@ class ModelTest(AironeTestCase):
                 entity.attrs.add(
                     EntityAttr.objects.create(
                         name="attr-%s" % index,
-                        type=AttrTypeValue["string"],
+                        type=AttrType.STRING,
                         created_user=user,
                         parent_entity=entity,
                     )
@@ -2881,7 +2875,7 @@ class ModelTest(AironeTestCase):
             entity.attrs.add(
                 EntityAttr.objects.create(
                     name="ほげ",
-                    type=AttrTypeValue["string"],
+                    type=AttrType.STRING,
                     created_user=user,
                     parent_entity=entity,
                 )
@@ -2890,7 +2884,7 @@ class ModelTest(AironeTestCase):
             entity.attrs.add(
                 EntityAttr.objects.create(
                     name="attr-arr",
-                    type=AttrTypeValue["array_string"],
+                    type=AttrType.ARRAY_STRING,
                     created_user=user,
                     parent_entity=entity,
                 )
@@ -2899,7 +2893,7 @@ class ModelTest(AironeTestCase):
             entity.attrs.add(
                 EntityAttr.objects.create(
                     name="attr-date",
-                    type=AttrTypeValue["date"],
+                    type=AttrType.DATE,
                     created_user=user,
                     parent_entity=entity,
                 )
@@ -3033,7 +3027,7 @@ class ModelTest(AironeTestCase):
         for name in ["foo", "bar"]:
             attr = EntityAttr.objects.create(
                 name=name,
-                type=AttrTypeValue["object"],
+                type=AttrType.OBJECT,
                 created_user=user,
                 parent_entity=entity,
             )
@@ -3069,7 +3063,7 @@ class ModelTest(AironeTestCase):
                 entity.attrs.add(
                     EntityAttr.objects.create(
                         name=attrname,
-                        type=AttrTypeValue["string"],
+                        type=AttrType.STRING,
                         created_user=user,
                         parent_entity=entity,
                     )
@@ -3124,7 +3118,7 @@ class ModelTest(AironeTestCase):
         entity.attrs.add(
             EntityAttr.objects.create(
                 name="date",
-                type=AttrTypeValue["date"],
+                type=AttrType.DATE,
                 created_user=user,
                 parent_entity=entity,
             )
@@ -3189,7 +3183,7 @@ class ModelTest(AironeTestCase):
             entity.attrs.add(
                 EntityAttr.objects.create(
                     name=name,
-                    type=AttrTypeValue["string"],
+                    type=AttrType.STRING,
                     created_user=user,
                     parent_entity=entity,
                 )
@@ -3293,13 +3287,13 @@ class ModelTest(AironeTestCase):
             # test return value of get_value method with 'with_metainfo' parameter
             expected_value = {"type": attr.schema.type, "value": info["exp_val"]}
             if attr.is_array():
-                if attr.schema.type & AttrTypeValue["named"]:
+                if attr.schema.type & AttrType._NAMED:
                     expected_value["value"] = [{"hoge": {"id": test_ref.id, "name": test_ref.name}}]
-                elif attr.schema.type & AttrTypeValue["object"]:
+                elif attr.schema.type & AttrType.OBJECT:
                     expected_value["value"] = [{"id": test_ref.id, "name": test_ref.name}]
-            elif attr.schema.type & AttrTypeValue["named"]:
+            elif attr.schema.type & AttrType._NAMED:
                 expected_value["value"] = {"bar": {"id": test_ref.id, "name": test_ref.name}}
-            elif attr.schema.type & AttrTypeValue["object"]:
+            elif attr.schema.type & AttrType.OBJECT:
                 expected_value["value"] = {"id": test_ref.id, "name": test_ref.name}
 
             self.assertEqual(attrv.get_value(with_metainfo=True, is_active=False), expected_value)
@@ -3353,13 +3347,13 @@ class ModelTest(AironeTestCase):
 
             expected_value = {"type": attr.schema.type, "value": info["exp_val"]}
             if attr.is_array():
-                if attr.schema.type & AttrTypeValue["named"]:
+                if attr.schema.type & AttrType._NAMED:
                     expected_value["value"] = [{"hoge": {"id": test_ref.id, "name": test_ref.name}}]
-                elif attr.schema.type & AttrTypeValue["object"]:
+                elif attr.schema.type & AttrType.OBJECT:
                     expected_value["value"] = [{"id": test_ref.id, "name": test_ref.name}]
-            elif attr.schema.type & AttrTypeValue["named"]:
+            elif attr.schema.type & AttrType._NAMED:
                 expected_value["value"] = {"bar": {"id": test_ref.id, "name": test_ref.name}}
-            elif attr.schema.type & AttrTypeValue["object"]:
+            elif attr.schema.type & AttrType.OBJECT:
                 expected_value["value"] = {"id": test_ref.id, "name": test_ref.name}
 
             self.assertEqual(attrv.get_value(with_metainfo=True, is_active=False), expected_value)
@@ -3613,9 +3607,9 @@ class ModelTest(AironeTestCase):
 
         # initialize EntityAttrs
         attr_info = {
-            "obj": {"type": AttrTypeValue["object"], "value": ref_entries[0]},
+            "obj": {"type": AttrType.OBJECT, "value": ref_entries[0]},
             "arr_obj": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "value": ref_entries[1:],
             },
         }
@@ -3629,7 +3623,7 @@ class ModelTest(AironeTestCase):
                 parent_entity=self._entity,
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             self._entity.attrs.add(attr)
@@ -3713,76 +3707,76 @@ class ModelTest(AironeTestCase):
         # This checks all attribute values which are generated by entry.to_dict method
         ret_dict = entry.to_dict(user, with_metainfo=True)
         expected_attrinfos = [
-            {"name": "str", "value": {"type": AttrTypeValue["string"], "value": "foo"}},
-            {"name": "text", "value": {"type": AttrTypeValue["text"], "value": "bar"}},
+            {"name": "str", "value": {"type": AttrType.STRING, "value": "foo"}},
+            {"name": "text", "value": {"type": AttrType.TEXT, "value": "bar"}},
             {
                 "name": "bool",
-                "value": {"type": AttrTypeValue["boolean"], "value": False},
+                "value": {"type": AttrType.BOOLEAN, "value": False},
             },
             {
                 "name": "date",
-                "value": {"type": AttrTypeValue["date"], "value": "2018-12-31"},
+                "value": {"type": AttrType.DATE, "value": "2018-12-31"},
             },
             {
                 "name": "arr_str",
                 "value": {
-                    "type": AttrTypeValue["array_string"],
+                    "type": AttrType.ARRAY_STRING,
                     "value": ["foo", "bar", "baz"],
                 },
             },
             {
                 "name": "obj",
                 "value": {
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "value": {"id": ref_entry.id, "name": ref_entry.name},
                 },
             },
             {
                 "name": "name",
                 "value": {
-                    "type": AttrTypeValue["named_object"],
+                    "type": AttrType.NAMED_OBJECT,
                     "value": {"bar": {"id": ref_entry.id, "name": ref_entry.name}},
                 },
             },
             {
                 "name": "arr_obj",
                 "value": {
-                    "type": AttrTypeValue["array_object"],
+                    "type": AttrType.ARRAY_OBJECT,
                     "value": [{"id": ref_entry.id, "name": ref_entry.name}],
                 },
             },
             {
                 "name": "arr_name",
                 "value": {
-                    "type": AttrTypeValue["array_named_object"],
+                    "type": AttrType.ARRAY_NAMED_OBJECT,
                     "value": [{"hoge": {"id": ref_entry.id, "name": ref_entry.name}}],
                 },
             },
             {
                 "name": "group",
                 "value": {
-                    "type": AttrTypeValue["group"],
+                    "type": AttrType.GROUP,
                     "value": {"id": test_group.id, "name": test_group.name},
                 },
             },
             {
                 "name": "arr_group",
                 "value": {
-                    "type": AttrTypeValue["array_group"],
+                    "type": AttrType.ARRAY_GROUP,
                     "value": [{"id": test_group.id, "name": test_group.name}],
                 },
             },
             {
                 "name": "role",
                 "value": {
-                    "type": AttrTypeValue["role"],
+                    "type": AttrType.ROLE,
                     "value": {"id": test_role.id, "name": test_role.name},
                 },
             },
             {
                 "name": "arr_role",
                 "value": {
-                    "type": AttrTypeValue["array_role"],
+                    "type": AttrType.ARRAY_ROLE,
                     "value": [{"id": test_role.id, "name": test_role.name}],
                 },
             },
@@ -3800,76 +3794,76 @@ class ModelTest(AironeTestCase):
 
         ret_dict = entry.to_dict(user, with_metainfo=True)
         expected_attrinfos = [
-            {"name": "str", "value": {"type": AttrTypeValue["string"], "value": ""}},
-            {"name": "text", "value": {"type": AttrTypeValue["text"], "value": ""}},
+            {"name": "str", "value": {"type": AttrType.STRING, "value": ""}},
+            {"name": "text", "value": {"type": AttrType.TEXT, "value": ""}},
             {
                 "name": "bool",
-                "value": {"type": AttrTypeValue["boolean"], "value": False},
+                "value": {"type": AttrType.BOOLEAN, "value": False},
             },
             {
                 "name": "date",
-                "value": {"type": AttrTypeValue["date"], "value": None},
+                "value": {"type": AttrType.DATE, "value": None},
             },
             {
                 "name": "arr_str",
                 "value": {
-                    "type": AttrTypeValue["array_string"],
+                    "type": AttrType.ARRAY_STRING,
                     "value": [],
                 },
             },
             {
                 "name": "obj",
                 "value": {
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "value": None,
                 },
             },
             {
                 "name": "name",
                 "value": {
-                    "type": AttrTypeValue["named_object"],
+                    "type": AttrType.NAMED_OBJECT,
                     "value": {"": None},
                 },
             },
             {
                 "name": "arr_obj",
                 "value": {
-                    "type": AttrTypeValue["array_object"],
+                    "type": AttrType.ARRAY_OBJECT,
                     "value": [],
                 },
             },
             {
                 "name": "arr_name",
                 "value": {
-                    "type": AttrTypeValue["array_named_object"],
+                    "type": AttrType.ARRAY_NAMED_OBJECT,
                     "value": [],
                 },
             },
             {
                 "name": "group",
                 "value": {
-                    "type": AttrTypeValue["group"],
+                    "type": AttrType.GROUP,
                     "value": None,
                 },
             },
             {
                 "name": "arr_group",
                 "value": {
-                    "type": AttrTypeValue["array_group"],
+                    "type": AttrType.ARRAY_GROUP,
                     "value": [],
                 },
             },
             {
                 "name": "role",
                 "value": {
-                    "type": AttrTypeValue["role"],
+                    "type": AttrType.ROLE,
                     "value": None,
                 },
             },
             {
                 "name": "arr_role",
                 "value": {
-                    "type": AttrTypeValue["array_role"],
+                    "type": AttrType.ARRAY_ROLE,
                     "value": [],
                 },
             },
@@ -3898,7 +3892,7 @@ class ModelTest(AironeTestCase):
                 e.attrs.add(
                     EntityAttr.objects.create(
                         **{
-                            "type": AttrTypeValue["string"],
+                            "type": AttrType.STRING,
                             "created_user": self._user,
                             "parent_entity": self._entity,
                             "name": info["name"],
@@ -3953,26 +3947,26 @@ class ModelTest(AironeTestCase):
         ref_group = Group.objects.create(name="group")
 
         attr_info = {
-            "str": {"type": AttrTypeValue["string"], "value": "foo-%d"},
-            "str2": {"type": AttrTypeValue["string"], "value": "foo-%d"},
-            "obj": {"type": AttrTypeValue["object"], "value": str(ref_entry.id)},
+            "str": {"type": AttrType.STRING, "value": "foo-%d"},
+            "str2": {"type": AttrType.STRING, "value": "foo-%d"},
+            "obj": {"type": AttrType.OBJECT, "value": str(ref_entry.id)},
             "name": {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "value": {"name": "bar", "id": str(ref_entry.id)},
             },
-            "bool": {"type": AttrTypeValue["boolean"], "value": False},
-            "group": {"type": AttrTypeValue["group"], "value": str(ref_group.id)},
-            "date": {"type": AttrTypeValue["date"], "value": date(2018, 12, 31)},
+            "bool": {"type": AttrType.BOOLEAN, "value": False},
+            "group": {"type": AttrType.GROUP, "value": str(ref_group.id)},
+            "date": {"type": AttrType.DATE, "value": date(2018, 12, 31)},
             "arr_str": {
-                "type": AttrTypeValue["array_string"],
+                "type": AttrType.ARRAY_STRING,
                 "value": ["foo", "bar", "baz"],
             },
             "arr_obj": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "value": [str(x.id) for x in Entry.objects.filter(schema=ref_entity)],
             },
             "arr_name": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "value": [{"name": "hoge", "id": str(ref_entry.id)}],
             },
         }
@@ -3986,7 +3980,7 @@ class ModelTest(AironeTestCase):
                 parent_entity=entity,
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             entity.attrs.add(attr)
@@ -4025,31 +4019,31 @@ class ModelTest(AironeTestCase):
         # search entries with back slash
         attr_info = {
             "str": {
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "value": CONFIG.EMPTY_SEARCH_CHARACTER,
             },
             "str2": {
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "value": CONFIG.EMPTY_SEARCH_CHARACTER,
             },
-            "obj": {"type": AttrTypeValue["object"], "value": str(ref_entry.id)},
+            "obj": {"type": AttrType.OBJECT, "value": str(ref_entry.id)},
             "name": {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "value": {"name": "bar", "id": str(ref_entry.id)},
             },
-            "bool": {"type": AttrTypeValue["boolean"], "value": False},
-            "group": {"type": AttrTypeValue["group"], "value": str(ref_group.id)},
-            "date": {"type": AttrTypeValue["date"], "value": date(2018, 12, 31)},
+            "bool": {"type": AttrType.BOOLEAN, "value": False},
+            "group": {"type": AttrType.GROUP, "value": str(ref_group.id)},
+            "date": {"type": AttrType.DATE, "value": date(2018, 12, 31)},
             "arr_str": {
-                "type": AttrTypeValue["array_string"],
+                "type": AttrType.ARRAY_STRING,
                 "value": [CONFIG.EMPTY_SEARCH_CHARACTER],
             },
             "arr_obj": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "value": [str(x.id) for x in Entry.objects.filter(schema=ref_entity)],
             },
             "arr_name": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "value": [{"name": "hoge", "id": str(ref_entry.id)}],
             },
         }
@@ -4112,30 +4106,30 @@ class ModelTest(AironeTestCase):
         """
         attr_info.append(
             {
-                "str1": {"type": AttrTypeValue["string"], "value": "foo"},
-                "str2": {"type": AttrTypeValue["string"], "value": ""},
-                "str3": {"type": AttrTypeValue["string"], "value": ""},
-                "arr_str": {"type": AttrTypeValue["array_string"], "value": ["hoge"]},
+                "str1": {"type": AttrType.STRING, "value": "foo"},
+                "str2": {"type": AttrType.STRING, "value": ""},
+                "str3": {"type": AttrType.STRING, "value": ""},
+                "arr_str": {"type": AttrType.ARRAY_STRING, "value": ["hoge"]},
             }
         )
         attr_info.append(
             {
-                "str1": {"type": AttrTypeValue["string"], "value": "foo"},
-                "str2": {"type": AttrTypeValue["string"], "value": "bar"},
-                "str3": {"type": AttrTypeValue["string"], "value": ""},
+                "str1": {"type": AttrType.STRING, "value": "foo"},
+                "str2": {"type": AttrType.STRING, "value": "bar"},
+                "str3": {"type": AttrType.STRING, "value": ""},
                 "arr_str": {
-                    "type": AttrTypeValue["array_string"],
+                    "type": AttrType.ARRAY_STRING,
                     "value": ["hoge", "fuga"],
                 },
             }
         )
         attr_info.append(
             {
-                "str1": {"type": AttrTypeValue["string"], "value": "foo"},
-                "str2": {"type": AttrTypeValue["string"], "value": "bar"},
-                "str3": {"type": AttrTypeValue["string"], "value": "baz"},
+                "str1": {"type": AttrType.STRING, "value": "foo"},
+                "str2": {"type": AttrType.STRING, "value": "bar"},
+                "str3": {"type": AttrType.STRING, "value": "baz"},
                 "arr_str": {
-                    "type": AttrTypeValue["array_string"],
+                    "type": AttrType.ARRAY_STRING,
                     "value": ["hoge", "fuga", "piyo"],
                 },
             }
@@ -4422,7 +4416,7 @@ class ModelTest(AironeTestCase):
                 [
                     {
                         "name": "test",
-                        "type": AttrTypeValue["string"],
+                        "type": AttrType.STRING,
                     }
                 ],
             )
@@ -4667,57 +4661,57 @@ class ModelTest(AironeTestCase):
                 "entry": {"id": entry.id, "name": "entry"},
                 "is_readable": True,
                 "attrs": {
-                    "bool": {"is_readable": True, "type": AttrTypeValue["boolean"], "value": False},
+                    "bool": {"is_readable": True, "type": AttrType.BOOLEAN, "value": False},
                     "date": {
                         "is_readable": True,
-                        "type": AttrTypeValue["date"],
+                        "type": AttrType.DATE,
                         "value": None,
                     },
                     "group": {
                         "is_readable": True,
-                        "type": AttrTypeValue["group"],
+                        "type": AttrType.GROUP,
                         "value": {"id": "", "name": ""},
                     },
                     "role": {
                         "is_readable": True,
-                        "type": AttrTypeValue["role"],
+                        "type": AttrType.ROLE,
                         "value": {"id": "", "name": ""},
                     },
                     "name": {
                         "is_readable": True,
-                        "type": AttrTypeValue["named_object"],
+                        "type": AttrType.NAMED_OBJECT,
                         "value": {"": {"id": "", "name": ""}},
                     },
                     "obj": {
                         "is_readable": True,
-                        "type": AttrTypeValue["object"],
+                        "type": AttrType.OBJECT,
                         "value": {"id": "", "name": ""},
                     },
-                    "str": {"is_readable": True, "type": AttrTypeValue["string"], "value": ""},
-                    "text": {"is_readable": True, "type": AttrTypeValue["text"], "value": ""},
+                    "str": {"is_readable": True, "type": AttrType.STRING, "value": ""},
+                    "text": {"is_readable": True, "type": AttrType.TEXT, "value": ""},
                     "arr_str": {
                         "is_readable": True,
-                        "type": AttrTypeValue["array_string"],
+                        "type": AttrType.ARRAY_STRING,
                         "value": [],
                     },
                     "arr_obj": {
                         "is_readable": True,
-                        "type": AttrTypeValue["array_object"],
+                        "type": AttrType.ARRAY_OBJECT,
                         "value": [],
                     },
                     "arr_name": {
                         "is_readable": True,
-                        "type": AttrTypeValue["array_named_object"],
+                        "type": AttrType.ARRAY_NAMED_OBJECT,
                         "value": [],
                     },
                     "arr_group": {
                         "is_readable": True,
-                        "type": AttrTypeValue["array_group"],
+                        "type": AttrType.ARRAY_GROUP,
                         "value": [],
                     },
                     "arr_role": {
                         "is_readable": True,
-                        "type": AttrTypeValue["array_role"],
+                        "type": AttrType.ARRAY_ROLE,
                         "value": [],
                     },
                 },
@@ -4750,7 +4744,7 @@ class ModelTest(AironeTestCase):
         ref_attr = EntityAttr.objects.create(
             **{
                 "name": "ref",
-                "type": AttrTypeValue["object"],
+                "type": AttrType.OBJECT,
                 "created_user": self._user,
                 "parent_entity": ref_entity,
             }
@@ -4807,7 +4801,7 @@ class ModelTest(AironeTestCase):
         ref_attr2 = EntityAttr.objects.create(
             **{
                 "name": "ref_array_named_object",
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "created_user": self._user,
                 "parent_entity": ref_entity2,
             }
@@ -4882,7 +4876,7 @@ class ModelTest(AironeTestCase):
             entity.attrs.add(
                 EntityAttr.objects.create(
                     name=attrname,
-                    type=AttrTypeValue["string"],
+                    type=AttrType.STRING,
                     created_user=user,
                     parent_entity=entity,
                 )
@@ -4916,7 +4910,7 @@ class ModelTest(AironeTestCase):
         entity = self.create_entity(
             self._user,
             "Test Entity",
-            attrs=[{"name": "attr", "type": AttrTypeValue["string"]}],
+            attrs=[{"name": "attr", "type": AttrType.STRING}],
         )
         entry = self.add_entry(
             self._user, "Test Entry", entity, is_public=False, values={"attr": "value"}
@@ -4942,7 +4936,7 @@ class ModelTest(AironeTestCase):
         entity = Entity.objects.create(name="entity", created_user=user1)
         entity_attr = EntityAttr.objects.create(
             name="attr",
-            type=AttrTypeValue["string"],
+            type=AttrType.STRING,
             created_user=user1,
             parent_entity=entity,
             is_public=False,
@@ -5124,71 +5118,71 @@ class ModelTest(AironeTestCase):
                 )
 
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["object"], self._entry.id, False),
+            AttributeValue.validate_attr_value(AttrType.OBJECT, self._entry.id, False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["object"], None, False),
+            AttributeValue.validate_attr_value(AttrType.OBJECT, None, False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["object"], "", False),
+            AttributeValue.validate_attr_value(AttrType.OBJECT, "", False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["object"], "hoge", False),
+            AttributeValue.validate_attr_value(AttrType.OBJECT, "hoge", False),
             (False, "value(hoge) is not int"),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["object"], 9999, False),
+            AttributeValue.validate_attr_value(AttrType.OBJECT, 9999, False),
             (False, "value(9999) is not entry id"),
         )
 
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"name": "hoge", "id": self._entry.id}, False
+                AttrType.NAMED_OBJECT, {"name": "hoge", "id": self._entry.id}, False
             ),
             (True, None),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"name": "", "id": self._entry.id}, False
+                AttrType.NAMED_OBJECT, {"name": "", "id": self._entry.id}, False
             ),
             (True, None),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"name": "hoge", "id": ""}, False
+                AttrType.NAMED_OBJECT, {"name": "hoge", "id": ""}, False
             ),
             (True, None),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"name": "hoge", "id": None}, False
+                AttrType.NAMED_OBJECT, {"name": "hoge", "id": None}, False
             ),
             (True, None),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"name": "", "id": ""}, False
+                AttrType.NAMED_OBJECT, {"name": "", "id": ""}, False
             ),
             (True, None),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"name": "", "id": None}, False
+                AttrType.NAMED_OBJECT, {"name": "", "id": None}, False
             ),
             (True, None),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"name": ["hoge"], "id": self._entry.id}, False
+                AttrType.NAMED_OBJECT, {"name": ["hoge"], "id": self._entry.id}, False
             ),
             (False, "value(['hoge']) is not str"),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"],
+                AttrType.NAMED_OBJECT,
                 {"name": "a" * AttributeValue.MAXIMUM_VALUE_SIZE, "id": self._entry.id},
                 False,
             ),
@@ -5196,156 +5190,146 @@ class ModelTest(AironeTestCase):
         )
         with self.assertRaises(ExceedLimitError):
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"],
+                AttrType.NAMED_OBJECT,
                 {"name": "a" * (AttributeValue.MAXIMUM_VALUE_SIZE + 1), "id": self._entry.id},
                 False,
             )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"name": "hoge", "id": "hoge"}, False
+                AttrType.NAMED_OBJECT, {"name": "hoge", "id": "hoge"}, False
             ),
             (False, "value(hoge) is not int"),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"name": "hoge", "id": 9999}, False
+                AttrType.NAMED_OBJECT, {"name": "hoge", "id": 9999}, False
             ),
             (False, "value(9999) is not entry id"),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["named_object"], "hoge", False),
+            AttributeValue.validate_attr_value(AttrType.NAMED_OBJECT, "hoge", False),
             (False, "value(hoge) is not dict"),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"a": 1, "b": 2}, False
-            ),
+            AttributeValue.validate_attr_value(AttrType.NAMED_OBJECT, {"a": 1, "b": 2}, False),
             (False, "value({'a': 1, 'b': 2}) is not key('name', 'id')"),
         )
 
         group: Group = Group.objects.create(name="group0")
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["group"], group.id, False),
+            AttributeValue.validate_attr_value(AttrType.GROUP, group.id, False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["group"], None, False),
+            AttributeValue.validate_attr_value(AttrType.GROUP, None, False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["group"], "", False),
+            AttributeValue.validate_attr_value(AttrType.GROUP, "", False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["group"], "hoge", False),
+            AttributeValue.validate_attr_value(AttrType.GROUP, "hoge", False),
             (False, "value(hoge) is not int"),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["group"], 9999, False),
+            AttributeValue.validate_attr_value(AttrType.GROUP, 9999, False),
             (False, "value(9999) is not group id"),
         )
 
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["boolean"], True, False), (True, None)
+            AttributeValue.validate_attr_value(AttrType.BOOLEAN, True, False), (True, None)
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["boolean"], False, False), (True, None)
+            AttributeValue.validate_attr_value(AttrType.BOOLEAN, False, False), (True, None)
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["boolean"], "hoge", False),
+            AttributeValue.validate_attr_value(AttrType.BOOLEAN, "hoge", False),
             (False, "value(hoge) is not bool"),
         )
 
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["date"], "2020-01-01", False),
+            AttributeValue.validate_attr_value(AttrType.DATE, "2020-01-01", False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["date"], "", False),
+            AttributeValue.validate_attr_value(AttrType.DATE, "", False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["date"], "01-01", False),
+            AttributeValue.validate_attr_value(AttrType.DATE, "01-01", False),
             (False, "value(01-01) is not format(YYYY-MM-DD)"),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["date"], "hoge", False),
+            AttributeValue.validate_attr_value(AttrType.DATE, "hoge", False),
             (False, "value(hoge) is not format(YYYY-MM-DD)"),
         )
 
         self.assertEqual(
-            AttributeValue.validate_attr_value(
-                AttrTypeValue["array_string"], ["hoge", "fuga"], False
-            ),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_STRING, ["hoge", "fuga"], False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_string"], [], False),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_STRING, [], False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_string"], ["hoge", ""], False),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_STRING, ["hoge", ""], False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_string"], "hoge", False),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_STRING, "hoge", False),
             (False, "value(hoge) is not list"),
         )
 
         self.assertEqual(
-            AttributeValue.validate_attr_value(
-                AttrTypeValue["array_object"], [self._entry.id], False
-            ),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_OBJECT, [self._entry.id], False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_object"], [], False),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_OBJECT, [], False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(
-                AttrTypeValue["array_object"], [self._entry.id, ""], False
-            ),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_OBJECT, [self._entry.id, ""], False),
             (True, None),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["array_object"], [self._entry.id, None], False
+                AttrType.ARRAY_OBJECT, [self._entry.id, None], False
             ),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(
-                AttrTypeValue["array_object"], self._entry.id, False
-            ),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_OBJECT, self._entry.id, False),
             (False, "value(%s) is not list" % self._entry.id),
         )
 
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["array_named_object"], [{"name": "hoge", "id": self._entry.id}], False
+                AttrType.ARRAY_NAMED_OBJECT, [{"name": "hoge", "id": self._entry.id}], False
             ),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_named_object"], [], False),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_NAMED_OBJECT, [], False),
             (True, None),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["array_named_object"], [{"name": "", "id": ""}], False
-            ),
-            (True, None),
-        )
-        self.assertEqual(
-            AttributeValue.validate_attr_value(
-                AttrTypeValue["array_named_object"], [{"name": "", "id": None}], False
+                AttrType.ARRAY_NAMED_OBJECT, [{"name": "", "id": ""}], False
             ),
             (True, None),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["array_named_object"],
+                AttrType.ARRAY_NAMED_OBJECT, [{"name": "", "id": None}], False
+            ),
+            (True, None),
+        )
+        self.assertEqual(
+            AttributeValue.validate_attr_value(
+                AttrType.ARRAY_NAMED_OBJECT,
                 [{"name": "hoge", "id": self._entry.id}, {"name": "", "id": ""}],
                 False,
             ),
@@ -5353,7 +5337,7 @@ class ModelTest(AironeTestCase):
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["array_named_object"],
+                AttrType.ARRAY_NAMED_OBJECT,
                 [{"name": "hoge", "id": self._entry.id}, {"name": "", "id": None}],
                 False,
             ),
@@ -5361,31 +5345,29 @@ class ModelTest(AironeTestCase):
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["array_named_object"], {"name": "hoge", "id": self._entry.id}, False
+                AttrType.ARRAY_NAMED_OBJECT, {"name": "hoge", "id": self._entry.id}, False
             ),
             (False, "value({'name': 'hoge', 'id': %s}) is not list" % self._entry.id),
         )
 
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_group"], [group.id], False),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_GROUP, [group.id], False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_group"], [], False),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_GROUP, [], False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_group"], [group.id, ""], False),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_GROUP, [group.id, ""], False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(
-                AttrTypeValue["array_group"], [group.id, None], False
-            ),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_GROUP, [group.id, None], False),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_group"], group.id, False),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_GROUP, group.id, False),
             (False, "value(%s) is not list" % group.id),
         )
 
@@ -5397,112 +5379,106 @@ class ModelTest(AironeTestCase):
             )
 
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["object"], None, True),
+            AttributeValue.validate_attr_value(AttrType.OBJECT, None, True),
             (False, "mandatory attrs value is not specified"),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["object"], "", True),
+            AttributeValue.validate_attr_value(AttrType.OBJECT, "", True),
             (False, "mandatory attrs value is not specified"),
         )
 
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"name": "", "id": self._entry.id}, True
+                AttrType.NAMED_OBJECT, {"name": "", "id": self._entry.id}, True
             ),
             (True, None),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"name": "hoge", "id": ""}, True
+                AttrType.NAMED_OBJECT, {"name": "hoge", "id": ""}, True
             ),
             (True, None),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"name": "hoge", "id": None}, True
+                AttrType.NAMED_OBJECT, {"name": "hoge", "id": None}, True
             ),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"name": "", "id": ""}, True
-            ),
+            AttributeValue.validate_attr_value(AttrType.NAMED_OBJECT, {"name": "", "id": ""}, True),
             (False, "mandatory attrs value is not specified"),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["named_object"], {"name": "", "id": None}, True
+                AttrType.NAMED_OBJECT, {"name": "", "id": None}, True
             ),
             (False, "mandatory attrs value is not specified"),
         )
 
         group: Group = Group.objects.create(name="group0")
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["group"], None, True),
+            AttributeValue.validate_attr_value(AttrType.GROUP, None, True),
             (False, "mandatory attrs value is not specified"),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["group"], "", True),
-            (False, "mandatory attrs value is not specified"),
-        )
-
-        self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["boolean"], True, True), (True, None)
-        )
-        self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["boolean"], False, True), (True, None)
-        )
-
-        self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["date"], "", True),
+            AttributeValue.validate_attr_value(AttrType.GROUP, "", True),
             (False, "mandatory attrs value is not specified"),
         )
 
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_string"], [], True),
+            AttributeValue.validate_attr_value(AttrType.BOOLEAN, True, True), (True, None)
+        )
+        self.assertEqual(
+            AttributeValue.validate_attr_value(AttrType.BOOLEAN, False, True), (True, None)
+        )
+
+        self.assertEqual(
+            AttributeValue.validate_attr_value(AttrType.DATE, "", True),
+            (False, "mandatory attrs value is not specified"),
+        )
+
+        self.assertEqual(
+            AttributeValue.validate_attr_value(AttrType.ARRAY_STRING, [], True),
             (False, "mandatory attrs value is not specified"),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_string"], ["hoge", ""], True),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_STRING, ["hoge", ""], True),
             (True, None),
         )
 
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_object"], [], True),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_OBJECT, [], True),
             (False, "mandatory attrs value is not specified"),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(
-                AttrTypeValue["array_object"], [self._entry.id, ""], True
-            ),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_OBJECT, [self._entry.id, ""], True),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(
-                AttrTypeValue["array_object"], [self._entry.id, None], True
-            ),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_OBJECT, [self._entry.id, None], True),
             (True, None),
         )
 
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_named_object"], [], True),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_NAMED_OBJECT, [], True),
             (False, "mandatory attrs value is not specified"),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["array_named_object"], [{"name": "", "id": ""}], True
+                AttrType.ARRAY_NAMED_OBJECT, [{"name": "", "id": ""}], True
             ),
             (False, "mandatory attrs value is not specified"),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["array_named_object"], [{"name": "", "id": None}], True
+                AttrType.ARRAY_NAMED_OBJECT, [{"name": "", "id": None}], True
             ),
             (False, "mandatory attrs value is not specified"),
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["array_named_object"],
+                AttrType.ARRAY_NAMED_OBJECT,
                 [{"name": "hoge", "id": self._entry.id}, {"name": "", "id": ""}],
                 True,
             ),
@@ -5510,7 +5486,7 @@ class ModelTest(AironeTestCase):
         )
         self.assertEqual(
             AttributeValue.validate_attr_value(
-                AttrTypeValue["array_named_object"],
+                AttrType.ARRAY_NAMED_OBJECT,
                 [{"name": "hoge", "id": self._entry.id}, {"name": "", "id": None}],
                 True,
             ),
@@ -5518,17 +5494,15 @@ class ModelTest(AironeTestCase):
         )
 
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_group"], [], True),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_GROUP, [], True),
             (False, "mandatory attrs value is not specified"),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(AttrTypeValue["array_group"], [group.id, ""], True),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_GROUP, [group.id, ""], True),
             (True, None),
         )
         self.assertEqual(
-            AttributeValue.validate_attr_value(
-                AttrTypeValue["array_group"], [group.id, None], True
-            ),
+            AttributeValue.validate_attr_value(AttrType.ARRAY_GROUP, [group.id, None], True),
             (True, None),
         )
 
@@ -5545,9 +5519,9 @@ class ModelTest(AironeTestCase):
 
         # initialize EntityAttrs
         attr_info = {
-            "obj": {"type": AttrTypeValue["object"], "value": ref_entries[0]},
+            "obj": {"type": AttrType.OBJECT, "value": ref_entries[0]},
             "arr_obj": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "value": ref_entries[1:],
             },
         }
@@ -5561,7 +5535,7 @@ class ModelTest(AironeTestCase):
                 parent_entity=self._entity,
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             self._entity.attrs.add(attr)
@@ -5602,16 +5576,16 @@ class ModelTest(AironeTestCase):
 
         # initialize EntityAttrs
         attr_info = {
-            "obj": {"type": AttrTypeValue["object"], "value": ref_entries[0]},
+            "obj": {"type": AttrType.OBJECT, "value": ref_entries[0]},
             "arr_obj": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "value": ref_entries[1:],
             },
         }
         attr_info_2 = {
-            "obj": {"type": AttrTypeValue["object"], "value": ref_entries_2[0]},
+            "obj": {"type": AttrType.OBJECT, "value": ref_entries_2[0]},
             "arr_obj": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "value": ref_entries_2[1:],
             },
         }
@@ -5625,7 +5599,7 @@ class ModelTest(AironeTestCase):
                 parent_entity=self._entity,
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             self._entity.attrs.add(attr)
@@ -5640,7 +5614,7 @@ class ModelTest(AironeTestCase):
                 parent_entity=ref_entity,
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity_2)
 
             ref_entity.attrs.add(attr)
@@ -5685,7 +5659,7 @@ class ModelTest(AironeTestCase):
 
         # initialize EntityAttrs
         attr_info = {
-            "obj": {"type": AttrTypeValue["object"], "value": ref_entry},
+            "obj": {"type": AttrType.OBJECT, "value": ref_entry},
         }
         for attr_name, info in attr_info.items():
             # create EntityAttr object with is_delete_in_chain object
@@ -5697,7 +5671,7 @@ class ModelTest(AironeTestCase):
                 parent_entity=self._entity,
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             self._entity.attrs.add(attr)
@@ -5786,7 +5760,7 @@ class ModelTest(AironeTestCase):
         entity = self.create_entity(
             user,
             "Entity",
-            attrs=[{"name": "attr", "type": AttrTypeValue["object"], "ref": ref_entity}],
+            attrs=[{"name": "attr", "type": AttrType.OBJECT, "ref": ref_entity}],
         )
         entry = self.add_entry(user, "entry", entity, values={"attr": e0})
         attr = entry.attrs.get(schema__name="attr", is_active=True)
@@ -5815,7 +5789,7 @@ class ModelTest(AironeTestCase):
         entity = self.create_entity(
             user,
             "Entity",
-            attrs=[{"name": "attr", "type": AttrTypeValue["array_object"], "ref": ref_entity}],
+            attrs=[{"name": "attr", "type": AttrType.ARRAY_OBJECT, "ref": ref_entity}],
         )
         entry = self.add_entry(user, "entry", entity, values={"attr": [e0, e1]})
         attr = entry.attrs.get(schema__name="attr", is_active=True)
@@ -5838,7 +5812,7 @@ class ModelTest(AironeTestCase):
         entity = self.create_entity(
             self._user,
             "Test Another Entity",
-            attrs=[{"name": "attr", "type": AttrTypeValue["string"]}],
+            attrs=[{"name": "attr", "type": AttrType.STRING}],
         )
         entry = self.add_entry(
             self._user, "Test Entry", entity, is_public=False, values={"attr": "value"}
@@ -5862,7 +5836,7 @@ class ModelTest(AironeTestCase):
 
     def test_get_preview_next_value(self):
         # case not array
-        attr = self.make_attr("test", AttrTypeValue["string"])
+        attr = self.make_attr("test", AttrType.STRING)
         attrv1 = attr.add_value(self._user, "hoge1")
         attrv2 = attr.add_value(self._user, "hoge2")
         attrv3 = attr.add_value(self._user, "hoge3")
@@ -5877,7 +5851,7 @@ class ModelTest(AironeTestCase):
         self.assertIsNone(attrv3.get_next_value())
 
         # case array
-        array_attr = self.make_attr("array", AttrTypeValue["array_string"])
+        array_attr = self.make_attr("array", AttrType.ARRAY_STRING)
         array_attrv1 = array_attr.add_value(self._user, ["hoge1", "fuga1"])
         array_attrv2 = array_attr.add_value(self._user, ["hoge2", "fuga2"])
         array_attrv3 = array_attr.add_value(self._user, ["hoge3", "fuga3"])

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -16,6 +16,7 @@ from airone.lib.acl import ACLType
 from airone.lib.log import Logger
 from airone.lib.test import AironeViewTest, DisableStderr
 from airone.lib.types import (
+    AttrType,
     AttrTypeArrNamedObj,
     AttrTypeArrObj,
     AttrTypeArrStr,
@@ -23,7 +24,6 @@ from airone.lib.types import (
     AttrTypeObj,
     AttrTypeStr,
     AttrTypeText,
-    AttrTypeValue,
 )
 from entity.models import Entity, EntityAttr
 from entry import tasks
@@ -387,7 +387,7 @@ class ViewTest(AironeViewTest):
         new_attr = EntityAttr.objects.create(
             name="new_attr",
             created_user=user,
-            type=AttrTypeValue["string"],
+            type=AttrType.STRING,
             parent_entity=self._entity,
             is_mandatory=False,
         )
@@ -813,7 +813,7 @@ class ViewTest(AironeViewTest):
             entity.attrs.add(
                 EntityAttr.objects.create(
                     name=attr_name,
-                    type=AttrTypeValue["string"],
+                    type=AttrType.STRING,
                     created_user=user,
                     parent_entity=entity,
                 )
@@ -1096,9 +1096,7 @@ class ViewTest(AironeViewTest):
         entity = self.create_entity(
             user,
             "Entity",
-            attrs=[
-                {"name": "attr", "type": AttrTypeValue["array_named_object"], "ref": ref_entity}
-            ],
+            attrs=[{"name": "attr", "type": AttrType.ARRAY_NAMED_OBJECT, "ref": ref_entity}],
         )
         entry = self.add_entry(
             user,
@@ -1372,7 +1370,7 @@ class ViewTest(AironeViewTest):
                 EntityAttr.objects.create(
                     **{
                         "name": name,
-                        "type": AttrTypeValue["string"],
+                        "type": AttrType.STRING,
                         "created_user": user,
                         "parent_entity": entity,
                     }
@@ -1424,7 +1422,7 @@ class ViewTest(AironeViewTest):
             EntityAttr.objects.create(
                 **{
                     "name": "new_attr",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "created_user": user,
                     "parent_entity": entity,
                     "is_public": False,
@@ -1530,7 +1528,7 @@ class ViewTest(AironeViewTest):
 
             test_val = None
 
-            if case[0].TYPE & AttrTypeValue["array"] == 0:
+            if case[0].TYPE & AttrType._ARRAY == 0:
                 if case[0] == AttrTypeStr:
                     test_val = AttributeValue.create(user=user, attr=test_attr, value=case[1])
                 elif case[0] == AttrTypeObj:
@@ -1892,8 +1890,8 @@ class ViewTest(AironeViewTest):
             user,
             "Entity",
             attrs=[
-                {"name": "Role", "type": AttrTypeValue["role"]},
-                {"name": "RoleArray", "type": AttrTypeValue["array_role"]},
+                {"name": "Role", "type": AttrType.ROLE},
+                {"name": "RoleArray", "type": AttrType.ARRAY_ROLE},
             ],
         )
 
@@ -1946,8 +1944,8 @@ class ViewTest(AironeViewTest):
             user,
             "Personal Information",
             attrs=[
-                {"name": "address", "type": AttrTypeValue["named_object"], "ref": entity_pref},
-                {"name": "age", "type": AttrTypeValue["string"]},
+                {"name": "address", "type": AttrType.NAMED_OBJECT, "ref": entity_pref},
+                {"name": "age", "type": AttrType.STRING},
             ],
         )
 
@@ -1984,7 +1982,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "id": str(entity.attrs.get(name="address").id),
-                    "type": str(AttrTypeValue["string"]),
+                    "type": str(AttrType.STRING),
                     "value": [{"data": "", "index": 0}],
                     "referral_key": [{"data": "unknown", "index": 0}],
                 }
@@ -2018,8 +2016,8 @@ class ViewTest(AironeViewTest):
             user,
             "Entity",
             attrs=[
-                {"name": "Role", "type": AttrTypeValue["role"]},
-                {"name": "RoleArray", "type": AttrTypeValue["array_role"]},
+                {"name": "Role", "type": AttrType.ROLE},
+                {"name": "RoleArray", "type": AttrType.ARRAY_ROLE},
             ],
         )
         entry = self.add_entry(user, "TestEntry", entity)
@@ -2070,8 +2068,8 @@ class ViewTest(AironeViewTest):
             user,
             "Personal Information",
             attrs=[
-                {"name": "address", "type": AttrTypeValue["named_object"], "ref": entity_pref},
-                {"name": "age", "type": AttrTypeValue["string"]},
+                {"name": "address", "type": AttrType.NAMED_OBJECT, "ref": entity_pref},
+                {"name": "age", "type": AttrType.STRING},
             ],
         )
         entry = self.add_entry(user, "Jhon Doe", entity)
@@ -2145,7 +2143,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "id": str(self._entity_attr.id),
-                    "type": str(AttrTypeValue["string"]),
+                    "type": str(AttrType.STRING),
                     "value": [{"data": "A" * AttributeValue.MAXIMUM_VALUE_SIZE, "index": 0}],
                     "referral_key": [],
                 }
@@ -2181,7 +2179,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(attr.id),
-                    "type": str(AttrTypeValue["string"]),
+                    "type": str(AttrType.STRING),
                     "value": [{"data": "A" * AttributeValue.MAXIMUM_VALUE_SIZE, "index": 0}],
                     "referral_key": [],
                 }
@@ -2209,7 +2207,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "id": str(self._entity_attr.id),
-                    "type": str(AttrTypeValue["string"]),
+                    "type": str(AttrType.STRING),
                     "value": {
                         "data": ["A" * AttributeValue.MAXIMUM_VALUE_SIZE + "A"],
                         "index": 0,
@@ -2240,7 +2238,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(attr.id),
-                    "type": str(AttrTypeValue["string"]),
+                    "type": str(AttrType.STRING),
                     "value": [
                         {
                             "data": "A" * AttributeValue.MAXIMUM_VALUE_SIZE + "A",
@@ -2476,7 +2474,7 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.create(name="entity", created_user=admin)
         entity_attr = EntityAttr.objects.create(
             name="attr_bool",
-            type=AttrTypeValue["boolean"],
+            type=AttrType.BOOLEAN,
             parent_entity=entity,
             created_user=admin,
         )
@@ -2488,7 +2486,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "id": str(entity_attr.id),
-                    "type": str(AttrTypeValue["boolean"]),
+                    "type": str(AttrType.BOOLEAN),
                     "value": [{"data": True, "index": 0}],
                     "referral_key": [],
                 },
@@ -2516,7 +2514,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(entry.attrs.get(name="attr_bool").id),
-                    "type": str(AttrTypeValue["boolean"]),
+                    "type": str(AttrType.BOOLEAN),
                     "value": [{"data": False, "index": 0}],
                     "referral_key": [],
                 },
@@ -2628,14 +2626,14 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.create(name="entity", created_user=user)
         entity_attr_ref = EntityAttr.objects.create(
             name="ref",
-            type=AttrTypeValue["object"],
+            type=AttrType.OBJECT,
             parent_entity=entity,
             created_user=user,
         )
         entity.attrs.add(entity_attr_ref)
         entity_attr_arr_ref = EntityAttr.objects.create(
             name="arr_ref",
-            type=AttrTypeValue["array_object"],
+            type=AttrType.ARRAY_OBJECT,
             parent_entity=entity,
             created_user=user,
         )
@@ -2649,7 +2647,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "id": str(entity_attr_ref.id),
-                    "type": str(AttrTypeValue["object"]),
+                    "type": str(AttrType.OBJECT),
                     "value": [
                         {"data": str(ref_entry1.id), "index": 0},
                     ],
@@ -2657,7 +2655,7 @@ class ViewTest(AironeViewTest):
                 },
                 {
                     "id": str(entity_attr_arr_ref.id),
-                    "type": str(AttrTypeValue["array_object"]),
+                    "type": str(AttrType.ARRAY_OBJECT),
                     "value": [
                         {"data": str(ref_entry1.id), "index": 0},
                         {"data": str(ref_entry2.id), "index": 1},
@@ -2690,14 +2688,14 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(entry.attrs.get(name="ref").id),
-                    "type": str(AttrTypeValue["object"]),
+                    "type": str(AttrType.OBJECT),
                     "value": [],
                     "referral_key": [],
                 },
                 {
                     "entity_attr_id": "",
                     "id": str(entry.attrs.get(name="arr_ref").id),
-                    "type": str(AttrTypeValue["array_object"]),
+                    "type": str(AttrType.ARRAY_OBJECT),
                     "value": [],
                     "referral_key": [],
                 },
@@ -2722,7 +2720,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(entry.attrs.get(name="ref").id),
-                    "type": str(AttrTypeValue["object"]),
+                    "type": str(AttrType.OBJECT),
                     "value": [
                         {"data": str(ref_entry2.id), "index": 0},
                     ],
@@ -2731,7 +2729,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(entry.attrs.get(name="arr_ref").id),
-                    "type": str(AttrTypeValue["array_object"]),
+                    "type": str(AttrType.ARRAY_OBJECT),
                     "value": [
                         {"data": str(ref_entry2.id), "index": 0},
                         {"data": str(ref_entry3.id), "index": 1},
@@ -2795,7 +2793,7 @@ class ViewTest(AironeViewTest):
                 "attrs": [
                     {
                         "id": str(entity.attrs.get(name="ref").id),
-                        "type": str(AttrTypeValue["object"]),
+                        "type": str(AttrType.OBJECT),
                         "value": [
                             {"data": req["value"], "index": 0},
                         ],
@@ -2803,7 +2801,7 @@ class ViewTest(AironeViewTest):
                     },
                     {
                         "id": str(entity.attrs.get(name="arr_ref").id),
-                        "type": str(AttrTypeValue["array_object"]),
+                        "type": str(AttrType.ARRAY_OBJECT),
                         "value": [
                             {"data": req["value"], "index": 0},
                         ],
@@ -2843,7 +2841,7 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.create(name="entity", created_user=user)
         new_attr_params = {
             "name": "named_ref",
-            "type": AttrTypeValue["named_object"],
+            "type": AttrType.NAMED_OBJECT,
             "created_user": user,
             "parent_entity": entity,
         }
@@ -2858,7 +2856,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "id": str(attr_base.id),
-                    "type": str(AttrTypeValue["named_object"]),
+                    "type": str(AttrType.NAMED_OBJECT),
                     "referral_key": [],
                     "value": [],
                 }
@@ -2884,7 +2882,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "id": str(attr_base.id),
-                    "type": str(AttrTypeValue["named_object"]),
+                    "type": str(AttrType.NAMED_OBJECT),
                     "value": [{"data": str(ref_entry.id), "index": 0}],
                     "referral_key": [],
                 }
@@ -2908,7 +2906,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "id": str(attr_base.id),
-                    "type": str(AttrTypeValue["named_object"]),
+                    "type": str(AttrType.NAMED_OBJECT),
                     "value": [],
                     "referral_key": [{"data": "hoge", "index": 0}],
                 }
@@ -2941,7 +2939,7 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.create(name="entity", created_user=user)
         new_attr_params = {
             "name": "arr_named_ref",
-            "type": AttrTypeValue["array_named_object"],
+            "type": AttrType.ARRAY_NAMED_OBJECT,
             "created_user": user,
             "parent_entity": entity,
         }
@@ -2955,7 +2953,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "id": str(attr_base.id),
-                    "type": str(AttrTypeValue["array_named_object"]),
+                    "type": str(AttrType.ARRAY_NAMED_OBJECT),
                     "value": [
                         {"data": str(ref_entry.id), "index": 0},
                         {"data": str(ref_entry.id), "index": 1},
@@ -3005,7 +3003,7 @@ class ViewTest(AironeViewTest):
         attr_base = EntityAttr.objects.create(
             **{
                 "name": "named_ref",
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "created_user": user,
                 "parent_entity": entity,
             }
@@ -3027,7 +3025,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(entry.attrs.get(name="named_ref").id),
-                    "type": str(AttrTypeValue["named_object"]),
+                    "type": str(AttrType.NAMED_OBJECT),
                     "value": [{"data": str(ref_entry.id), "index": 0}],
                     "referral_key": [{"data": "hoge", "index": 0}],
                 }
@@ -3054,7 +3052,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(entry.attrs.get(name="named_ref").id),
-                    "type": str(AttrTypeValue["named_object"]),
+                    "type": str(AttrType.NAMED_OBJECT),
                     "value": [{"data": str(ref_entry2.id), "index": 0}],
                     "referral_key": [{"data": "fuga", "index": 0}],
                 }
@@ -3087,7 +3085,7 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.create(name="entity", created_user=user)
         new_attr_params = {
             "name": "arr_named_ref",
-            "type": AttrTypeValue["array_named_object"],
+            "type": AttrType.ARRAY_NAMED_OBJECT,
             "created_user": user,
             "parent_entity": entity,
         }
@@ -3125,7 +3123,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(entry.attrs.get(name="arr_named_ref").id),
-                    "type": str(AttrTypeValue["array_named_object"]),
+                    "type": str(AttrType.ARRAY_NAMED_OBJECT),
                     "value": [{"data": str(r), "index": i} for i, r in enumerate(r_entries)],
                     "referral_key": [{"data": "key_%d" % i, "index": i} for i in range(0, 3)],
                 }
@@ -3152,7 +3150,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(entry.attrs.get(name="arr_named_ref").id),
-                    "type": str(AttrTypeValue["array_named_object"]),
+                    "type": str(AttrType.ARRAY_NAMED_OBJECT),
                     "value": [
                         {"data": r_entries[1], "index": 1},
                         {"data": r_entries[2], "index": 2},
@@ -3196,7 +3194,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(entry.attrs.get(name="arr_named_ref").id),
-                    "type": str(AttrTypeValue["array_named_object"]),
+                    "type": str(AttrType.ARRAY_NAMED_OBJECT),
                     "value": [
                         {"data": r_entries[2], "index": 2},
                         {"data": r_entries[1], "index": 1},
@@ -3366,7 +3364,7 @@ class ViewTest(AironeViewTest):
             EntityAttr.objects.create(
                 **{
                     "name": "attr_group",
-                    "type": AttrTypeValue["group"],
+                    "type": AttrType.GROUP,
                     "created_user": admin,
                     "parent_entity": entity,
                 }
@@ -3378,7 +3376,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "id": str(entity.attrs.first().id),
-                    "type": str(AttrTypeValue["group"]),
+                    "type": str(AttrType.GROUP),
                     "value": [{"index": 0, "data": str(group.id)}],
                 }
             ],
@@ -3396,7 +3394,7 @@ class ViewTest(AironeViewTest):
         attrv = entry.attrs.first().get_latest_value()
         self.assertIsNotNone(attrv)
         self.assertEqual(attrv.value, str(group.id))
-        self.assertEqual(attrv.data_type, AttrTypeValue["group"])
+        self.assertEqual(attrv.data_type, AttrType.GROUP)
 
     @patch("entry.tasks.edit_entry_attrs.delay", Mock(side_effect=tasks.edit_entry_attrs))
     def test_edit_entry_with_group_attr(self):
@@ -3411,7 +3409,7 @@ class ViewTest(AironeViewTest):
             EntityAttr.objects.create(
                 **{
                     "name": "attr_group",
-                    "type": AttrTypeValue["group"],
+                    "type": AttrType.GROUP,
                     "created_user": admin,
                     "parent_entity": entity,
                 }
@@ -3432,7 +3430,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(attr.id),
-                    "type": str(AttrTypeValue["group"]),
+                    "type": str(AttrType.GROUP),
                     "value": [{"index": 0, "data": str(Group.objects.get(name="group-0").id)}],
                 }
             ],
@@ -3453,7 +3451,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(attr.id),
-                    "type": str(AttrTypeValue["group"]),
+                    "type": str(AttrType.GROUP),
                     "value": [{"index": 0, "data": str(Group.objects.get(name="group-1").id)}],
                 }
             ],
@@ -3483,18 +3481,18 @@ class ViewTest(AironeViewTest):
 
         entity = Entity.objects.create(name="Entity", created_user=user)
         attr_info = {
-            "str": {"type": AttrTypeValue["string"]},
-            "obj": {"type": AttrTypeValue["object"]},
-            "grp": {"type": AttrTypeValue["group"]},
-            "role": {"type": AttrTypeValue["role"]},
-            "name": {"type": AttrTypeValue["named_object"]},
-            "bool": {"type": AttrTypeValue["boolean"]},
-            "date": {"type": AttrTypeValue["date"]},
-            "arr1": {"type": AttrTypeValue["array_string"]},
-            "arr2": {"type": AttrTypeValue["array_object"]},
-            "arr3": {"type": AttrTypeValue["array_named_object"]},
-            "arr4": {"type": AttrTypeValue["array_group"]},
-            "arr5": {"type": AttrTypeValue["array_role"]},
+            "str": {"type": AttrType.STRING},
+            "obj": {"type": AttrType.OBJECT},
+            "grp": {"type": AttrType.GROUP},
+            "role": {"type": AttrType.ROLE},
+            "name": {"type": AttrType.NAMED_OBJECT},
+            "bool": {"type": AttrType.BOOLEAN},
+            "date": {"type": AttrType.DATE},
+            "arr1": {"type": AttrType.ARRAY_STRING},
+            "arr2": {"type": AttrType.ARRAY_OBJECT},
+            "arr3": {"type": AttrType.ARRAY_NAMED_OBJECT},
+            "arr4": {"type": AttrType.ARRAY_GROUP},
+            "arr5": {"type": AttrType.ARRAY_ROLE},
         }
         for attr_name, info in attr_info.items():
             attr = EntityAttr.objects.create(
@@ -3504,7 +3502,7 @@ class ViewTest(AironeViewTest):
                 parent_entity=entity,
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             entity.attrs.add(attr)
@@ -3613,9 +3611,7 @@ class ViewTest(AironeViewTest):
     def test_import_entry_when_trigger_is_set(self):
         user = self.guest_login()
 
-        entity = self.create_entity(
-            user, "Entity", [{"name": "str", "type": AttrTypeValue["string"]}]
-        )
+        entity = self.create_entity(user, "Entity", [{"name": "str", "type": AttrType.STRING}])
 
         TriggerCondition.register(
             entity,
@@ -3776,15 +3772,15 @@ class ViewTest(AironeViewTest):
 
         entity = Entity.objects.create(name="Entity", created_user=user)
         attr_info = {
-            "str (before changing)": {"type": AttrTypeValue["string"]},
-            "obj": {"type": AttrTypeValue["object"]},
-            "grp": {"type": AttrTypeValue["group"]},
-            "name": {"type": AttrTypeValue["named_object"]},
-            "bool": {"type": AttrTypeValue["boolean"]},
-            "date": {"type": AttrTypeValue["date"]},
-            "arr1": {"type": AttrTypeValue["array_string"]},
-            "arr2": {"type": AttrTypeValue["array_object"]},
-            "arr3": {"type": AttrTypeValue["array_named_object"]},
+            "str (before changing)": {"type": AttrType.STRING},
+            "obj": {"type": AttrType.OBJECT},
+            "grp": {"type": AttrType.GROUP},
+            "name": {"type": AttrType.NAMED_OBJECT},
+            "bool": {"type": AttrType.BOOLEAN},
+            "date": {"type": AttrType.DATE},
+            "arr1": {"type": AttrType.ARRAY_STRING},
+            "arr2": {"type": AttrType.ARRAY_OBJECT},
+            "arr3": {"type": AttrType.ARRAY_NAMED_OBJECT},
         }
         for attr_name, info in attr_info.items():
             attr = EntityAttr.objects.create(
@@ -3794,7 +3790,7 @@ class ViewTest(AironeViewTest):
                 parent_entity=entity,
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             entity.attrs.add(attr)
@@ -3816,7 +3812,7 @@ class ViewTest(AironeViewTest):
 
         # check array_string value is set correctly
         attrv = entry.attrs.get(name="arr1").get_latest_value()
-        self.assertEqual(attrv.data_type, AttrTypeValue["array_string"])
+        self.assertEqual(attrv.data_type, AttrType.ARRAY_STRING)
         self.assertEqual(attrv.data_array.count(), 3)
         self.assertTrue(all([x.parent_attrv == attrv for x in attrv.data_array.all()]))
 
@@ -3836,7 +3832,7 @@ class ViewTest(AironeViewTest):
         entity.attrs.add(
             EntityAttr.objects.create(
                 name="str",
-                type=AttrTypeValue["string"],
+                type=AttrType.STRING,
                 created_user=user,
                 parent_entity=entity,
             )
@@ -3910,7 +3906,7 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.create(name="entity", created_user=admin)
         entity_attr = EntityAttr.objects.create(
             name="attr_date",
-            type=AttrTypeValue["date"],
+            type=AttrType.DATE,
             parent_entity=entity,
             created_user=admin,
         )
@@ -3922,7 +3918,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "id": str(entity_attr.id),
-                    "type": str(AttrTypeValue["date"]),
+                    "type": str(AttrType.DATE),
                     "value": [{"data": "2018-12-31", "index": 0}],
                     "referral_key": [],
                 },
@@ -3950,7 +3946,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(entry.attrs.get(name="attr_date").id),
-                    "type": str(AttrTypeValue["date"]),
+                    "type": str(AttrType.DATE),
                     "value": [{"data": "2019-1-1", "index": 0}],
                     "referral_key": [],
                 },
@@ -3978,7 +3974,7 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.create(name="entity", created_user=admin)
         entity_attr = EntityAttr.objects.create(
             name="attr_date",
-            type=AttrTypeValue["date"],
+            type=AttrType.DATE,
             parent_entity=entity,
             created_user=admin,
         )
@@ -3990,7 +3986,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "id": str(entity_attr.id),
-                    "type": str(AttrTypeValue["date"]),
+                    "type": str(AttrType.DATE),
                     "value": [{"data": "2018-13-30", "index": 0}],
                     "referral_key": [],
                 },
@@ -4013,7 +4009,7 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.create(name="entity", created_user=admin)
         entity_attr = EntityAttr.objects.create(
             name="attr_date",
-            type=AttrTypeValue["date"],
+            type=AttrType.DATE,
             parent_entity=entity,
             created_user=admin,
         )
@@ -4032,7 +4028,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(attr.id),
-                    "type": str(AttrTypeValue["date"]),
+                    "type": str(AttrType.DATE),
                     "value": [{"data": "hoge", "index": 0}],
                     "referral_key": [],
                 },
@@ -4062,7 +4058,7 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.create(name="entity", created_user=admin)
         entity_attr = EntityAttr.objects.create(
             name="attr_date",
-            type=AttrTypeValue["date"],
+            type=AttrType.DATE,
             parent_entity=entity,
             created_user=admin,
         )
@@ -4074,7 +4070,7 @@ class ViewTest(AironeViewTest):
             "attrs": [
                 {
                     "id": str(entity_attr.id),
-                    "type": str(AttrTypeValue["date"]),
+                    "type": str(AttrType.DATE),
                     "value": [{"data": "", "index": 0}],
                     "referral_key": [],
                 },
@@ -4108,63 +4104,63 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.create(name="Entity", created_user=user)
         attr_info = {
             "str": {
-                "type": AttrTypeValue["string"],
+                "type": AttrType.STRING,
                 "value": [{"data": "data", "index": 0}],
                 "expect_value": "data",
                 "expect_blank_value": "",
                 "referral_key": [],
             },
             "obj": {
-                "type": AttrTypeValue["object"],
+                "type": AttrType.OBJECT,
                 "value": [{"data": str(ref_entry.id), "index": 0}],
                 "expect_value": "ref",
                 "expect_blank_value": None,
                 "referral_key": [],
             },
             "grp": {
-                "type": AttrTypeValue["group"],
+                "type": AttrType.GROUP,
                 "value": [{"data": str(group.id), "index": 0}],
                 "expect_value": "group",
                 "expect_blank_value": None,
                 "referral_key": [],
             },
             "name": {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "value": [{"data": str(ref_entry.id), "index": 0}],
                 "expect_value": {"key": "ref"},
                 "expect_blank_value": {"": None},
                 "referral_key": [{"data": "key", "index": 0}],
             },
             "bool": {
-                "type": AttrTypeValue["boolean"],
+                "type": AttrType.BOOLEAN,
                 "value": [{"data": True, "index": 0}],
                 "expect_value": True,
                 "expect_blank_value": False,
                 "referral_key": [],
             },
             "date": {
-                "type": AttrTypeValue["date"],
+                "type": AttrType.DATE,
                 "value": [{"data": "2018-01-01", "index": 0}],
                 "expect_value": date(2018, 1, 1),
                 "expect_blank_value": None,
                 "referral_key": [],
             },
             "arr1": {
-                "type": AttrTypeValue["array_string"],
+                "type": AttrType.ARRAY_STRING,
                 "value": [{"data": "foo", "index": 0}, {"data": "bar", "index": 1}],
                 "expect_value": ["bar", "foo"],
                 "expect_blank_value": [],
                 "referral_key": [],
             },
             "arr2": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "value": [{"data": str(ref_entry.id), "index": 0}],
                 "expect_value": ["ref"],
                 "expect_blank_value": [],
                 "referral_key": [],
             },
             "arr3": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "value": [{"data": str(ref_entry.id), "index": 0}],
                 "expect_value": [{"foo": "ref"}, {"bar": None}],
                 "expect_blank_value": [],
@@ -4183,7 +4179,7 @@ class ViewTest(AironeViewTest):
             )
 
             info["schema"] = attr
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             entity.attrs.add(attr)
@@ -4302,14 +4298,14 @@ class ViewTest(AironeViewTest):
 
         entity = Entity.objects.create(name="Entity", created_user=user)
         attr_info = {
-            "obj": {"type": AttrTypeValue["object"], "checker": checker_obj},
-            "name": {"type": AttrTypeValue["named_object"], "checker": checker_name},
+            "obj": {"type": AttrType.OBJECT, "checker": checker_obj},
+            "name": {"type": AttrType.NAMED_OBJECT, "checker": checker_name},
             "arr_obj": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "checker": checker_arr_obj,
             },
             "arr_name": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "checker": checker_arr_name,
             },
         }
@@ -4333,7 +4329,7 @@ class ViewTest(AironeViewTest):
                         "type": str(x.type),
                         "value": [{"data": value, "index": 0}],
                         "referral_key": [{"data": "foo", "index": 0}]
-                        if x.type & AttrTypeValue["named"]
+                        if x.type & AttrType._NAMED
                         else [],
                     }
                     for x in entity.attrs.all()
@@ -4366,15 +4362,15 @@ class ViewTest(AironeViewTest):
 
         # prepare to Entity and Entries which importing data refers to
         entity_info = {
-            "str": {"type": AttrTypeValue["string"]},
-            "obj": {"type": AttrTypeValue["object"]},
-            "grp": {"type": AttrTypeValue["group"]},
-            "name": {"type": AttrTypeValue["named_object"]},
-            "bool": {"type": AttrTypeValue["boolean"]},
-            "date": {"type": AttrTypeValue["date"]},
-            "arr1": {"type": AttrTypeValue["array_string"]},
-            "arr2": {"type": AttrTypeValue["array_object"]},
-            "arr3": {"type": AttrTypeValue["array_named_object"]},
+            "str": {"type": AttrType.STRING},
+            "obj": {"type": AttrType.OBJECT},
+            "grp": {"type": AttrType.GROUP},
+            "name": {"type": AttrType.NAMED_OBJECT},
+            "bool": {"type": AttrType.BOOLEAN},
+            "date": {"type": AttrType.DATE},
+            "arr1": {"type": AttrType.ARRAY_STRING},
+            "arr2": {"type": AttrType.ARRAY_OBJECT},
+            "arr3": {"type": AttrType.ARRAY_NAMED_OBJECT},
         }
         for name, info in entity_info.items():
             # create entity that only has one attribute of specified type
@@ -4391,7 +4387,7 @@ class ViewTest(AironeViewTest):
 
             # send a request to create entry and expect to be error
             referral_key = []
-            if info["type"] & AttrTypeValue["named"]:
+            if info["type"] & AttrType._NAMED:
                 referral_key = [{"data": "", "index": 0}]
             params = {
                 "entry_name": "entry",
@@ -4413,7 +4409,7 @@ class ViewTest(AironeViewTest):
             self.assertEqual(Entry.objects.filter(schema=entity).count(), 0)
 
             # when a referral_key is specified, named type will be successful to create
-            if info["type"] & AttrTypeValue["named"]:
+            if info["type"] & AttrType._NAMED:
                 referral_key[0]["data"] = "hoge"
                 resp = self.client.post(
                     reverse("entry:do_create", args=[entity.id]),
@@ -4437,10 +4433,10 @@ class ViewTest(AironeViewTest):
         ref_entity = Entity.objects.create(name="ref", created_user=user)
         for index, attr_type in enumerate(
             [
-                AttrTypeValue["object"],
-                AttrTypeValue["named_object"],
-                AttrTypeValue["array_object"],
-                AttrTypeValue["array_named_object"],
+                AttrType.OBJECT,
+                AttrType.NAMED_OBJECT,
+                AttrType.ARRAY_OBJECT,
+                AttrType.ARRAY_NAMED_OBJECT,
             ]
         ):
             # create Entity and Entry which test to create
@@ -4456,7 +4452,7 @@ class ViewTest(AironeViewTest):
             entity.attrs.add(attr)
 
             referral_key = []
-            if attr_type & AttrTypeValue["named"]:
+            if attr_type & AttrType._NAMED:
                 referral_key = [{"data": "", "index": 0}]
 
             # This checks error response would be returned by sending a request
@@ -4561,7 +4557,7 @@ class ViewTest(AironeViewTest):
                     "name": "attr",
                     "created_user": user,
                     "parent_entity": entity,
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                 }
             )
         )
@@ -4586,7 +4582,7 @@ class ViewTest(AironeViewTest):
             name="attr",
             created_user=user,
             parent_entity=entity,
-            type=AttrTypeValue["string"],
+            type=AttrType.STRING,
         )
         entity.attrs.add(attr)
 
@@ -4679,7 +4675,7 @@ class ViewTest(AironeViewTest):
             EntityAttr.objects.create(
                 **{
                     "name": "attr",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "created_user": user,
                     "parent_entity": entity,
                 }
@@ -4803,34 +4799,34 @@ class ViewTest(AironeViewTest):
         # 'revert_attrv' handler. So finnaly, this test expects first value is stored
         # in Database and Elasticsearch.
         attr_info = {
-            "str": {"type": AttrTypeValue["string"], "values": ["foo", "bar"]},
+            "str": {"type": AttrType.STRING, "values": ["foo", "bar"]},
             "obj": {
-                "type": AttrTypeValue["object"],
+                "type": AttrType.OBJECT,
                 "values": [ref_entries[0], ref_entries[1]],
             },
-            "grp": {"type": AttrTypeValue["group"], "values": [groups[0], groups[1]]},
+            "grp": {"type": AttrType.GROUP, "values": [groups[0], groups[1]]},
             "name": {
-                "type": AttrTypeValue["named_object"],
+                "type": AttrType.NAMED_OBJECT,
                 "values": [
                     {"name": "foo", "id": ref_entries[0]},
                     {"name": "bar", "id": ref_entries[1]},
                 ],
             },
-            "bool": {"type": AttrTypeValue["boolean"], "values": [False, True]},
+            "bool": {"type": AttrType.BOOLEAN, "values": [False, True]},
             "date": {
-                "type": AttrTypeValue["date"],
+                "type": AttrType.DATE,
                 "values": ["2018-01-01", "2018-02-01"],
             },
             "arr1": {
-                "type": AttrTypeValue["array_string"],
+                "type": AttrType.ARRAY_STRING,
                 "values": [["foo", "bar", "baz"], ["hoge", "fuga", "puyo"]],
             },
             "arr2": {
-                "type": AttrTypeValue["array_object"],
+                "type": AttrType.ARRAY_OBJECT,
                 "values": [[ref_entries[0], ref_entries[1]], [ref_entries[2]]],
             },
             "arr3": {
-                "type": AttrTypeValue["array_named_object"],
+                "type": AttrType.ARRAY_NAMED_OBJECT,
                 "values": [
                     [
                         {"name": "foo", "id": ref_entries[0]},
@@ -4851,7 +4847,7 @@ class ViewTest(AironeViewTest):
                 parent_entity=entity,
             )
 
-            if info["type"] & AttrTypeValue["object"]:
+            if info["type"] & AttrType.OBJECT:
                 attr.referral.add(ref_entity)
 
             entity.attrs.add(attr)
@@ -4886,25 +4882,25 @@ class ViewTest(AironeViewTest):
             self.assertEqual(data["type"], attr_info[attr_name]["type"])
 
             value = attr_info[attr_name]["values"][0]
-            if data["type"] == AttrTypeValue["boolean"]:
+            if data["type"] == AttrType.BOOLEAN:
                 self.assertEqual(data["value"], value)
 
-            elif data["type"] == AttrTypeValue["group"]:
+            elif data["type"] == AttrType.GROUP:
                 self.assertEqual(data["value"], {"name": value.name, "id": value.id})
 
-            elif data["type"] == AttrTypeValue["object"]:
+            elif data["type"] == AttrType.OBJECT:
                 self.assertEqual(data["value"], {"name": value.name, "id": value.id})
 
-            elif data["type"] == AttrTypeValue["array_object"]:
+            elif data["type"] == AttrType.ARRAY_OBJECT:
                 self.assertEqual(data["value"], [{"name": x.name, "id": x.id} for x in value])
 
-            elif data["type"] == AttrTypeValue["named_object"]:
+            elif data["type"] == AttrType.NAMED_OBJECT:
                 self.assertEqual(
                     data["value"],
                     {value["name"]: {"name": value["id"].name, "id": value["id"].id}},
                 )
 
-            elif data["type"] == AttrTypeValue["array_named_object"]:
+            elif data["type"] == AttrType.ARRAY_NAMED_OBJECT:
                 self.assertEqual(
                     data["value"],
                     [{x["name"]: {"name": x["id"].name, "id": x["id"].id}} for x in value],
@@ -4927,9 +4923,9 @@ class ViewTest(AironeViewTest):
             user,
             "Entity",
             [
-                {"name": "cond_str", "type": AttrTypeValue["string"]},
-                {"name": "cond_name", "type": AttrTypeValue["named_object"]},
-                {"name": "action", "type": AttrTypeValue["string"]},
+                {"name": "cond_str", "type": AttrType.STRING},
+                {"name": "cond_name", "type": AttrType.NAMED_OBJECT},
+                {"name": "action", "type": AttrType.STRING},
             ],
         )
 
@@ -4993,7 +4989,7 @@ class ViewTest(AironeViewTest):
                 EntityAttr.objects.create(
                     **{
                         "name": attr_name,
-                        "type": AttrTypeValue["string"],
+                        "type": AttrType.STRING,
                         "created_user": user,
                         "parent_entity": entity,
                     }
@@ -5025,7 +5021,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(attr1.get_latest_value(), attrvs[-1])
 
         # change Attribute type of attr then get latest AttributeValue
-        attr1.schema.type = AttrTypeValue["object"]
+        attr1.schema.type = AttrType.OBJECT
         attr1.schema.save(update_fields=["type"])
 
         self.assertGreater(attr1.get_latest_value().id, attrvs[-1].id)
@@ -5049,7 +5045,7 @@ class ViewTest(AironeViewTest):
             EntityAttr.objects.create(
                 **{
                     "name": "attr",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "created_user": user,
                     "parent_entity": entity,
                 }
@@ -5088,7 +5084,7 @@ class ViewTest(AironeViewTest):
             EntityAttr.objects.create(
                 **{
                     "name": "attr",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "created_user": user,
                     "parent_entity": entity,
                 }
@@ -5246,7 +5242,7 @@ class ViewTest(AironeViewTest):
         entity = Entity.objects.create(name="entity", created_user=user)
         entity_attr = EntityAttr.objects.create(
             name="attr",
-            type=AttrTypeValue["string"],
+            type=AttrType.STRING,
             parent_entity=entity,
             created_user=user,
         )
@@ -5359,7 +5355,7 @@ class ViewTest(AironeViewTest):
             **{
                 "name": "ref",
                 "created_user": user,
-                "type": AttrTypeValue["object"],
+                "type": AttrType.OBJECT,
                 "parent_entity": entity,
             }
         )
@@ -5469,7 +5465,7 @@ class ViewTest(AironeViewTest):
             entity = self.create_entity(
                 user,
                 "Test Another Entity %d" % index,
-                attrs=[{"name": "attr", "type": AttrTypeValue["string"]}],
+                attrs=[{"name": "attr", "type": AttrType.STRING}],
                 is_public=False,
                 default_permission=acltype.id,
             )
@@ -5503,7 +5499,7 @@ class ViewTest(AironeViewTest):
                 attrs=[
                     {
                         "name": "attr",
-                        "type": AttrTypeValue["string"],
+                        "type": AttrType.STRING,
                         "is_public": False,
                         "default_permission": acltype.id,
                     }
@@ -5535,7 +5531,7 @@ class ViewTest(AironeViewTest):
             entity = self.create_entity(
                 user,
                 "Test Another Entity %d" % index,
-                attrs=[{"name": "attr", "type": AttrTypeValue["string"], "is_public": True}],
+                attrs=[{"name": "attr", "type": AttrType.STRING, "is_public": True}],
                 is_public=True,
                 default_permission=acltype.id,
             )
@@ -5567,7 +5563,7 @@ class ViewTest(AironeViewTest):
             user,
             "Entity",
             attrs=[
-                {"name": "Attr", "type": AttrTypeValue["string"]},
+                {"name": "Attr", "type": AttrType.STRING},
             ],
         )
         entity_attr = entity.attrs.last()
@@ -5590,7 +5586,7 @@ class ViewTest(AironeViewTest):
                 {
                     "entity_attr_id": "",
                     "id": str(entry.attrs.last().id),
-                    "type": str(AttrTypeValue["string"]),
+                    "type": str(AttrType.STRING),
                     "value": [{"data": "", "index": 0}],
                     "referral_key": [],
                 },

--- a/entry/views.py
+++ b/entry/views.py
@@ -21,7 +21,7 @@ from airone.lib.http import (
     http_post,
     render,
 )
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity
 from entry.models import Attribute, AttributeValue, Entry
 from entry.utils import get_sort_order
@@ -70,11 +70,11 @@ def _validate_input(recv_data, obj):
             is_valid = attr_data["value"] and all([_has_data(x) for x in attr_data["value"]])
 
             # This checks whether valid referral parameter is passed
-            if is_valid and attr.type & AttrTypeValue["object"]:
+            if is_valid and attr.type & AttrType.OBJECT:
                 is_valid &= all([_has_referral(x) for x in attr_data["value"]])
 
             # This checks whether valid referral_key parameter is passed
-            if attr.type & AttrTypeValue["named"]:
+            if attr.type & AttrType._NAMED:
                 is_valid |= attr_data["referral_key"] and all(
                     [_has_data(x) for x in attr_data["referral_key"]]
                 )
@@ -92,7 +92,7 @@ def _validate_input(recv_data, obj):
             return HttpResponse("Passed value is exceeded the limit", status=400)
 
         # Check date value format
-        if attr.type & AttrTypeValue["date"]:
+        if attr.type & AttrType.DATE:
             try:
                 [
                     datetime.strptime(str(i["data"]), "%Y-%m-%d")

--- a/group/models.py
+++ b/group/models.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import Group as DjangoGroup
 from django.db import models
 from django.db.models import Q
 
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 
 
 class Group(DjangoGroup):
@@ -66,11 +66,11 @@ class Group(DjangoGroup):
         query = Q(
             Q(
                 is_latest=True,
-                parent_attr__schema__type=AttrTypeValue["group"],
+                parent_attr__schema__type=AttrType.GROUP,
             )
             | Q(
                 parent_attrv__is_latest=True,
-                parent_attr__schema__type=AttrTypeValue["array_group"],
+                parent_attr__schema__type=AttrType.ARRAY_GROUP,
             ),
             value=str(self.id),
             parent_attr__parent_entry__is_active=True,

--- a/group/tests/test_api_v1.py
+++ b/group/tests/test_api_v1.py
@@ -4,7 +4,7 @@ from unittest import mock
 from django.urls import reverse
 
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entry.models import Entry
 from group import tasks
 from group.models import Group
@@ -68,7 +68,7 @@ class APITest(AironeViewTest):
             **{
                 "user": user,
                 "name": "Entity",
-                "attrs": [{"name": "group", "type": AttrTypeValue["group"]}],
+                "attrs": [{"name": "group", "type": AttrType.GROUP}],
             }
         )
 

--- a/group/tests/test_model.py
+++ b/group/tests/test_model.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 from airone.lib.test import AironeTestCase
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entry.models import Entry
 from group.models import Group
 from user.models import User
@@ -62,7 +62,7 @@ class ModelTest(AironeTestCase):
                 **{
                     "user": self.user1,
                     "name": "Entity%d" % index,
-                    "attrs": [{"name": "group", "type": AttrTypeValue["group"]}],
+                    "attrs": [{"name": "group", "type": AttrType.GROUP}],
                 }
             )
             self.add_entry(
@@ -96,7 +96,7 @@ class ModelTest(AironeTestCase):
                 **{
                     "user": self.user1,
                     "name": "Entity%d" % index,
-                    "attrs": [{"name": "groups", "type": AttrTypeValue["array_group"]}],
+                    "attrs": [{"name": "groups", "type": AttrType.ARRAY_GROUP}],
                 }
             )
             self.add_entry(

--- a/job/tests/test_api_v2.py
+++ b/job/tests/test_api_v2.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity, EntityAttr
 from entry.models import Entry
 from job.models import Job, JobOperation, JobStatus
@@ -176,7 +176,7 @@ class ViewTest(AironeViewTest):
         attr = EntityAttr.objects.create(
             name="attr",
             created_user=user,
-            type=AttrTypeValue["string"],
+            type=AttrType.STRING,
             parent_entity=entity,
         )
         entity.attrs.add(attr)

--- a/role/models.py
+++ b/role/models.py
@@ -10,7 +10,7 @@ from django.db.models import Q
 from simple_history.models import HistoricalRecords
 
 from airone.lib.acl import ACLType
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 
 
 class Role(models.Model):
@@ -124,11 +124,11 @@ class Role(models.Model):
         query = Q(
             Q(
                 is_latest=True,
-                parent_attr__schema__type=AttrTypeValue["role"],
+                parent_attr__schema__type=AttrType.ROLE,
             )
             | Q(
                 parent_attrv__is_latest=True,
-                parent_attr__schema__type=AttrTypeValue["array_role"],
+                parent_attr__schema__type=AttrType.ARRAY_ROLE,
             ),
             value=str(self.id),
             parent_attr__parent_entry__is_active=True,

--- a/role/tests/test_api_v1.py
+++ b/role/tests/test_api_v1.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from django.urls import reverse
 
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entry.models import Entry
 from role import tasks
 
@@ -61,7 +61,7 @@ class ModelTest(RoleTestBase):
             **{
                 "user": user,
                 "name": "Entity",
-                "attrs": [{"name": "role", "type": AttrTypeValue["role"]}],
+                "attrs": [{"name": "role", "type": AttrType.ROLE}],
             }
         )
 

--- a/role/tests/test_model.py
+++ b/role/tests/test_model.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 from airone.lib.acl import ACLType
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity
 from group.models import Group
 from role.models import Role
@@ -159,7 +159,7 @@ class ModelTest(RoleTestBase):
                 "attrs": [
                     {
                         "name": "role",
-                        "type": AttrTypeValue["role"],
+                        "type": AttrType.ROLE,
                     }
                 ],
             }
@@ -178,7 +178,7 @@ class ModelTest(RoleTestBase):
                 "attrs": [
                     {
                         "name": "roles",
-                        "type": AttrTypeValue["array_role"],
+                        "type": AttrType.ARRAY_ROLE,
                     }
                 ],
             }

--- a/tools/tests/test_update_es_document.py
+++ b/tools/tests/test_update_es_document.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 from airone.lib.log import Logger
 from airone.lib.test import AironeTestCase
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity, EntityAttr
 from entry.models import Entry
 from entry.tasks import update_es_documents
@@ -25,7 +25,7 @@ class UpdateESDocuemntlTest(AironeTestCase):
             EntityAttr.objects.create(
                 **{
                     "name": "attr",
-                    "type": AttrTypeValue["string"],
+                    "type": AttrType.STRING,
                     "created_user": self.user,
                     "parent_entity": self.entity1,
                 }

--- a/trigger/tests/test_api_v2.py
+++ b/trigger/tests/test_api_v2.py
@@ -1,7 +1,7 @@
 import json
 
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from trigger.models import (
     TriggerAction,
     TriggerActionValue,
@@ -22,28 +22,28 @@ class APITest(AironeViewTest):
             self.user,
             "people",
             attrs=[
-                {"name": "address", "type": AttrTypeValue["string"]},
-                {"name": "is_orphan", "type": AttrTypeValue["boolean"]},
+                {"name": "address", "type": AttrType.STRING},
+                {"name": "is_orphan", "type": AttrType.BOOLEAN},
             ],
         )
         self.entity_book = self.create_entity(
             self.user,
             "book",
             attrs=[
-                {"name": "title", "type": AttrTypeValue["string"]},
-                {"name": "borrowed_by", "type": AttrTypeValue["object"]},
-                {"name": "isbn", "type": AttrTypeValue["string"]},
-                {"name": "is_overdue", "type": AttrTypeValue["boolean"]},
-                {"name": "in_preparation", "type": AttrTypeValue["boolean"]},
-                {"name": "memo", "type": AttrTypeValue["string"]},
-                {"name": "authors", "type": AttrTypeValue["array_string"]},
-                {"name": "recommended_by", "type": AttrTypeValue["array_object"]},
+                {"name": "title", "type": AttrType.STRING},
+                {"name": "borrowed_by", "type": AttrType.OBJECT},
+                {"name": "isbn", "type": AttrType.STRING},
+                {"name": "is_overdue", "type": AttrType.BOOLEAN},
+                {"name": "in_preparation", "type": AttrType.BOOLEAN},
+                {"name": "memo", "type": AttrType.STRING},
+                {"name": "authors", "type": AttrType.ARRAY_STRING},
+                {"name": "recommended_by", "type": AttrType.ARRAY_OBJECT},
                 {
                     "name": "price",
-                    "type": AttrTypeValue["named_object"],
+                    "type": AttrType.NAMED_OBJECT,
                     "ref": self.entity_currency,
                 },
-                {"name": "history", "type": AttrTypeValue["array_named_object"]},
+                {"name": "history", "type": AttrType.ARRAY_NAMED_OBJECT},
             ],
         )
 

--- a/trigger/tests/test_models.py
+++ b/trigger/tests/test_models.py
@@ -3,7 +3,7 @@ import json
 import mock
 
 from airone.lib.test import AironeTestCase
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entry.models import AttributeValue
 from trigger import tasks as trigger_tasks
 from trigger.models import (
@@ -29,58 +29,58 @@ class ModelTest(AironeTestCase):
             "test_entity",
             attrs=[
                 # These are attributes that are used for trigger
-                {"name": "str_trigger", "type": AttrTypeValue["string"]},
+                {"name": "str_trigger", "type": AttrType.STRING},
                 {
                     "name": "ref_trigger",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "ref": self.entity_ref,
                 },
                 {
                     "name": "named_trigger",
-                    "type": AttrTypeValue["named_object"],
+                    "type": AttrType.NAMED_OBJECT,
                     "ref": self.entity_ref,
                 },
                 {
                     "name": "named_trigger2",
-                    "type": AttrTypeValue["named_object"],
+                    "type": AttrType.NAMED_OBJECT,
                     "ref": self.entity_ref,
                 },
-                {"name": "arr_str_trigger", "type": AttrTypeValue["array_string"]},
+                {"name": "arr_str_trigger", "type": AttrType.ARRAY_STRING},
                 {
                     "name": "arr_ref_trigger",
-                    "type": AttrTypeValue["array_object"],
+                    "type": AttrType.ARRAY_OBJECT,
                     "ref": self.entity_ref,
                 },
                 {
                     "name": "arr_named_trigger",
-                    "type": AttrTypeValue["array_named_object"],
+                    "type": AttrType.ARRAY_NAMED_OBJECT,
                     "ref": self.entity_ref,
                 },
-                {"name": "bool_trigger", "type": AttrTypeValue["boolean"]},
+                {"name": "bool_trigger", "type": AttrType.BOOLEAN},
                 # These are attributes that are used for action
-                {"name": "str_action", "type": AttrTypeValue["string"]},
+                {"name": "str_action", "type": AttrType.STRING},
                 {
                     "name": "ref_action",
-                    "type": AttrTypeValue["object"],
+                    "type": AttrType.OBJECT,
                     "ref": self.entity_ref,
                 },
                 {
                     "name": "named_action",
-                    "type": AttrTypeValue["named_object"],
+                    "type": AttrType.NAMED_OBJECT,
                     "ref": self.entity_ref,
                 },
-                {"name": "arr_str_action", "type": AttrTypeValue["array_string"]},
+                {"name": "arr_str_action", "type": AttrType.ARRAY_STRING},
                 {
                     "name": "arr_ref_action",
-                    "type": AttrTypeValue["array_object"],
+                    "type": AttrType.ARRAY_OBJECT,
                     "ref": self.entity_ref,
                 },
                 {
                     "name": "arr_named_action",
-                    "type": AttrTypeValue["array_named_object"],
+                    "type": AttrType.ARRAY_NAMED_OBJECT,
                     "ref": self.entity_ref,
                 },
-                {"name": "bool_action", "type": AttrTypeValue["boolean"]},
+                {"name": "bool_action", "type": AttrType.BOOLEAN},
             ],
         )
 
@@ -320,7 +320,7 @@ class ModelTest(AironeTestCase):
         self.assertEqual(trigger_actions.count(), len(settingTriggerActions))
 
         for trigger_action in trigger_actions:
-            if trigger_action.attr.type & AttrTypeValue["array"]:
+            if trigger_action.attr.type & AttrType._ARRAY:
                 self.assertEqual(trigger_action.values.count(), 3)
             else:
                 self.assertEqual(trigger_action.values.count(), 1)

--- a/user/tests/test_model.py
+++ b/user/tests/test_model.py
@@ -4,7 +4,7 @@ from rest_framework.authtoken.models import Token
 from social_django.models import UserSocialAuth
 
 from airone.lib.acl import ACLType
-from airone.lib.types import AttrTypeValue
+from airone.lib.types import AttrType
 from entity.models import Entity, EntityAttr
 from entry.models import Entry
 from group.models import Group
@@ -64,7 +64,7 @@ class ModelTest(TestCase):
         entity = Entity.objects.create(name="test-entity", created_user=self.user)
         attr = EntityAttr.objects.create(
             name="test-attr",
-            type=AttrTypeValue["object"],
+            type=AttrType.OBJECT,
             created_user=self.user,
             parent_entity=entity,
         )


### PR DESCRIPTION
The enum based refer like `AttrType.KEY` is safer than `AttrTypeValue["key"]`, it can catch errors before runtime.