### PR TITLE
Added helper class method Entry.get_referred_entries() to get referral Entries from multiple referred Entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## In development
 
 ### Added
+* Added helper class tmethod Entry.get_referred_entries() to get referral Entries from multiple referred Entries.
+  Contributed by @userlocalhost
 
 ### Changed
 


### PR DESCRIPTION
I want to get Entries that refer specified Entries.

In the current implementation, I can do it but only from single Entry.
(likely to get IP addresses (`192.168.0.x, 192.168.0.y, ...`) from specific Network (`192.168.0.0/24`))

I want to retrieve Entries across multiple referred Entries with a single request.
(likely to get IP addersses (`192.168.0.x, 10.0.y.z, ...`) from specific Networks (`192.168.0.0/24, 10.0.0.0/16`))

We can do it by small expand of current implementation of Entry.get_referred_object().