### PR TITLE
Add group/role relations, and double write into them for data migration

### DIFF
--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -1201,6 +1201,7 @@ class ModelTest(AironeTestCase):
     def test_set_value_method(self):
         user = User.objects.create(username="hoge")
         test_groups = [Group.objects.create(name=x) for x in ["g1", "g2"]]
+        test_roles = [Role.objects.create(name=x) for x in ["r1", "r2"]]
 
         # create referred Entity and Entries
         ref_entity = Entity.objects.create(name="Referred Entity", created_user=user)
@@ -1217,6 +1218,7 @@ class ModelTest(AironeTestCase):
             {"name": "arr_obj", "val": [ref_entry]},
             {"name": "arr_name", "val": [{"name": "new_value", "id": ref_entry}]},
             {"name": "arr_group", "val": test_groups},
+            {"name": "arr_role", "val": test_roles},
         ]
         for info in attr_info:
             attr = entry.attrs.get(schema__name=info["name"])
@@ -1242,6 +1244,20 @@ class ModelTest(AironeTestCase):
         self.assertEqual(
             [int(x.value) for x in latest_value.data_array.all()],
             [x.id for x in test_groups],
+        )
+        self.assertEqual(
+            [x.group for x in latest_value.data_array.all().select_related("group")],
+            test_groups,
+        )
+
+        latest_value = entry.attrs.get(name="arr_role").get_latest_value()
+        self.assertEqual(
+            [int(x.value) for x in latest_value.data_array.all()],
+            [x.id for x in test_roles],
+        )
+        self.assertEqual(
+            [x.role for x in latest_value.data_array.all().select_related("role")],
+            test_roles,
         )
 
     def test_get_available_attrs(self):


### PR DESCRIPTION
A part of https://github.com/dmm-com/pagoda/pull/1214 , so see the PR first of all.
It covers the steps:
1. update the newly written values
2. update existing values (data migration

For the 1st step, it appends `group`, `role` fields and stores these ids into the fields, with keeping existing logic.

For the 2nd step, we need to modify existing records to store `group_id` and `role_id`. For e.g. the following DML can perform it:
```sql
BEGIN;

UPDATE entry_attributevalue
SET
    group_id = CASE
        WHEN data_type IN (16, 1040) THEN CAST(value AS UNSIGNED)
        ELSE NULL
    END,
    role_id = CASE
        WHEN data_type IN (64, 1088) THEN CAST(value AS UNSIGNED)
        ELSE NULL
    END
WHERE
  -- group
  (data_type = 16)
  OR
  -- children of array_group
  (data_type = 1040 AND parent_attrv_id IS NOT NULL)
  OR
  -- role
  (data_type = 64)
  OR
  -- children of array_role
  (data_type = 1088 AND parent_attrv_id IS NOT NULL);

SELECT ROW_COUNT() AS updated_rows;

COMMIT;
```