### PR TITLE
Added an option to be able to disable showing history page of Item from entry details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 ### Changed
+* Added an option to be able to disable showing history page of Item from entry details page
+  Contributed by @userlocalhost
 
 ### Fixed
 

--- a/frontend/src/components/common/FlexBox.tsx
+++ b/frontend/src/components/common/FlexBox.tsx
@@ -1,0 +1,8 @@
+import { Box } from "@mui/material";
+import { styled } from "@mui/material/styles";
+
+export const FlexBox = styled(Box)(({}) => ({
+  display: "flex",
+  flexDirection: "column",
+  flexGrow: "1",
+}));

--- a/frontend/src/components/entry/EntryControlMenu.test.tsx
+++ b/frontend/src/components/entry/EntryControlMenu.test.tsx
@@ -26,3 +26,23 @@ test("should render a component with essential props", function () {
     )
   ).not.toThrow();
 });
+
+test("should render a component with optional props", function () {
+  const anchorElem = document.createElement("button");
+  const handleClose = () => undefined;
+
+  expect(() =>
+    render(
+      <EntryControlMenu
+        entityId={0}
+        entryId={0}
+        anchorElem={anchorElem}
+        handleClose={handleClose}
+        disableChangeHistory={true}
+      />,
+      {
+        wrapper: TestWrapper,
+      }
+    )
+  ).not.toThrow();
+});

--- a/frontend/src/components/entry/EntryControlMenu.tsx
+++ b/frontend/src/components/entry/EntryControlMenu.tsx
@@ -30,6 +30,7 @@ interface EntryControlProps {
   anchorElem: HTMLButtonElement | null;
   handleClose: (entryId: number) => void;
   setToggle?: () => void;
+  disableChangeHistory?: boolean;
 }
 
 export const EntryControlMenu: FC<EntryControlProps> = ({
@@ -38,6 +39,7 @@ export const EntryControlMenu: FC<EntryControlProps> = ({
   anchorElem,
   handleClose,
   setToggle,
+  disableChangeHistory = false,
 }) => {
   const { enqueueSnackbar } = useSnackbar();
   const history = useHistory();
@@ -86,7 +88,7 @@ export const EntryControlMenu: FC<EntryControlProps> = ({
         <MenuItem component={Link} to={aclPath(entryId)}>
           <Typography>ACL 設定</Typography>
         </MenuItem>
-        <MenuItem component={Link} to={showEntryHistoryPath(entityId, entryId)}>
+        <MenuItem component={Link} to={showEntryHistoryPath(entityId, entryId)} disabled={disableChangeHistory}>
           <Typography>変更履歴</Typography>
         </MenuItem>
         <MenuItem component={Link} to={aclHistoryPath(entryId)}>

--- a/frontend/src/components/entry/EntryControlMenu.tsx
+++ b/frontend/src/components/entry/EntryControlMenu.tsx
@@ -88,7 +88,11 @@ export const EntryControlMenu: FC<EntryControlProps> = ({
         <MenuItem component={Link} to={aclPath(entryId)}>
           <Typography>ACL 設定</Typography>
         </MenuItem>
-        <MenuItem component={Link} to={showEntryHistoryPath(entityId, entryId)} disabled={disableChangeHistory}>
+        <MenuItem
+          component={Link}
+          to={showEntryHistoryPath(entityId, entryId)}
+          disabled={disableChangeHistory}
+        >
           <Typography>変更履歴</Typography>
         </MenuItem>
         <MenuItem component={Link} to={aclHistoryPath(entryId)}>

--- a/frontend/src/pages/UnavailableErrorPage.tsx
+++ b/frontend/src/pages/UnavailableErrorPage.tsx
@@ -1,0 +1,50 @@
+import { Box, Button, Typography } from "@mui/material";
+import React, { FC, useCallback } from "react";
+
+import { topPath } from "../Routes";
+
+export const UnavailableErrorPage: FC = () => {
+  const handleClickGoToTop = useCallback(() => {
+    location.href = topPath();
+  }, []);
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      flexGrow={1}
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Box display="flex" my="52px">
+        <Typography
+          id="sorry_forbidden"
+          variant="h1"
+          color="#B0BEC5"
+          fontWeight="bold"
+        >
+          利用できません:;(∩´﹏`∩);:
+        </Typography>
+      </Box>
+      <Box display="flex" flexDirection="column" alignItems="center">
+        <Typography color="#455A64">
+          このページは現在、利用ができません。
+        </Typography>
+        <Typography color="#455A64">
+          管理者からのお知らせをご覧いただくか、お問合せください。
+        </Typography>
+      </Box>
+      <Box>
+        <Button
+          variant="contained"
+          color="secondary"
+          sx={{ borderRadius: "16px", my: "40px" }}
+          onClick={handleClickGoToTop}
+        >
+          トップページへ
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+

--- a/frontend/src/pages/UnavailableErrorPage.tsx
+++ b/frontend/src/pages/UnavailableErrorPage.tsx
@@ -47,4 +47,3 @@ export const UnavailableErrorPage: FC = () => {
     </Box>
   );
 };
-


### PR DESCRIPTION
This is a small change to be able to set administrator intentionally disable specific item of EntryControlMenu.