### PR TITLE
Fixed search_entries when specified multi entity

### DIFF
--- a/entry/models.py
+++ b/entry/models.py
@@ -1,5 +1,6 @@
 import re
 from collections.abc import Iterable
+from copy import deepcopy
 from datetime import date, datetime
 from typing import Any, List, Optional, Type
 
@@ -2238,11 +2239,12 @@ class Entry(ACLBase):
             if "status" in resp and resp["status"] == 404:
                 continue
 
+            tmp_hint_attrs = deepcopy(hint_attrs)
             # Check for has permission to EntityAttr, when is_output_all flag
             if is_output_all:
                 for entity_attr in entity.attrs.filter(is_active=True):
-                    if entity_attr.name not in [x["name"] for x in hint_attrs if "name" in x]:
-                        hint_attrs.append(
+                    if entity_attr.name not in [x["name"] for x in tmp_hint_attrs if "name" in x]:
+                        tmp_hint_attrs.append(
                             {
                                 "name": entity_attr.name,
                                 "is_readable": True
@@ -2258,7 +2260,7 @@ class Entry(ACLBase):
             search_result = make_search_results(
                 user,
                 resp,
-                hint_attrs,
+                tmp_hint_attrs,
                 hint_referral,
                 limit,
             )

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -4430,6 +4430,23 @@ class ModelTest(AironeTestCase):
         )
         self.assertEqual(ret.ret_count, 0)
 
+        # multi entity case
+        test_entity = self.create_entity(
+            self._user, "test_entity", [{"name": "attr", "type": AttrType.STRING}]
+        )
+        self.add_entry(self._user, "test_entry", test_entity, {"attr": "fuga"})
+        ret = Entry.search_entries(
+            self._user, [self._entity.id, test_entity.id], is_output_all=True
+        )
+        self.assertEqual(
+            ret.ret_values[0].attrs,
+            {"attr": {"value": "hoge", "is_readable": True, "type": 2}},
+        )
+        self.assertEqual(
+            ret.ret_values[1].attrs,
+            {"attr": {"value": "fuga", "is_readable": True, "type": 2}},
+        )
+
     def test_search_entries_with_offset(self):
         entities = []
         for i in range(3):


### PR DESCRIPTION
The problem occurred under the following conditions:
- is_output_all: True
- attrinfo: []
- entities: multiple entities specified