### PR TITLE
Fixed failed invoke trigger for oldUI

### DIFF
--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -1976,6 +1976,7 @@ class ViewTest(AironeViewTest):
             "entry_name": "Jhon Doe",
             "attrs": [
                 {
+                    "entity_attr_id": str(entity.attrs.get(name="address").id),
                     "id": str(entity.attrs.get(name="address").id),
                     "type": str(AttrType.STRING),
                     "value": [{"data": "", "index": 0}],
@@ -2101,7 +2102,7 @@ class ViewTest(AironeViewTest):
             "entry_name": "entry",
             "attrs": [
                 {
-                    "entity_attr_id": "",
+                    "entity_attr_id": str(entity.attrs.get(name="address").id),
                     "id": str(entry.attrs.get(schema__name="address").id),
                     "value": [{"data": "", "index": 0}],
                     "referral_key": [{"data": "unknown", "index": 0}],

--- a/trigger/models.py
+++ b/trigger/models.py
@@ -11,7 +11,7 @@ from airone.lib.log import Logger
 from airone.lib.types import AttrType
 from entity.models import Entity, EntityAttr
 from entry.api_v2.serializers import EntryUpdateSerializer
-from entry.models import Attribute, Entry
+from entry.models import Entry
 
 if TYPE_CHECKING:
     from django.db.models import Manager
@@ -431,20 +431,11 @@ class TriggerCondition(models.Model):
         # But in the APIv1, the "id" parameter in the recv_data variable means Attribute ID
         # of Entry. So, it's necessary to refer "entity_attr_id" parameter to be compatible
         # with both API versions.
-        if any([("entity_attr_id" in x) or ("referral_key" in x) for x in recv_data]):
+        if any(["entity_attr_id" in x for x in recv_data]):
             # This is for APIv1
             params = []
             for data in recv_data:
-                # this is for create Item operation
-                entity_attr = EntityAttr.objects.filter(id=data["id"]).first()
-
-                # this is for update Item operation
-                if entity_attr is None:
-                    attr = Attribute.objects.filter(id=data["id"]).first()
-                    entity_attr = attr.schema if attr else None
-
-                    if entity_attr is None and data["entity_attr_id"]:
-                        entity_attr = EntityAttr.objects.filter(id=data["entity_attr_id"]).first()
+                entity_attr = EntityAttr.objects.filter(id=data["entity_attr_id"]).first()
 
                 if entity_attr.type & AttrType._NAMED and entity_attr.type & AttrType.OBJECT:
                     # merge name and id value to the data parameter to be compatible with APIv2
@@ -462,16 +453,9 @@ class TriggerCondition(models.Model):
                             sorted(data["referral_key"], key=lambda x: x["index"]),
                         )
                     ]
-                    params.append(
-                        {"attr_id": int(entity_attr.id) if entity_attr else 0, "value": v}
-                    )
+                    params.append({"attr_id": int(entity_attr.id), "value": v})
                 else:
-                    params.append(
-                        {
-                            "attr_id": int(entity_attr.id) if entity_attr else 0,
-                            "value": data["value"],
-                        }
-                    )
+                    params.append({"attr_id": int(entity_attr.id), "value": data["value"]})
         else:
             # This is for APIv2
             params = [{"attr_id": int(x["id"]), "value": x["value"]} for x in recv_data]

--- a/trigger/tests/test_models.py
+++ b/trigger/tests/test_models.py
@@ -509,6 +509,167 @@ class ModelTest(AironeTestCase):
             else:
                 self.assertEqual(len(actions), 0)
 
+    def test_condition_can_be_invoked_for_each_attribute_types_with_oldui(self):
+        self.add_entry(self.user, "test_entry", self.entity)
+
+        # register TriggerCondition and its Actions
+        settingTriggerAction = self.FULL_ACTION_CONFIGURATION_PARAMETERS.copy()[0]
+
+        for cond_param in self.FULL_CONDITION_CONFIGURATION_PARAMETERS:
+            TriggerCondition.register(self.entity, [cond_param], [settingTriggerAction])
+
+        # These are testing parameters whether specifying "vlaue" could invoke TriggerCondition
+        # for each typed Attributes.
+        test_input_params = [
+            {
+                "attrname": "str_trigger",
+                "value": [{"data": ""}],
+                "referral_key": [],
+                "will_invoke": False,
+            },
+            {
+                "attrname": "str_trigger",
+                "value": [{"data": "Open Sesame"}],
+                "referral_key": [],
+                "will_invoke": False,
+            },
+            {
+                "attrname": "str_trigger",
+                "value": [{"data": FAT_LADY_PASSWDS[0]}],
+                "referral_key": [],
+                "will_invoke": True,
+            },
+            {
+                "attrname": "ref_trigger",
+                "value": [{"data": None, "index": "0"}],
+                "referral_key": [],
+                "will_invoke": False,
+            },
+            {
+                "attrname": "ref_trigger",
+                "value": [{"data": self.entry_refs[0].id, "index": "0"}],
+                "referral_key": [],
+                "will_invoke": False,
+            },
+            {
+                "attrname": "ref_trigger",
+                "value": [{"data": self.entry_refs[2].id, "index": "0"}],
+                "referral_key": [],
+                "will_invoke": True,
+            },
+            {
+                "attrname": "named_trigger",
+                "value": [{"data": self.entry_refs[0].id, "index": "0"}],
+                "referral_key": [{"data": "Open Sesame", "index": "0"}],
+                "will_invoke": False,
+            },
+            {
+                "attrname": "named_trigger",
+                "value": [{"data": self.entry_refs[0].id, "index": "0"}],
+                "referral_key": [{"data": "", "index": "0"}],
+                "will_invoke": False,
+            },
+            {
+                "attrname": "named_trigger",
+                "value": [{"data": None, "index": "0"}],
+                "referral_key": [{"data": "Unexpected words", "index": "0 "}],
+                "will_invoke": False,
+            },
+            {
+                "attrname": "named_trigger",
+                "value": [{"data": None, "index": "0"}],
+                "referral_key": [{"data": FAT_LADY_PASSWDS[0], "index": "0"}],
+                "will_invoke": True,
+            },
+            {
+                "attrname": "named_trigger",
+                "value": [{"data": self.entry_refs[2].id, "index": "0"}],
+                "referral_key": [{"data": "", "index": "0"}],
+                "will_invoke": True,
+            },
+            {
+                "attrname": "named_trigger",
+                "value": [{"data": self.entry_refs[2].id, "index": "0"}],
+                "referral_key": [{"data": FAT_LADY_PASSWDS[0], "index": "0"}],
+                "will_invoke": True,
+            },
+            {
+                "attrname": "arr_str_trigger",
+                "value": [{"data": "", "index": "0"}],
+                "referral_key": [],
+                "will_invoke": False,
+            },
+            {
+                "attrname": "arr_str_trigger",
+                "value": [{"data": "Open Sesame", "index": "0"}],
+                "referral_key": [],
+                "will_invoke": False,
+            },
+            {
+                "attrname": "arr_str_trigger",
+                "value": [
+                    {"data": "Open Sesame", "index": "0"},
+                    {"data": FAT_LADY_PASSWDS[0], "index": "1"},
+                ],
+                "referral_key": [],
+                "will_invoke": True,
+            },
+            {"attrname": "arr_ref_trigger", "value": [], "referral_key": [], "will_invoke": False},
+            {
+                "attrname": "arr_ref_trigger",
+                "value": [
+                    {"data": self.entry_refs[0].id, "index": "0"},
+                    {"data": self.entry_refs[1].id, "index": "1"},
+                ],
+                "referral_key": [],
+                "will_invoke": False,
+            },
+            {
+                "attrname": "arr_ref_trigger",
+                "value": [
+                    {"data": self.entry_refs[0].id, "index": "0"},
+                    {"data": self.entry_refs[1].id, "index": "1"},
+                    {"data": self.entry_refs[2].id, "index": "2"},
+                ],
+                "referral_key": [],
+                "will_invoke": True,
+            },
+            {
+                "attrname": "arr_named_trigger",
+                "value": [{"data": self.entry_refs[0].id, "index": "0"}],
+                "referral_key": [{"data": "Open Sesame", "index": "0"}],
+                "will_invoke": False,
+            },
+            {
+                "attrname": "arr_named_trigger",
+                "value": [
+                    {"data": self.entry_refs[0].id, "index": "0"},
+                    {"data": self.entry_refs[2].id, "index": "1"},
+                ],
+                "referral_key": [
+                    {"data": "Open Sesame", "index": "0"},
+                    {"data": FAT_LADY_PASSWDS[0], "index": "1"},
+                ],
+                "will_invoke": True,
+            },
+        ]
+        for test_input_param in test_input_params:
+            attr = self.entity.attrs.get(name=test_input_param["attrname"])
+            actions = TriggerCondition.get_invoked_actions(
+                self.entity,
+                [
+                    {
+                        "entity_attr_id": attr.id,
+                        "value": test_input_param["value"],
+                        "referral_key": test_input_param["referral_key"],
+                    }
+                ],
+            )
+            if test_input_param["will_invoke"]:
+                self.assertGreaterEqual(len(actions), 1)
+            else:
+                self.assertEqual(len(actions), 0)
+
     def test_register_conditions_with_blank_values(self):
         # register TriggerCondition and its Actions
         settingTriggerAction = self.FULL_ACTION_CONFIGURATION_PARAMETERS.copy()[0]


### PR DESCRIPTION
In the Old UI, entity_attr_id is always included, so we changed it to use that.