### PR TITLE
Disable fail-fast to catch expected failures as possible

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup_python311
     strategy:
+      fail-fast: false
       matrix:
         target: ${{ fromJson(needs.setup_python311.outputs.targets) }}
     services:


### PR DESCRIPTION
To catch all errors caused by a PR.
ref. https://qiita.com/yokawasa/items/c9fdb84d48f502d97480