### PR TITLE
Added tooltip for long entry name

### DIFF
--- a/frontend/src/components/common/ClipboardCopyButton.tsx
+++ b/frontend/src/components/common/ClipboardCopyButton.tsx
@@ -1,0 +1,30 @@
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import { ClickAwayListener, IconButton, Tooltip } from "@mui/material";
+import React, { FC, useState } from "react";
+
+interface Props {
+  name: string;
+}
+
+export const ClipboardCopyButton: FC<Props> = ({ name }) => {
+  const [open, setOpen] = useState<boolean>(false);
+  return (
+    <ClickAwayListener onClickAway={() => setOpen(false)}>
+      <Tooltip
+        title="名前をコピーしました"
+        open={open}
+        disableHoverListener
+        disableFocusListener
+      >
+        <IconButton
+          onClick={() => {
+            global.navigator.clipboard.writeText(name);
+            setOpen(true);
+          }}
+        >
+          <ContentCopyIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+    </ClickAwayListener>
+  );
+};

--- a/frontend/src/components/entity/EntityListCard.tsx
+++ b/frontend/src/components/entity/EntityListCard.tsx
@@ -6,6 +6,7 @@ import {
   CardContent,
   CardHeader,
   IconButton,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
@@ -15,6 +16,7 @@ import { Link } from "react-router-dom";
 import { EntityControlMenu } from "./EntityControlMenu";
 
 import { entityEntriesPath } from "Routes";
+import { ClipboardCopyButton } from "components/common/ClipboardCopyButton";
 import { EntryImportModal } from "components/entry/EntryImportModal";
 
 const EntityNote = styled(Typography)(({ theme }) => ({
@@ -67,17 +69,21 @@ export const EntityListCard: FC<Props> = ({ entity, setToggle }) => {
       <StyledCardHeader
         title={
           <CardActionArea component={Link} to={entityEntriesPath(entity.id)}>
-            <EntityName variant="h6">{entity.name}</EntityName>
+            <Tooltip title={entity.name} placement="bottom-start">
+              <EntityName variant="h6">{entity.name}</EntityName>
+            </Tooltip>
           </CardActionArea>
         }
         action={
           <>
+            <ClipboardCopyButton name={entity.name} />
+
             <IconButton
               onClick={(e) => {
                 setAnchorElem(e.currentTarget);
               }}
             >
-              <MoreVertIcon />
+              <MoreVertIcon fontSize="small" />
             </IconButton>
             <EntityControlMenu
               entityId={entity.id}

--- a/frontend/src/components/entry/EntryListCard.tsx
+++ b/frontend/src/components/entry/EntryListCard.tsx
@@ -5,6 +5,7 @@ import {
   CardActionArea,
   CardHeader,
   IconButton,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
@@ -12,6 +13,7 @@ import React, { FC, useState } from "react";
 import { Link } from "react-router-dom";
 
 import { entryDetailsPath } from "Routes";
+import { ClipboardCopyButton } from "components/common/ClipboardCopyButton";
 import { EntryControlMenu } from "components/entry/EntryControlMenu";
 
 const StyledCard = styled(Card)(({}) => ({
@@ -51,13 +53,17 @@ export const EntryListCard: FC<Props> = ({ entityId, entry, setToggle }) => {
             component={Link}
             to={entryDetailsPath(entityId, entry.id)}
           >
-            <EntryName variant="h6">{entry.name}</EntryName>
+            <Tooltip title={entry.name} placement="bottom-start">
+              <EntryName variant="h6">{entry.name}</EntryName>
+            </Tooltip>
           </CardActionArea>
         }
         action={
           <>
+            <ClipboardCopyButton name={entry.name} />
+
             <IconButton onClick={(e) => setAnchorElem(e.currentTarget)}>
-              <MoreVertIcon />
+              <MoreVertIcon fontSize="small" />
             </IconButton>
             <EntryControlMenu
               entityId={entityId}

--- a/frontend/src/components/user/UserList.test.tsx
+++ b/frontend/src/components/user/UserList.test.tsx
@@ -106,8 +106,8 @@ describe("UserList", () => {
 
     act(() => {
       // open a menu for user1
-      // NOTE there are 2 buttons (user1 menu, user2 menu)
-      screen.getAllByRole("button")[0].click();
+      // NOTE there are 4 buttons (user1 copy, user1 menu, user2 copy, user2 menu)
+      screen.getAllByRole("button")[1].click();
     });
     act(() => {
       screen.getByRole("menuitem", { name: "削除" }).click();

--- a/frontend/src/components/user/UserList.tsx
+++ b/frontend/src/components/user/UserList.tsx
@@ -8,24 +8,42 @@ import {
   CardHeader,
   Grid,
   IconButton,
+  Tooltip,
   Typography,
 } from "@mui/material";
+import { styled } from "@mui/material/styles";
 import React, { FC, useMemo, useState } from "react";
 import { Link, useHistory, useLocation } from "react-router-dom";
-
-import { useAsyncWithThrow } from "../../hooks/useAsyncWithThrow";
 
 import { UserControlMenu } from "./UserControlMenu";
 
 import { newUserPath, userPath } from "Routes";
+import { ClipboardCopyButton } from "components/common/ClipboardCopyButton";
 import { Loading } from "components/common/Loading";
 import { PaginationFooter } from "components/common/PaginationFooter";
 import { SearchBox } from "components/common/SearchBox";
+import { useAsyncWithThrow } from "hooks/useAsyncWithThrow";
 import { usePage } from "hooks/usePage";
 import { aironeApiClient } from "repository/AironeApiClient";
 import { UserList as ConstUserList } from "services/Constants";
 import { ServerContext } from "services/ServerContext";
 import { normalizeToMatch } from "services/StringUtil";
+
+const StyledCardHeader = styled(CardHeader)(({}) => ({
+  p: "0px",
+  mt: "24px",
+  mx: "16px",
+  mb: "16px",
+  ".MuiCardHeader-content": {
+    width: "80%",
+  },
+}));
+
+const UserName = styled(Typography)(({}) => ({
+  textOverflow: "ellipsis",
+  overflow: "hidden",
+  whiteSpace: "nowrap",
+}));
 
 export const UserList: FC = ({}) => {
   const location = useLocation();
@@ -97,32 +115,18 @@ export const UserList: FC = ({}) => {
             return (
               <Grid item xs={4} key={user.id}>
                 <Card sx={{ height: "100%" }}>
-                  <CardHeader
-                    sx={{
-                      p: "0px",
-                      mt: "24px",
-                      mx: "16px",
-                      mb: "16px",
-                      ".MuiCardHeader-content": {
-                        width: "80%",
-                      },
-                    }}
+                  <StyledCardHeader
                     title={
                       <CardActionArea component={Link} to={userPath(user.id)}>
-                        <Typography
-                          variant="h6"
-                          sx={{
-                            textOverflow: "ellipsis",
-                            overflow: "hidden",
-                            whiteSpace: "nowrap",
-                          }}
-                        >
-                          {user.username}
-                        </Typography>
+                        <Tooltip title={user.username} placement="bottom-start">
+                          <UserName>{user.username}</UserName>
+                        </Tooltip>
                       </CardActionArea>
                     }
                     action={
                       <>
+                        <ClipboardCopyButton name={user.username} />
+
                         <IconButton
                           onClick={(e) => {
                             setUserAnchorEls({
@@ -131,7 +135,7 @@ export const UserList: FC = ({}) => {
                             });
                           }}
                         >
-                          <MoreVertIcon />
+                          <MoreVertIcon fontSize="small" />
                         </IconButton>
                         <UserControlMenu
                           user={user}

--- a/frontend/src/pages/__snapshots__/EntityListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntityListPage.test.tsx.snap
@@ -214,7 +214,9 @@ exports[`should match snapshot 1`] = `
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-1o3f16q-MuiTypography-root"
+                            aria-label="aaa"
+                            class="MuiTypography-root MuiTypography-h6  css-1o3f16q-MuiTypography-root"
+                            data-mui-internal-clone-element="true"
                           >
                             aaa
                           </h6>
@@ -228,13 +230,32 @@ exports[`should match snapshot 1`] = `
                       class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
                     >
                       <button
+                        aria-label="名前をコピーしました"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                      </button>
+                      <button
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                           data-testid="MoreVertIcon"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -276,7 +297,9 @@ exports[`should match snapshot 1`] = `
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-1o3f16q-MuiTypography-root"
+                            aria-label="aaaaa"
+                            class="MuiTypography-root MuiTypography-h6  css-1o3f16q-MuiTypography-root"
+                            data-mui-internal-clone-element="true"
                           >
                             aaaaa
                           </h6>
@@ -290,13 +313,32 @@ exports[`should match snapshot 1`] = `
                       class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
                     >
                       <button
+                        aria-label="名前をコピーしました"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                      </button>
+                      <button
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                           data-testid="MoreVertIcon"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -338,7 +380,9 @@ exports[`should match snapshot 1`] = `
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-1o3f16q-MuiTypography-root"
+                            aria-label="bbbbb"
+                            class="MuiTypography-root MuiTypography-h6  css-1o3f16q-MuiTypography-root"
+                            data-mui-internal-clone-element="true"
                           >
                             bbbbb
                           </h6>
@@ -352,13 +396,32 @@ exports[`should match snapshot 1`] = `
                       class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
                     >
                       <button
+                        aria-label="名前をコピーしました"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                      </button>
+                      <button
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                           data-testid="MoreVertIcon"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -660,7 +723,9 @@ exports[`should match snapshot 1`] = `
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-1o3f16q-MuiTypography-root"
+                          aria-label="aaa"
+                          class="MuiTypography-root MuiTypography-h6  css-1o3f16q-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
                         >
                           aaa
                         </h6>
@@ -674,13 +739,32 @@ exports[`should match snapshot 1`] = `
                     class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
                   >
                     <button
+                      aria-label="名前をコピーしました"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                    </button>
+                    <button
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       type="button"
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                         data-testid="MoreVertIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -722,7 +806,9 @@ exports[`should match snapshot 1`] = `
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-1o3f16q-MuiTypography-root"
+                          aria-label="aaaaa"
+                          class="MuiTypography-root MuiTypography-h6  css-1o3f16q-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
                         >
                           aaaaa
                         </h6>
@@ -736,13 +822,32 @@ exports[`should match snapshot 1`] = `
                     class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
                   >
                     <button
+                      aria-label="名前をコピーしました"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                    </button>
+                    <button
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       type="button"
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                         data-testid="MoreVertIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -784,7 +889,9 @@ exports[`should match snapshot 1`] = `
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-1o3f16q-MuiTypography-root"
+                          aria-label="bbbbb"
+                          class="MuiTypography-root MuiTypography-h6  css-1o3f16q-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
                         >
                           bbbbb
                         </h6>
@@ -798,13 +905,32 @@ exports[`should match snapshot 1`] = `
                     class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
                   >
                     <button
+                      aria-label="名前をコピーしました"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                    </button>
+                    <button
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       type="button"
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                         data-testid="MoreVertIcon"
                         focusable="false"
                         viewBox="0 0 24 24"

--- a/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
@@ -252,7 +252,9 @@ exports[`should match snapshot 1`] = `
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-1o3f16q-MuiTypography-root"
+                            aria-label="aaa"
+                            class="MuiTypography-root MuiTypography-h6  css-1o3f16q-MuiTypography-root"
+                            data-mui-internal-clone-element="true"
                           >
                             aaa
                           </h6>
@@ -266,13 +268,32 @@ exports[`should match snapshot 1`] = `
                       class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
                     >
                       <button
+                        aria-label="名前をコピーしました"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                      </button>
+                      <button
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                           data-testid="MoreVertIcon"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -307,7 +328,9 @@ exports[`should match snapshot 1`] = `
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-1o3f16q-MuiTypography-root"
+                            aria-label="aaaaa"
+                            class="MuiTypography-root MuiTypography-h6  css-1o3f16q-MuiTypography-root"
+                            data-mui-internal-clone-element="true"
                           >
                             aaaaa
                           </h6>
@@ -321,13 +344,32 @@ exports[`should match snapshot 1`] = `
                       class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
                     >
                       <button
+                        aria-label="名前をコピーしました"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                      </button>
+                      <button
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                           data-testid="MoreVertIcon"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -362,7 +404,9 @@ exports[`should match snapshot 1`] = `
                           tabindex="0"
                         >
                           <h6
-                            class="MuiTypography-root MuiTypography-h6 css-1o3f16q-MuiTypography-root"
+                            aria-label="bbbbb"
+                            class="MuiTypography-root MuiTypography-h6  css-1o3f16q-MuiTypography-root"
+                            data-mui-internal-clone-element="true"
                           >
                             bbbbb
                           </h6>
@@ -376,13 +420,32 @@ exports[`should match snapshot 1`] = `
                       class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
                     >
                       <button
+                        aria-label="名前をコピーしました"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                      </button>
+                      <button
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                           data-testid="MoreVertIcon"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -715,7 +778,9 @@ exports[`should match snapshot 1`] = `
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-1o3f16q-MuiTypography-root"
+                          aria-label="aaa"
+                          class="MuiTypography-root MuiTypography-h6  css-1o3f16q-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
                         >
                           aaa
                         </h6>
@@ -729,13 +794,32 @@ exports[`should match snapshot 1`] = `
                     class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
                   >
                     <button
+                      aria-label="名前をコピーしました"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                    </button>
+                    <button
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       type="button"
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                         data-testid="MoreVertIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -770,7 +854,9 @@ exports[`should match snapshot 1`] = `
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-1o3f16q-MuiTypography-root"
+                          aria-label="aaaaa"
+                          class="MuiTypography-root MuiTypography-h6  css-1o3f16q-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
                         >
                           aaaaa
                         </h6>
@@ -784,13 +870,32 @@ exports[`should match snapshot 1`] = `
                     class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
                   >
                     <button
+                      aria-label="名前をコピーしました"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                    </button>
+                    <button
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       type="button"
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                         data-testid="MoreVertIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -825,7 +930,9 @@ exports[`should match snapshot 1`] = `
                         tabindex="0"
                       >
                         <h6
-                          class="MuiTypography-root MuiTypography-h6 css-1o3f16q-MuiTypography-root"
+                          aria-label="bbbbb"
+                          class="MuiTypography-root MuiTypography-h6  css-1o3f16q-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
                         >
                           bbbbb
                         </h6>
@@ -839,13 +946,32 @@ exports[`should match snapshot 1`] = `
                     class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
                   >
                     <button
+                      aria-label="名前をコピーしました"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                    </button>
+                    <button
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       type="button"
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                         data-testid="MoreVertIcon"
                         focusable="false"
                         viewBox="0 0 24 24"

--- a/frontend/src/pages/__snapshots__/UserListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/UserListPage.test.tsx.snap
@@ -201,7 +201,7 @@ exports[`should match snapshot 1`] = `
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-zwt9xa-MuiPaper-root-MuiCard-root"
                 >
                   <div
-                    class="MuiCardHeader-root css-123p1mg-MuiCardHeader-root"
+                    class="MuiCardHeader-root css-2hnidy-MuiCardHeader-root"
                   >
                     <div
                       class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -214,11 +214,13 @@ exports[`should match snapshot 1`] = `
                           href="/ui/users/1"
                           tabindex="0"
                         >
-                          <h6
-                            class="MuiTypography-root MuiTypography-h6 css-c6mpt2-MuiTypography-root"
+                          <p
+                            aria-label="user1"
+                            class="MuiTypography-root MuiTypography-body1  css-twhdu-MuiTypography-root"
+                            data-mui-internal-clone-element="true"
                           >
                             user1
-                          </h6>
+                          </p>
                           <span
                             class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
                           />
@@ -229,13 +231,32 @@ exports[`should match snapshot 1`] = `
                       class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
                     >
                       <button
+                        aria-label="名前をコピーしました"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                      </button>
+                      <button
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                           data-testid="MoreVertIcon"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -531,7 +552,7 @@ exports[`should match snapshot 1`] = `
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-zwt9xa-MuiPaper-root-MuiCard-root"
               >
                 <div
-                  class="MuiCardHeader-root css-123p1mg-MuiCardHeader-root"
+                  class="MuiCardHeader-root css-2hnidy-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -544,11 +565,13 @@ exports[`should match snapshot 1`] = `
                         href="/ui/users/1"
                         tabindex="0"
                       >
-                        <h6
-                          class="MuiTypography-root MuiTypography-h6 css-c6mpt2-MuiTypography-root"
+                        <p
+                          aria-label="user1"
+                          class="MuiTypography-root MuiTypography-body1  css-twhdu-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
                         >
                           user1
-                        </h6>
+                        </p>
                         <span
                           class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
                         />
@@ -559,13 +582,32 @@ exports[`should match snapshot 1`] = `
                     class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
                   >
                     <button
+                      aria-label="名前をコピーしました"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                    </button>
+                    <button
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       type="button"
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
                         data-testid="MoreVertIcon"
                         focusable="false"
                         viewBox="0 0 24 24"


### PR DESCRIPTION
On the entry list page, if the name was long, it would be truncated and not be visible in full.
A tooltip has been added.
![image](https://github.com/dmm-com/pagoda/assets/5561786/30afe7fa-c6d3-4021-96d8-6b556d1f75d4)
