### PR TITLE
prefetch related sub models

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -949,7 +949,9 @@ def make_search_results(
 
     # get django objects from the hit information from Elasticsearch
     hit_entry_ids = [x["_id"] for x in res["hits"]["hits"]]
-    hit_entries = Entry.objects.filter(id__in=hit_entry_ids, is_active=True)
+    hit_entries = Entry.objects.filter(id__in=hit_entry_ids, is_active=True).select_related(
+        "schema"
+    )
 
     hit_infos: dict = {}
     for entry in hit_entries[:limit]:


### PR DESCRIPTION
Remove N+1 on advanced search.

# before / after

Examined with 100+ entries have 4 attributes.

## before

About 6s, caused by heavy N+1.

<img width="710" alt="image" src="https://github.com/dmm-com/pagoda/assets/191684/635574d9-8eb0-43ea-9493-8d3dbf6e39a6">

<img width="1548" alt="image" src="https://github.com/dmm-com/pagoda/assets/191684/2cdcd57d-f15f-4d40-8477-d07ad27dca83">

## after

About 1s, with smart queries.

<img width="710" alt="image" src="https://github.com/dmm-com/pagoda/assets/191684/f532b058-2de7-48bb-a680-1872b044661b">

<img width="1570" alt="image" src="https://github.com/dmm-com/pagoda/assets/191684/c95c86b7-1523-48ba-9fc4-de4ae84ff28d">
