### PR TITLE
Simplify attrv relations

### DIFF
--- a/dashboard/tests/fixtures/entry.yaml
+++ b/dashboard/tests/fixtures/entry.yaml
@@ -29,22 +29,22 @@ Attribute:
 - {created_user: admin, entry_id: 14, id: 18, name: attr-arr-obj, schema_id: 7}
 
 AttributeValue:
-- {attribute_id: 15, created_time: '2017-08-29 03:07:21', created_user: admin, data_arr: '',
+- {attribute_id: 15, created_time: '2017-08-29 03:07:21', created_user: admin, parent_attrv: '',
   id: 101, refer: '', status: 0, value: 'I am srv001'}
-- {attribute_id: 16, created_time: '2017-08-29 03:07:21', created_user: admin, data_arr: '',
+- {attribute_id: 16, created_time: '2017-08-29 03:07:21', created_user: admin, parent_attrv: '',
   id: 102, refer: 8, status: 0, value: ''}
-- {attribute_id: 17, created_time: '2017-08-29 03:07:21', created_user: admin, data_arr: '104,105',
+- {attribute_id: 17, created_time: '2017-08-29 03:07:21', created_user: admin, parent_attrv: '',
   id: 103, refer: '', status: 1, value: ''}
-- {attribute_id: 17, created_time: '2017-08-29 03:07:21', created_user: admin, data_arr: '',
+- {attribute_id: 17, created_time: '2017-08-29 03:07:21', created_user: admin, parent_attrv: '103',
   id: 104, refer: '', status: 0, value: hoge}
-- {attribute_id: 17, created_time: '2017-08-29 03:07:21', created_user: admin, data_arr: '',
+- {attribute_id: 17, created_time: '2017-08-29 03:07:21', created_user: admin, parent_attrv: '103',
   id: 105, refer: '', status: 0, value: fuga}
-- {attribute_id: 18, created_time: '2017-08-29 03:07:22', created_user: admin, data_arr: '107,108',
+- {attribute_id: 18, created_time: '2017-08-29 03:07:22', created_user: admin, parent_attrv: '',
   id: 106, refer: '', status: 1, value: ''}
-- {attribute_id: 18, created_time: '2017-08-29 03:07:22', created_user: admin, data_arr: '',
+- {attribute_id: 18, created_time: '2017-08-29 03:07:22', created_user: admin, parent_attrv: '106',
   id: 107, refer: 11, status: 0, value: ''}
-- {attribute_id: 18, created_time: '2017-08-29 03:07:22', created_user: admin, data_arr: '',
+- {attribute_id: 18, created_time: '2017-08-29 03:07:22', created_user: admin, parent_attrv: '106',
   id: 108, refer: 12, status: 0, value: ''}
 # Create a new AttributeValue for String type Attribute
-- {attribute_id: 15, created_time: '2017-08-29 03:07:28', created_user: admin, data_arr: '',
+- {attribute_id: 15, created_time: '2017-08-29 03:07:28', created_user: admin, parent_attrv: '',
   id: 999, refer: '', status: 0, value: bar}

--- a/entry/admin.py
+++ b/entry/admin.py
@@ -26,7 +26,7 @@ class AttrValueResource(AironeModelResource):
             "created_time",
             "created_user",
             "status",
-            "data_arr",
+            "parent_attrv",
         ],
         "mandatory_keys": ["id", "attribute_id", "created_user", "status"],
         "resource_module": "entry.admin",
@@ -57,10 +57,10 @@ class AttrValueResource(AironeModelResource):
         attribute="created_user",
         widget=widgets.ForeignKeyWidget(User, "username"),
     )
-    data_arr = fields.Field(
-        column_name="data_arr",
-        attribute="data_array",
-        widget=widgets.ManyToManyWidget(model=AttributeValue, field="id"),
+    parent_attrv = fields.Field(
+        column_name="parent_attrv",
+        attribute="parent_attrv",
+        widget=widgets.ForeignKeyWidget(AttributeValue, "id"),
     )
 
     class Meta:
@@ -114,14 +114,6 @@ class AttrValueResource(AironeModelResource):
             if x["data"]["status"] & AttributeValue.STATUS_DATA_ARRAY_PARENT
         ]:
             attr_value = AttributeValue.objects.get(id=data["id"])
-            for child_id in [int(x) for x in data["data_arr"].split(",")]:
-                if (
-                    AttributeValue.objects.filter(id=child_id).exists()
-                    and not attr_value.data_array.filter(id=child_id).exists()
-                ):
-                    # append related AttributeValue if it's not existed
-                    attr_value.data_array.add(AttributeValue.objects.get(id=child_id))
-
             attr_value.parent_attr.parent_entry.register_es()
 
 

--- a/entry/models.py
+++ b/entry/models.py
@@ -49,7 +49,6 @@ class AttributeValue(models.Model):
         related_name="referred_attr_value",
         on_delete=models.SET_NULL,
     )
-    data_array = models.ManyToManyField("AttributeValue")
     created_time = models.DateTimeField(auto_now_add=True)
     created_user = models.ForeignKey(User, on_delete=models.DO_NOTHING)
     parent_attr = models.ForeignKey("Attribute", on_delete=models.DO_NOTHING)
@@ -89,7 +88,7 @@ class AttributeValue(models.Model):
     # This indicates the parent AttributeValue object, this parameter is usefull to identify
     # leaf AttriuteValue objects.
     parent_attrv = models.ForeignKey(
-        "AttributeValue", null=True, related_name="child", on_delete=models.SET_NULL
+        "AttributeValue", null=True, related_name="data_array", on_delete=models.SET_NULL
     )
 
     @classmethod


### PR DESCRIPTION
I guess some ManyToMany relations on Pagoda are redundant. How about simplifying it to 1:N relation? It makes relations simple, safe to keep that ( maintaining N->M, N<-M relations is so hard ) For now, I try to simplify parent - children AttributeValue relations.

NOTE it contains breaking changes on the DB schema and import export yaml format.