### PR TITLE
Added Docker volume for Elasticsearch data persistence

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
         hard: -1
     ports:
       - 9200:9200
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
 
   rabbitmq:
     image: rabbitmq:3.8.19-management
@@ -40,3 +42,6 @@ services:
 volumes:
   mysql:
     driver: local
+  elasticsearch-data:
+    driver: local
+


### PR DESCRIPTION
Configured Elasticsearch to use a persistent data volume for index retention.