### PR TITLE
Make ACLType enum

### DIFF
--- a/acl/models.py
+++ b/acl/models.py
@@ -44,7 +44,7 @@ class ACLBase(models.Model):
     created_user = models.ForeignKey(User, on_delete=models.DO_NOTHING)
     is_active = models.BooleanField(default=True)
     status = models.IntegerField(default=0)
-    default_permission = models.IntegerField(default=ACLType.Nothing().id)
+    default_permission = models.IntegerField(default=ACLType.Nothing.id)
     created_time = models.DateTimeField(auto_now_add=True)
     updated_time = models.DateTimeField(auto_now=True)
     deleted_user = models.ForeignKey(

--- a/acl/tests/test_model.py
+++ b/acl/tests/test_model.py
@@ -135,11 +135,9 @@ class ModelTest(TestCase):
 
         self.assertTrue(type_readable == ACLType.Readable)
         self.assertTrue(type_readable == ACLType.Readable.id)
-        self.assertTrue(type_readable == ACLType.Readable.name)
 
         self.assertFalse(type_readable != ACLType.Readable)
         self.assertFalse(type_readable != ACLType.Readable.id)
-        self.assertFalse(type_readable != ACLType.Readable.name)
         self.assertTrue(type_readable != ACLType.Writable)
 
         self.assertTrue(type_readable <= ACLType.Writable)

--- a/airone/lib/acl.py
+++ b/airone/lib/acl.py
@@ -3,11 +3,6 @@ import enum
 __all__ = ["ACLType", "ACLObjType"]
 
 
-class Iteratable(object):
-    def __iter__(self):
-        return self._types.__iter__()
-
-
 @enum.unique
 class ACLObjType(enum.IntEnum):
     Entity = 1 << 0
@@ -16,54 +11,35 @@ class ACLObjType(enum.IntEnum):
     EntryAttr = 1 << 3
 
 
-class MetaACLType(type):
-    def __eq__(cls, comp):
-        if isinstance(comp, int):
-            return cls.id == comp
-        elif isinstance(comp, str):
-            return cls.name == comp
-        elif issubclass(comp, ACLTypeBase):
-            return cls.id == comp.id
-        else:
-            return False
+class ACLType(enum.IntEnum):
+    Nothing = 1 << 0
+    Readable = 1 << 1
+    Writable = 1 << 2
+    Full = 1 << 3
 
-    def __ne__(cls, comp):
-        return not cls == comp
+    @property
+    def id(self):
+        return self.value
 
-    def __le__(cls, comp):
-        if isinstance(comp, int):
-            return cls.id <= comp
-        elif issubclass(comp, ACLTypeBase):
-            return cls.id <= comp.id
-        else:
-            return False
+    @property
+    def name(self):
+        names = {
+            self.Nothing: "nothing",
+            self.Readable: "readable",
+            self.Writable: "writable",
+            self.Full: "full",
+        }
+        return names[self.value]
 
-
-class ACLTypeBase(metaclass=MetaACLType):
-    pass
-
-
-class ACLType(Iteratable):
-    Nothing = type(
-        "ACLTypeNone",
-        (ACLTypeBase,),
-        {"id": (1 << 0), "name": "nothing", "label": "Nothing"},
-    )
-    Readable = type(
-        "ACLTypeReadable",
-        (ACLTypeBase,),
-        {"id": (1 << 1), "name": "readable", "label": "Readable"},
-    )
-    Writable = type(
-        "ACLTypeWritable",
-        (ACLTypeBase,),
-        {"id": (1 << 2), "name": "writable", "label": "Writable"},
-    )
-    Full = type(
-        "ACLTypeFull",
-        (ACLTypeBase,),
-        {"id": (1 << 3), "name": "full", "label": "Full Controllable"},
-    )
+    @property
+    def label(self):
+        labels = {
+            self.Nothing: "Nothing",
+            self.Readable: "Readable",
+            self.Writable: "Writable",
+            self.Full: "Full Controllable",
+        }
+        return labels[self.value]
 
     @classmethod
     def all(cls):

--- a/role/models.py
+++ b/role/models.py
@@ -117,7 +117,7 @@ class Role(models.Model):
         if permissions:
             return permissions[0].get_aclid()
         else:
-            return ACLType.Nothing().id
+            return ACLType.Nothing.id
 
     def get_referred_entries(self, entity_name: str | None = None):
         # make query to identify AttributeValue that specify this Role instance

--- a/user/models.py
+++ b/user/models.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.db import models
 from rest_framework.authtoken.models import Token
 
-from airone.lib.acl import ACLType, ACLTypeBase
+from airone.lib.acl import ACLType
 from group.models import Group
 from role.models import Role
 
@@ -83,7 +83,7 @@ class User(AbstractUser):
         # This try-catch syntax is needed because the 'issubclass' may occur a
         # TypeError exception when permission_level is not object.
         try:
-            if not issubclass(permission_level, ACLTypeBase):
+            if not isinstance(permission_level, ACLType):
                 return False
         except TypeError:
             return False


### PR DESCRIPTION
Migrate self-defined enum like type to python native enum type, to make it more type safe and simple.