### PR TITLE
Change Japanese words for specific things

### DIFF
--- a/frontend/src/components/entity/EntityBreadcrumbs.tsx
+++ b/frontend/src/components/entity/EntityBreadcrumbs.tsx
@@ -25,7 +25,7 @@ export const EntityBreadcrumbs: FC<Props> = ({ entity, attr, title }) => {
         Top
       </Typography>
       <Typography component={Link} to={entitiesPath()}>
-        エンティティ一覧
+        モデル一覧
       </Typography>
       {entity && (
         <StyledBox>

--- a/frontend/src/components/entity/EntityControlMenu.tsx
+++ b/frontend/src/components/entity/EntityControlMenu.tsx
@@ -49,7 +49,7 @@ export const EntityControlMenu: FC<Props> = ({
     await aironeApiClient
       .deleteEntity(entityId)
       .then(() => {
-        enqueueSnackbar("エンティティの削除が完了しました", {
+        enqueueSnackbar("モデルの削除が完了しました", {
           variant: "success",
         });
         // A magic to reload the entity list with keeping snackbar
@@ -58,7 +58,7 @@ export const EntityControlMenu: FC<Props> = ({
         setToggle && setToggle();
       })
       .catch(() => {
-        enqueueSnackbar("エンティティの削除が失敗しました", {
+        enqueueSnackbar("モデルの削除が失敗しました", {
           variant: "error",
         });
       });
@@ -66,11 +66,11 @@ export const EntityControlMenu: FC<Props> = ({
   const handleExport = async (entityId: number, format: ExportFormatType) => {
     try {
       await aironeApiClient.exportEntries(entityId, format);
-      enqueueSnackbar("エンティティのエクスポートのジョブ登録が成功しました", {
+      enqueueSnackbar("モデルのエクスポートのジョブ登録が成功しました", {
         variant: "success",
       });
     } catch (e) {
-      enqueueSnackbar("エンティティのエクスポートのジョブ登録が失敗しました", {
+      enqueueSnackbar("モデルのエクスポートのジョブ登録が失敗しました", {
         variant: "error",
       });
     }

--- a/frontend/src/components/entity/EntityControlMenu.tsx
+++ b/frontend/src/components/entity/EntityControlMenu.tsx
@@ -92,7 +92,7 @@ export const EntityControlMenu: FC<Props> = ({
       }}
     >
       <MenuItem component={Link} to={entityEntriesPath(entityId)}>
-        <Typography>エントリ一覧</Typography>
+        <Typography>アイテム一覧</Typography>
       </MenuItem>
       <MenuItem component={Link} to={editEntityPath(entityId)}>
         <Typography>編集</Typography>
@@ -126,7 +126,7 @@ export const EntityControlMenu: FC<Props> = ({
         <Typography>インポート</Typography>
       </MenuItem>
       <MenuItem component={Link} to={restoreEntryPath(entityId)}>
-        <Typography>削除エントリの復旧</Typography>
+        <Typography>削除アイテムの復旧</Typography>
       </MenuItem>
       <Confirmable
         componentGenerator={(handleOpen) => (

--- a/frontend/src/components/entity/EntityImportModal.tsx
+++ b/frontend/src/components/entity/EntityImportModal.tsx
@@ -20,7 +20,7 @@ export const EntityImportModal: FC<Props> = ({
 
   return (
     <AironeModal
-      title={"エンティティのインポート"}
+      title={"モデルのインポート"}
       description={"インポートするファイルを選択してください。"}
       caption={"※CSV形式のファイルは選択できません。"}
       open={openImportModal}

--- a/frontend/src/components/entity/EntityList.test.tsx
+++ b/frontend/src/components/entity/EntityList.test.tsx
@@ -55,11 +55,11 @@ describe("EntityList", () => {
 
     // specify keyword
     act(() => {
-      fireEvent.change(screen.getByPlaceholderText("エンティティを絞り込む"), {
+      fireEvent.change(screen.getByPlaceholderText("モデルを絞り込む"), {
         target: { value: "entity" },
       });
       fireEvent.keyPress(
-        screen.getByPlaceholderText("エンティティを絞り込む"),
+        screen.getByPlaceholderText("モデルを絞り込む"),
         {
           key: "Enter",
           code: 13,
@@ -67,7 +67,7 @@ describe("EntityList", () => {
         }
       );
     });
-    expect(screen.getByPlaceholderText("エンティティを絞り込む")).toHaveValue(
+    expect(screen.getByPlaceholderText("モデルを絞り込む")).toHaveValue(
       "entity"
     );
     expect(handleChangeQuery).toBeCalled();

--- a/frontend/src/components/entity/EntityList.test.tsx
+++ b/frontend/src/components/entity/EntityList.test.tsx
@@ -58,14 +58,11 @@ describe("EntityList", () => {
       fireEvent.change(screen.getByPlaceholderText("モデルを絞り込む"), {
         target: { value: "entity" },
       });
-      fireEvent.keyPress(
-        screen.getByPlaceholderText("モデルを絞り込む"),
-        {
-          key: "Enter",
-          code: 13,
-          charCode: 13,
-        }
-      );
+      fireEvent.keyPress(screen.getByPlaceholderText("モデルを絞り込む"), {
+        key: "Enter",
+        code: 13,
+        charCode: 13,
+      });
     });
     expect(screen.getByPlaceholderText("モデルを絞り込む")).toHaveValue(
       "entity"

--- a/frontend/src/components/entity/EntityList.tsx
+++ b/frontend/src/components/entity/EntityList.tsx
@@ -37,7 +37,7 @@ export const EntityList: FC<Props> = ({
       <Box display="flex" justifyContent="space-between" mb="16px">
         <Box width="600px">
           <SearchBox
-            placeholder="エンティティを絞り込む"
+            placeholder="モデルを絞り込む"
             value={keyword}
             onChange={(e) => setKeyword(e.target.value)}
             onKeyPress={(e) => {
@@ -55,7 +55,7 @@ export const EntityList: FC<Props> = ({
           to={newEntityPath()}
           sx={{ height: "48px", borderRadius: "24px" }}
         >
-          <AddIcon /> 新規エンティティを作成
+          <AddIcon /> 新規モデルを作成
         </Button>
       </Box>
 

--- a/frontend/src/components/entity/entityForm/AttributeField.tsx
+++ b/frontend/src/components/entity/entityForm/AttributeField.tsx
@@ -149,7 +149,7 @@ export const AttributeField: FC<Props> = ({
                     <TextField
                       {...params}
                       variant="outlined"
-                      placeholder="エンティティを選択"
+                      placeholder="モデルを選択"
                       disabled={!isWritable}
                     />
                   )}

--- a/frontend/src/components/entity/entityForm/BasicFields.test.tsx
+++ b/frontend/src/components/entity/entityForm/BasicFields.test.tsx
@@ -45,7 +45,7 @@ describe("BasicFields", () => {
     render(<BasicFields control={control} />, { wrapper: TestWrapper });
 
     act(() => {
-      fireEvent.change(screen.getByPlaceholderText("エンティティ名"), {
+      fireEvent.change(screen.getByPlaceholderText("モデル名"), {
         target: { value: "entity name" },
       });
       fireEvent.change(screen.getByPlaceholderText("備考"), {
@@ -54,7 +54,7 @@ describe("BasicFields", () => {
       screen.getByRole("checkbox").click();
     });
 
-    expect(screen.getByPlaceholderText("エンティティ名")).toHaveValue(
+    expect(screen.getByPlaceholderText("モデル名")).toHaveValue(
       "entity name"
     );
     expect(screen.getByPlaceholderText("備考")).toHaveValue("note");

--- a/frontend/src/components/entity/entityForm/BasicFields.test.tsx
+++ b/frontend/src/components/entity/entityForm/BasicFields.test.tsx
@@ -54,9 +54,7 @@ describe("BasicFields", () => {
       screen.getByRole("checkbox").click();
     });
 
-    expect(screen.getByPlaceholderText("モデル名")).toHaveValue(
-      "entity name"
-    );
+    expect(screen.getByPlaceholderText("モデル名")).toHaveValue("entity name");
     expect(screen.getByPlaceholderText("備考")).toHaveValue("note");
     expect(screen.getByRole("checkbox")).toBeChecked();
 

--- a/frontend/src/components/entity/entityForm/BasicFields.tsx
+++ b/frontend/src/components/entity/entityForm/BasicFields.tsx
@@ -50,7 +50,7 @@ export const BasicFields: FC<Props> = ({ control }) => {
         </TableHead>
         <TableBody>
           <StyledTableRow>
-            <TableCell>エンティティ名</TableCell>
+            <TableCell>モデル名</TableCell>
             <TableCell>
               <Controller
                 name="name"
@@ -61,7 +61,7 @@ export const BasicFields: FC<Props> = ({ control }) => {
                     {...field}
                     id="entity-name"
                     required
-                    placeholder="エンティティ名"
+                    placeholder="モデル名"
                     error={error != null}
                     helperText={error?.message}
                     size="small"

--- a/frontend/src/components/entity/entityForm/EntityFormSchema.ts
+++ b/frontend/src/components/entity/entityForm/EntityFormSchema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const schema = z.object({
-  name: z.string().min(1, "エンティティ名は必須です").default(""),
+  name: z.string().min(1, "モデル名は必須です").default(""),
   note: z.string().default(""),
   isToplevel: z.boolean().default(false),
   webhooks: z

--- a/frontend/src/components/entry/AdvancedSearchModal.tsx
+++ b/frontend/src/components/entry/AdvancedSearchModal.tsx
@@ -78,7 +78,7 @@ export const AdvancedSearchModal: FC<Props> = ({
       />
       <Box display="flex" justifyContent="center">
         <Box>
-          参照エントリも含める
+          参照アイテムも含める
           <Checkbox
             checked={hasReferral}
             onChange={(e) => setHasReferral(e.target.checked)}

--- a/frontend/src/components/entry/CopyForm.test.tsx
+++ b/frontend/src/components/entry/CopyForm.test.tsx
@@ -36,7 +36,7 @@ describe("CopyForm", () => {
     );
 
     act(() => {
-      fireEvent.change(screen.getByPlaceholderText("コピーするエントリ名"), {
+      fireEvent.change(screen.getByPlaceholderText("コピーするアイテム名"), {
         target: { value: "entry1\nentry2" },
       });
     });

--- a/frontend/src/components/entry/CopyForm.tsx
+++ b/frontend/src/components/entry/CopyForm.tsx
@@ -33,14 +33,14 @@ export const CopyForm: FC<CopyFormProps> = ({
       <Typography>
         {"入力した各行ごとに " +
           templateEntry.name.substring(0, 50) +
-          " と同じ属性を持つ別のエントリを作成"}
+          " と同じ属性を持つ別のアイテムを作成"}
       </Typography>
       <TextField
         id="copy-name"
         fullWidth
         minRows={6}
         maxRows={15}
-        placeholder="コピーするエントリ名"
+        placeholder="コピーするアイテム名"
         multiline
         value={entries}
         onChange={(e) => setEntries(e.target.value)}
@@ -51,12 +51,12 @@ export const CopyForm: FC<CopyFormProps> = ({
           SAMPLE
         </Typography>
         <Typography color="primary">
-          (Vm0001、vm0002、…vm006の6エントリを作成する場合)
+          (Vm0001、vm0002、…vm006の6アイテムを作成する場合)
         </Typography>
         <SampleTextField
           multiline
           disabled
-          label="コピーするエントリ名"
+          label="コピーするアイテム名"
           value="vm0001
 vm0002
 vm0003

--- a/frontend/src/components/entry/EntryBreadcrumbs.tsx
+++ b/frontend/src/components/entry/EntryBreadcrumbs.tsx
@@ -29,7 +29,7 @@ export const EntryBreadcrumbs: FC<Props> = ({ entry, title }) => {
         Top
       </Typography>
       <Typography component={Link} to={entitiesPath()}>
-        エンティティ一覧
+        モデル一覧
       </Typography>
       {entry && (
         <StyledBox>

--- a/frontend/src/components/entry/EntryControlMenu.tsx
+++ b/frontend/src/components/entry/EntryControlMenu.tsx
@@ -47,14 +47,14 @@ export const EntryControlMenu: FC<EntryControlProps> = ({
   const handleDelete = async (entryId: number) => {
     try {
       await aironeApiClient.destroyEntry(entryId);
-      enqueueSnackbar("エントリの削除が完了しました", {
+      enqueueSnackbar("アイテムの削除が完了しました", {
         variant: "success",
       });
       setToggle && setToggle();
       history.replace(topPath());
       history.replace(entityEntriesPath(entityId));
     } catch (e) {
-      enqueueSnackbar("エントリの削除が失敗しました", {
+      enqueueSnackbar("アイテムの削除が失敗しました", {
         variant: "error",
       });
     }

--- a/frontend/src/components/entry/EntryForm.tsx
+++ b/frontend/src/components/entry/EntryForm.tsx
@@ -94,7 +94,7 @@ export const EntryForm: FC<EntryFormProps> = ({
           component="a"
           href={`#name`}
           icon={<ArrowDropDownIcon />}
-          label="エントリ名"
+          label="アイテム名"
           clickable={true}
           variant="outlined"
         />
@@ -122,7 +122,7 @@ export const EntryForm: FC<EntryFormProps> = ({
           <TableRow>
             <StyledTableCell>
               <TableBox>
-                <StyledTypography id="name">エントリ名</StyledTypography>
+                <StyledTypography id="name">アイテム名</StyledTypography>
                 <RequiredLabel>必須</RequiredLabel>
               </TableBox>
             </StyledTableCell>

--- a/frontend/src/components/entry/EntryImportModal.tsx
+++ b/frontend/src/components/entry/EntryImportModal.tsx
@@ -19,7 +19,7 @@ export const EntryImportModal: FC<Props> = ({
 
   return (
     <AironeModal
-      title={"エントリのインポート"}
+      title={"アイテムのインポート"}
       description={"インポートするファイルを選択してください。"}
       caption={"※CSV形式のファイルは選択できません。"}
       open={openImportModal}

--- a/frontend/src/components/entry/EntryList.tsx
+++ b/frontend/src/components/entry/EntryList.tsx
@@ -52,7 +52,7 @@ export const EntryList: FC<Props> = ({ entityId, canCreateEntry = true }) => {
       <Box display="flex" justifyContent="space-between" mb="16px">
         <Box width="600px">
           <SearchBox
-            placeholder="エントリを絞り込む"
+            placeholder="アイテムを絞り込む"
             value={keyword}
             onChange={(e) => setKeyword(e.target.value)}
             onKeyPress={(e) => {
@@ -72,7 +72,7 @@ export const EntryList: FC<Props> = ({ entityId, canCreateEntry = true }) => {
           sx={{ borderRadius: "24px" }}
         >
           <AddIcon />
-          新規エントリを作成
+          新規アイテムを作成
         </Button>
       </Box>
 

--- a/frontend/src/components/entry/EntryReferral.tsx
+++ b/frontend/src/components/entry/EntryReferral.tsx
@@ -69,10 +69,10 @@ export const EntryReferral: FC<Props> = ({ entryId }) => {
     <Box>
       <Box px="16px">
         <ReferralCount id="ref_count">
-          {"関連づけられたエントリ(計" + count + ")"}
+          {"関連づけられたアイテム(計" + count + ")"}
         </ReferralCount>
         <SearchBox
-          placeholder="エントリを絞り込む"
+          placeholder="アイテムを絞り込む"
           value={keyword}
           onChange={(e) => {
             setKeyword(e.target.value);

--- a/frontend/src/components/entry/RestorableEntryList.tsx
+++ b/frontend/src/components/entry/RestorableEntryList.tsx
@@ -139,14 +139,14 @@ export const RestorableEntryList: FC<Props> = ({ entityId }) => {
     await aironeApiClient
       .restoreEntry(entryId)
       .then(() => {
-        enqueueSnackbar("エントリの復旧が完了しました", {
+        enqueueSnackbar("アイテムの復旧が完了しました", {
           variant: "success",
         });
         history.replace(topPath());
         history.replace(restoreEntryPath(entityId, keyword));
       })
       .catch(() => {
-        enqueueSnackbar("エントリの復旧が失敗しました", {
+        enqueueSnackbar("アイテムの復旧が失敗しました", {
           variant: "error",
         });
       });
@@ -158,7 +158,7 @@ export const RestorableEntryList: FC<Props> = ({ entityId }) => {
       <Box display="flex" justifyContent="space-between" mb="16px">
         <Box width="600px">
           <SearchBox
-            placeholder="エントリを絞り込む"
+            placeholder="アイテムを絞り込む"
             value={keyword}
             onChange={(e) => setKeyword(e.target.value)}
             onKeyPress={(e) => {

--- a/frontend/src/components/entry/SearchResultsTableHead.tsx
+++ b/frontend/src/components/entry/SearchResultsTableHead.tsx
@@ -178,7 +178,7 @@ export const SearchResultsTableHead: FC<Props> = ({
         <TableCell sx={{ witdh: "80px" }} />
         <StyledTableCell sx={{ outline: "1px solid #FFFFFF" }}>
           <HeaderBox>
-            <Typography>エントリ名</Typography>
+            <Typography>アイテム名</Typography>
             <StyledIconButton
               onClick={(e) => {
                 setEntryMenuEls(e.currentTarget);
@@ -260,7 +260,7 @@ export const SearchResultsTableHead: FC<Props> = ({
         {hasReferral && (
           <StyledTableCell sx={{ outline: "1px solid #FFFFFF" }}>
             <HeaderBox>
-              <Typography>参照エントリ</Typography>
+              <Typography>参照アイテム</Typography>
               <StyledIconButton
                 onClick={(e) => {
                   setReferralMenuEls(e.currentTarget);

--- a/frontend/src/components/entry/entryForm/EntryFormSchema.ts
+++ b/frontend/src/components/entry/entryForm/EntryFormSchema.ts
@@ -13,8 +13,8 @@ export const schema = schemaForType<EditableEntry>()(
     name: z
       .string()
       .trim()
-      .min(1, "エントリ名は必須です")
-      .max(200, "エントリ名が大きすぎます")
+      .min(1, "アイテム名は必須です")
+      .max(200, "アイテム名が大きすぎます")
       .default(""),
     schema: z.object({
       id: z.number(),

--- a/frontend/src/components/entry/entryForm/ObjectAttributeValueField.tsx
+++ b/frontend/src/components/entry/entryForm/ObjectAttributeValueField.tsx
@@ -100,7 +100,7 @@ export const ObjectAttributeValueField: FC<
 
   return (
     <Box>
-      <StyledTypography variant="caption">エントリを選択</StyledTypography>
+      <StyledTypography variant="caption">アイテムを選択</StyledTypography>
       <StyledBox>
         <Controller
           name={
@@ -206,7 +206,7 @@ export const NamedObjectAttributeValueField: FC<
         </BooleanBox>
       )}
       <Box flexGrow={1}>
-        <StyledTypography variant="caption">エントリを選択</StyledTypography>
+        <StyledTypography variant="caption">アイテムを選択</StyledTypography>
         <Controller
           name={
             index != null

--- a/frontend/src/components/job/JobList.tsx
+++ b/frontend/src/components/job/JobList.tsx
@@ -128,7 +128,7 @@ export const JobList: FC<Props> = ({ jobs }) => {
       <TableHead>
         <AironeTableHeadRow>
           <AironeTableHeadCell sx={{ width: "160px" }}>
-            対象エンティティ
+            対象モデル
           </AironeTableHeadCell>
           <AironeTableHeadCell sx={{ width: "120px" }}>
             状況

--- a/frontend/src/components/trigger/TriggerFormSchema.tsx
+++ b/frontend/src/components/trigger/TriggerFormSchema.tsx
@@ -7,7 +7,7 @@ export const schema = schemaForType<TriggerParent>()(
   z.object({
     id: z.number(), // Add the 'id' property
     entity: z.object({
-      id: z.number().min(1, "エンティティは必須です"),
+      id: z.number().min(1, "モデルは必須です"),
       name: z.string(),
       isPublic: z.boolean().optional(),
     }),

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -60,7 +60,7 @@ const resources = toResource({
   },
   ja: {
     translation: {
-      entities: "エンティティ一覧",
+      entities: "モデル一覧",
       advancedSearch: "高度な検索",
       management: "管理機能",
       manageUsers: "ユーザ管理",

--- a/frontend/src/pages/AdvancedSearchPage.test.tsx
+++ b/frontend/src/pages/AdvancedSearchPage.test.tsx
@@ -59,7 +59,7 @@ afterAll(() => server.close());
 
 describe("AdvancedSearchPage", () => {
   test("no entity is shown by specifying wrong hint", async () => {
-    const elemInputEntity = screen.getByPlaceholderText("エンティティを選択");
+    const elemInputEntity = screen.getByPlaceholderText("モデルを選択");
 
     // set wrong hint that there is no entity that have "hoge"
     fireEvent.change(elemInputEntity, { target: { value: "hoge" } });
@@ -70,7 +70,7 @@ describe("AdvancedSearchPage", () => {
   });
 
   test("part of entities are shown by specifying hint", async () => {
-    const elemInputEntity = screen.getByPlaceholderText("エンティティを選択");
+    const elemInputEntity = screen.getByPlaceholderText("モデルを選択");
 
     // write down text to the input field
     fireEvent.change(elemInputEntity, { target: { value: "2" } });
@@ -83,7 +83,7 @@ describe("AdvancedSearchPage", () => {
   });
 
   test("all entities are shown", async () => {
-    const elemInputEntity = screen.getByPlaceholderText("エンティティを選択");
+    const elemInputEntity = screen.getByPlaceholderText("モデルを選択");
 
     if (elemInputEntity.parentNode) {
       fireEvent.click(elemInputEntity.parentNode);
@@ -98,7 +98,7 @@ describe("AdvancedSearchPage", () => {
   });
 
   test("show all attributes that are related to the entity", async () => {
-    const elemInputEntity = screen.getByPlaceholderText("エンティティを選択");
+    const elemInputEntity = screen.getByPlaceholderText("モデルを選択");
 
     // write down text to the input field
     fireEvent.change(elemInputEntity, { target: { value: "2" } });
@@ -161,7 +161,7 @@ describe("AdvancedSearchPage", () => {
   });
 
   test("select 'Select All' in entity attr element", async () => {
-    const elemInputEntity = screen.getByPlaceholderText("エンティティを選択");
+    const elemInputEntity = screen.getByPlaceholderText("モデルを選択");
     fireEvent.change(elemInputEntity, { target: { value: "2" } });
 
     const optionsEntity = screen.getAllByRole("option");
@@ -200,7 +200,7 @@ describe("AdvancedSearchPage", () => {
   });
 
   test("show part of attributes by specifying hint attrs", async () => {
-    const elemInputEntity = screen.getByPlaceholderText("エンティティを選択");
+    const elemInputEntity = screen.getByPlaceholderText("モデルを選択");
     fireEvent.change(elemInputEntity, { target: { value: "2" } });
 
     const optionsEntity = screen.getAllByRole("option");
@@ -221,7 +221,7 @@ describe("AdvancedSearchPage", () => {
   });
 
   test("show no attribute by specifying wrong hint", async () => {
-    const elemInputEntity = screen.getByPlaceholderText("エンティティを選択");
+    const elemInputEntity = screen.getByPlaceholderText("モデルを選択");
     fireEvent.change(elemInputEntity, { target: { value: "2" } });
 
     const optionsEntity = screen.getAllByRole("option");
@@ -241,7 +241,7 @@ describe("AdvancedSearchPage", () => {
   });
 
   test("submit search button", async () => {
-    const elemInputEntity = screen.getByPlaceholderText("エンティティを選択");
+    const elemInputEntity = screen.getByPlaceholderText("モデルを選択");
     fireEvent.change(elemInputEntity, { target: { value: "2" } });
 
     const optionsEntity = screen.getAllByRole("option");

--- a/frontend/src/pages/AdvancedSearchPage.tsx
+++ b/frontend/src/pages/AdvancedSearchPage.tsx
@@ -132,9 +132,7 @@ export const AdvancedSearchPage: FC = () => {
 
       <Container>
         <StyledFlexColumnBox>
-          <StyledTypography variant="h4">
-            検索対象のモデル
-          </StyledTypography>
+          <StyledTypography variant="h4">検索対象のモデル</StyledTypography>
 
           <Autocomplete
             options={entities.value ?? []}

--- a/frontend/src/pages/AdvancedSearchPage.tsx
+++ b/frontend/src/pages/AdvancedSearchPage.tsx
@@ -190,7 +190,7 @@ export const AdvancedSearchPage: FC = () => {
             />
           )}
           <Box>
-            参照エントリも含める
+            参照アイテムも含める
             <Checkbox
               checked={hasReferral}
               onChange={(e) => setHasReferral(e.target.checked)}

--- a/frontend/src/pages/AdvancedSearchPage.tsx
+++ b/frontend/src/pages/AdvancedSearchPage.tsx
@@ -133,7 +133,7 @@ export const AdvancedSearchPage: FC = () => {
       <Container>
         <StyledFlexColumnBox>
           <StyledTypography variant="h4">
-            検索対象のエンティティ
+            検索対象のモデル
           </StyledTypography>
 
           <Autocomplete
@@ -150,7 +150,7 @@ export const AdvancedSearchPage: FC = () => {
               <TextField
                 {...params}
                 variant="outlined"
-                placeholder="エンティティを選択"
+                placeholder="モデルを選択"
               />
             )}
             multiple

--- a/frontend/src/pages/AdvancedSearchResultsPage.tsx
+++ b/frontend/src/pages/AdvancedSearchResultsPage.tsx
@@ -189,13 +189,13 @@ export const AdvancedSearchResultsPage: FC = () => {
   const handleBulkDelete = async () => {
     try {
       await aironeApiClient.destroyEntries(bulkOperationEntryIds);
-      enqueueSnackbar("複数エントリの削除に成功しました", {
+      enqueueSnackbar("複数アイテムの削除に成功しました", {
         variant: "success",
       });
       setBulkOperationEntryIds([]);
       setToggle(!toggle);
     } catch (e) {
-      enqueueSnackbar("複数エントリの削除に失敗しました", {
+      enqueueSnackbar("複数アイテムの削除に失敗しました", {
         variant: "error",
       });
     }

--- a/frontend/src/pages/EntityEditPage.tsx
+++ b/frontend/src/pages/EntityEditPage.tsx
@@ -29,7 +29,7 @@ export const EntityEditPage: FC = () => {
 
   const history = useHistory();
   const { enqueueSubmitResult } = useFormNotification(
-    "エンティティ",
+    "モデル",
     willCreate
   );
 
@@ -196,7 +196,7 @@ export const EntityEditPage: FC = () => {
 
       <PageHeader
         title={
-          entity?.value != null ? entity.value.name : "新規エンティティの作成"
+          entity?.value != null ? entity.value.name : "新規モデルの作成"
         }
         description={entity?.value && "エンティテイティ詳細 / 編集"}
         targetId={entity.value?.id}

--- a/frontend/src/pages/EntityEditPage.tsx
+++ b/frontend/src/pages/EntityEditPage.tsx
@@ -28,10 +28,7 @@ export const EntityEditPage: FC = () => {
   const willCreate = entityId === undefined;
 
   const history = useHistory();
-  const { enqueueSubmitResult } = useFormNotification(
-    "モデル",
-    willCreate
-  );
+  const { enqueueSubmitResult } = useFormNotification("モデル", willCreate);
 
   const {
     formState: { isValid, isDirty, isSubmitting, isSubmitSuccessful },
@@ -195,9 +192,7 @@ export const EntityEditPage: FC = () => {
       )}
 
       <PageHeader
-        title={
-          entity?.value != null ? entity.value.name : "新規モデルの作成"
-        }
+        title={entity?.value != null ? entity.value.name : "新規モデルの作成"}
         description={entity?.value && "エンティテイティ詳細 / 編集"}
         targetId={entity.value?.id}
         hasOngoingProcess={entity?.value?.hasOngoingChanges}

--- a/frontend/src/pages/EntityListPage.tsx
+++ b/frontend/src/pages/EntityListPage.tsx
@@ -49,10 +49,10 @@ export const EntityListPage: FC = () => {
         <Typography component={Link} to={topPath()}>
           Top
         </Typography>
-        <Typography color="textPrimary">エンティティ一覧</Typography>
+        <Typography color="textPrimary">モデル一覧</Typography>
       </AironeBreadcrumbs>
 
-      <PageHeader title="エンティティ一覧">
+      <PageHeader title="モデル一覧">
         <Box display="flex" alignItems="center">
           <Button
             variant="contained"

--- a/frontend/src/pages/EntryCopyPage.tsx
+++ b/frontend/src/pages/EntryCopyPage.tsx
@@ -53,14 +53,14 @@ export const EntryCopyPage: FC<Props> = ({ CopyForm = DefaultCopyForm }) => {
     try {
       await aironeApiClient.copyEntry(entryId, entries.split("\n"));
       setSubmitted(true);
-      enqueueSnackbar("エントリコピーのジョブ登録が成功しました", {
+      enqueueSnackbar("アイテムコピーのジョブ登録が成功しました", {
         variant: "success",
       });
       setTimeout(() => {
         history.replace(entityEntriesPath(entityId));
       }, 0.1);
     } catch {
-      enqueueSnackbar("エントリコピーのジョブ登録が失敗しました", {
+      enqueueSnackbar("アイテムコピーのジョブ登録が失敗しました", {
         variant: "error",
       });
     }
@@ -78,7 +78,7 @@ export const EntryCopyPage: FC<Props> = ({ CopyForm = DefaultCopyForm }) => {
 
       <PageHeader
         title={entry.value?.name ?? ""}
-        description="エントリのコピーを作成"
+        description="アイテムのコピーを作成"
       >
         <SubmitButton
           name="コピーを作成"

--- a/frontend/src/pages/EntryDetailsPage.tsx
+++ b/frontend/src/pages/EntryDetailsPage.tsx
@@ -102,7 +102,7 @@ export const EntryDetailsPage: FC<Props> = ({
     <FlexBox>
       <EntryBreadcrumbs entry={entry.value} />
 
-      <PageHeader title={entry.value?.name ?? ""} description="エントリ詳細">
+      <PageHeader title={entry.value?.name ?? ""} description="アイテム詳細">
         <ChipBox>
           <Stack direction="row" spacing={1}>
             {[

--- a/frontend/src/pages/EntryEditPage.tsx
+++ b/frontend/src/pages/EntryEditPage.tsx
@@ -46,7 +46,7 @@ export const EntryEditPage: FC<Props> = ({
   const willCreate = entryId == null;
 
   const history = useHistory();
-  const { enqueueSubmitResult } = useFormNotification("エントリ", willCreate);
+  const { enqueueSubmitResult } = useFormNotification("アイテム", willCreate);
 
   const [initialized, setInitialized] = useState(false);
 
@@ -168,8 +168,8 @@ export const EntryEditPage: FC<Props> = ({
       )}
 
       <PageHeader
-        title={entry?.value != null ? entry.value.name : "新規エントリの作成"}
-        description={entry?.value != null ? "エントリ編集" : undefined}
+        title={entry?.value != null ? entry.value.name : "新規アイテムの作成"}
+        description={entry?.value != null ? "アイテム編集" : undefined}
       >
         <SubmitButton
           name="保存"

--- a/frontend/src/pages/EntryListPage.tsx
+++ b/frontend/src/pages/EntryListPage.tsx
@@ -33,7 +33,7 @@ export const EntryListPage: FC<Props> = ({ canCreateEntry = true }) => {
 
       <PageHeader
         title={entity.value?.name ?? ""}
-        description="エントリ一覧"
+        description="アイテム一覧"
         targetId={entity.value?.id}
         hasOngoingProcess={entity.value?.hasOngoingChanges}
       >

--- a/frontend/src/pages/EntryRestorePage.tsx
+++ b/frontend/src/pages/EntryRestorePage.tsx
@@ -29,7 +29,7 @@ export const EntryRestorePage: FC = () => {
 
       <PageHeader
         title={entity.value?.name ?? ""}
-        description="削除エントリの復旧"
+        description="削除アイテムの復旧"
       >
         <Box width="50px">
           <IconButton

--- a/frontend/src/pages/TriggerEditPage.tsx
+++ b/frontend/src/pages/TriggerEditPage.tsx
@@ -318,7 +318,7 @@ export const TriggerEditPage: FC = () => {
 
       <Container>
         <StyledFlexColumnBox>
-          <Typography variant="h4">設定対象のエンティティ</Typography>
+          <Typography variant="h4">設定対象のモデル</Typography>
 
           <Controller
             name={`entity`}
@@ -350,7 +350,7 @@ export const TriggerEditPage: FC = () => {
                   <TextField
                     {...params}
                     variant="outlined"
-                    placeholder="エンティティを選択"
+                    placeholder="モデルを選択"
                   />
                 )}
                 fullWidth

--- a/frontend/src/pages/TriggerListPage.tsx
+++ b/frontend/src/pages/TriggerListPage.tsx
@@ -261,7 +261,7 @@ export const TriggerListPage: FC = () => {
                 <TableHead>
                   <HeaderTableRow>
                     <HeaderTableCell width="200px">
-                      エンティティ
+                      モデル
                     </HeaderTableCell>
                     <HeaderTableCell width="420px">条件</HeaderTableCell>
                     <HeaderTableCell width="420px">アクション</HeaderTableCell>

--- a/frontend/src/pages/TriggerListPage.tsx
+++ b/frontend/src/pages/TriggerListPage.tsx
@@ -260,9 +260,7 @@ export const TriggerListPage: FC = () => {
               <Table data-testid="TriggerList">
                 <TableHead>
                   <HeaderTableRow>
-                    <HeaderTableCell width="200px">
-                      モデル
-                    </HeaderTableCell>
+                    <HeaderTableCell width="200px">モデル</HeaderTableCell>
                     <HeaderTableCell width="420px">条件</HeaderTableCell>
                     <HeaderTableCell width="420px">アクション</HeaderTableCell>
                     <HeaderTableCell width="20px"></HeaderTableCell>

--- a/frontend/src/pages/__snapshots__/AdvancedSearchResultsPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/AdvancedSearchResultsPage.test.tsx.snap
@@ -221,7 +221,7 @@ exports[`should match snapshot 1`] = `
                           <p
                             class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                           >
-                            エントリ名
+                            アイテム名
                           </p>
                           <button
                             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-tzk60-MuiButtonBase-root-MuiIconButton-root"
@@ -587,7 +587,7 @@ exports[`should match snapshot 1`] = `
                         <p
                           class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                         >
-                          エントリ名
+                          アイテム名
                         </p>
                         <button
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-tzk60-MuiButtonBase-root-MuiIconButton-root"

--- a/frontend/src/pages/__snapshots__/EntityEditPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntityEditPage.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`EditEntityPage should match snapshot 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                       href="/ui/entities"
                     >
-                      エンティティ一覧
+                      モデル一覧
                     </a>
                   </li>
                   <li
@@ -196,7 +196,7 @@ exports[`EditEntityPage should match snapshot 1`] = `
                   <td
                     class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1ex1afd-MuiTableCell-root"
                   >
-                    エンティティ名
+                    モデル名
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1ex1afd-MuiTableCell-root"
@@ -212,7 +212,7 @@ exports[`EditEntityPage should match snapshot 1`] = `
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
                           id="entity-name"
                           name="name"
-                          placeholder="エンティティ名"
+                          placeholder="モデル名"
                           required=""
                           type="text"
                           value=""
@@ -610,7 +610,7 @@ exports[`EditEntityPage should match snapshot 1`] = `
                     class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     href="/ui/entities"
                   >
-                    エンティティ一覧
+                    モデル一覧
                   </a>
                 </li>
                 <li
@@ -759,7 +759,7 @@ exports[`EditEntityPage should match snapshot 1`] = `
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1ex1afd-MuiTableCell-root"
                 >
-                  エンティティ名
+                  モデル名
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1ex1afd-MuiTableCell-root"
@@ -775,7 +775,7 @@ exports[`EditEntityPage should match snapshot 1`] = `
                         class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
                         id="entity-name"
                         name="name"
-                        placeholder="エンティティ名"
+                        placeholder="モデル名"
                         required=""
                         type="text"
                         value=""

--- a/frontend/src/pages/__snapshots__/EntityHistoryPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntityHistoryPage.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`should match snapshot 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                       href="/ui/entities"
                     >
-                      エンティティ一覧
+                      モデル一覧
                     </a>
                   </li>
                   <li
@@ -421,7 +421,7 @@ exports[`should match snapshot 1`] = `
                     class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     href="/ui/entities"
                   >
-                    エンティティ一覧
+                    モデル一覧
                   </a>
                 </li>
                 <li

--- a/frontend/src/pages/__snapshots__/EntityListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntityListPage.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`should match snapshot 1`] = `
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1gqyz35-MuiTypography-root"
                     >
-                      エンティティ一覧
+                      モデル一覧
                     </p>
                   </li>
                 </ol>
@@ -67,7 +67,7 @@ exports[`should match snapshot 1`] = `
                 class="MuiTypography-root MuiTypography-h6 css-178toxd-MuiTypography-root"
                 id="title"
               >
-                エンティティ一覧
+                モデル一覧
               </h6>
               <h6
                 class="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
@@ -149,7 +149,7 @@ exports[`should match snapshot 1`] = `
                       aria-invalid="false"
                       class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
                       id=":r0:"
-                      placeholder="エンティティを絞り込む"
+                      placeholder="モデルを絞り込む"
                       type="text"
                       value=""
                     />
@@ -186,7 +186,7 @@ exports[`should match snapshot 1`] = `
                     d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
                   />
                 </svg>
-                 新規エンティティを作成
+                 新規モデルを作成
               </a>
             </div>
             <div
@@ -555,7 +555,7 @@ exports[`should match snapshot 1`] = `
                   <p
                     class="MuiTypography-root MuiTypography-body1 css-1gqyz35-MuiTypography-root"
                   >
-                    エンティティ一覧
+                    モデル一覧
                   </p>
                 </li>
               </ol>
@@ -576,7 +576,7 @@ exports[`should match snapshot 1`] = `
               class="MuiTypography-root MuiTypography-h6 css-178toxd-MuiTypography-root"
               id="title"
             >
-              エンティティ一覧
+              モデル一覧
             </h6>
             <h6
               class="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
@@ -658,7 +658,7 @@ exports[`should match snapshot 1`] = `
                     aria-invalid="false"
                     class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
                     id=":r0:"
-                    placeholder="エンティティを絞り込む"
+                    placeholder="モデルを絞り込む"
                     type="text"
                     value=""
                   />
@@ -695,7 +695,7 @@ exports[`should match snapshot 1`] = `
                   d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
                 />
               </svg>
-               新規エンティティを作成
+               新規モデルを作成
             </a>
           </div>
           <div

--- a/frontend/src/pages/__snapshots__/EntryCopyPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryCopyPage.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`should match snapshot 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                       href="/ui/entities"
                     >
-                      エンティティ一覧
+                      モデル一覧
                     </a>
                   </li>
                   <li
@@ -151,7 +151,7 @@ exports[`should match snapshot 1`] = `
                 class="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
                 id="description"
               >
-                エントリのコピーを作成
+                アイテムのコピーを作成
               </h6>
               <div
                 class="MuiBox-root css-1b3gh38"
@@ -188,7 +188,7 @@ exports[`should match snapshot 1`] = `
           <p
             class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
           >
-            入力した各行ごとに aaa と同じ属性を持つ別のエントリを作成
+            入力した各行ごとに aaa と同じ属性を持つ別のアイテムを作成
           </p>
           <div
             class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
@@ -200,7 +200,7 @@ exports[`should match snapshot 1`] = `
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-347vvv-MuiInputBase-input-MuiOutlinedInput-input"
                 id="copy-name"
-                placeholder="コピーするエントリ名"
+                placeholder="コピーするアイテム名"
                 style="height: 0px; overflow: hidden;"
               />
               <textarea
@@ -237,7 +237,7 @@ exports[`should match snapshot 1`] = `
             <p
               class="MuiTypography-root MuiTypography-body1 css-vkc4v8-MuiTypography-root"
             >
-              (Vm0001、vm0002、…vm006の6エントリを作成する場合)
+              (Vm0001、vm0002、…vm006の6アイテムを作成する場合)
             </p>
             <div
               class="MuiFormControl-root MuiTextField-root css-ksw8wi-MuiFormControl-root-MuiTextField-root"
@@ -248,7 +248,7 @@ exports[`should match snapshot 1`] = `
                 for=":r1:"
                 id=":r1:-label"
               >
-                コピーするエントリ名
+                コピーするアイテム名
               </label>
               <div
                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl MuiInputBase-multiline css-dpjnhs-MuiInputBase-root-MuiOutlinedInput-root"
@@ -282,7 +282,7 @@ vm0006
                     class="css-14lo706"
                   >
                     <span>
-                      コピーするエントリ名
+                      コピーするアイテム名
                     </span>
                   </legend>
                 </fieldset>
@@ -336,7 +336,7 @@ vm0006
                     class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     href="/ui/entities"
                   >
-                    エンティティ一覧
+                    モデル一覧
                   </a>
                 </li>
                 <li
@@ -440,7 +440,7 @@ vm0006
               class="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
               id="description"
             >
-              エントリのコピーを作成
+              アイテムのコピーを作成
             </h6>
             <div
               class="MuiBox-root css-1b3gh38"
@@ -477,7 +477,7 @@ vm0006
         <p
           class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
         >
-          入力した各行ごとに aaa と同じ属性を持つ別のエントリを作成
+          入力した各行ごとに aaa と同じ属性を持つ別のアイテムを作成
         </p>
         <div
           class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
@@ -489,7 +489,7 @@ vm0006
               aria-invalid="false"
               class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-347vvv-MuiInputBase-input-MuiOutlinedInput-input"
               id="copy-name"
-              placeholder="コピーするエントリ名"
+              placeholder="コピーするアイテム名"
               style="height: 0px; overflow: hidden;"
             />
             <textarea
@@ -526,7 +526,7 @@ vm0006
           <p
             class="MuiTypography-root MuiTypography-body1 css-vkc4v8-MuiTypography-root"
           >
-            (Vm0001、vm0002、…vm006の6エントリを作成する場合)
+            (Vm0001、vm0002、…vm006の6アイテムを作成する場合)
           </p>
           <div
             class="MuiFormControl-root MuiTextField-root css-ksw8wi-MuiFormControl-root-MuiTextField-root"
@@ -537,7 +537,7 @@ vm0006
               for=":r1:"
               id=":r1:-label"
             >
-              コピーするエントリ名
+              コピーするアイテム名
             </label>
             <div
               class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl MuiInputBase-multiline css-dpjnhs-MuiInputBase-root-MuiOutlinedInput-root"
@@ -571,7 +571,7 @@ vm0006
                   class="css-14lo706"
                 >
                   <span>
-                    コピーするエントリ名
+                    コピーするアイテム名
                   </span>
                 </legend>
               </fieldset>

--- a/frontend/src/pages/__snapshots__/EntryDetailsPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryDetailsPage.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`should match snapshot 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                       href="/ui/entities"
                     >
-                      エンティティ一覧
+                      モデル一覧
                     </a>
                   </li>
                   <li
@@ -136,7 +136,7 @@ exports[`should match snapshot 1`] = `
                 class="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
                 id="description"
               >
-                エントリ詳細
+                アイテム詳細
               </h6>
               <div
                 class="MuiBox-root css-1b3gh38"
@@ -223,7 +223,7 @@ exports[`should match snapshot 1`] = `
                   class="MuiTypography-root MuiTypography-body1 css-9md421-MuiTypography-root"
                   id="ref_count"
                 >
-                  関連づけられたエントリ(計1)
+                  関連づけられたアイテム(計1)
                 </p>
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-miwl14-MuiFormControl-root-MuiTextField-root"
@@ -255,7 +255,7 @@ exports[`should match snapshot 1`] = `
                       aria-invalid="false"
                       class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
                       id=":r0:"
-                      placeholder="エントリを絞り込む"
+                      placeholder="アイテムを絞り込む"
                       type="text"
                       value=""
                     />
@@ -476,7 +476,7 @@ exports[`should match snapshot 1`] = `
                     class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     href="/ui/entities"
                   >
-                    エンティティ一覧
+                    モデル一覧
                   </a>
                 </li>
                 <li
@@ -565,7 +565,7 @@ exports[`should match snapshot 1`] = `
               class="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
               id="description"
             >
-              エントリ詳細
+              アイテム詳細
             </h6>
             <div
               class="MuiBox-root css-1b3gh38"
@@ -652,7 +652,7 @@ exports[`should match snapshot 1`] = `
                 class="MuiTypography-root MuiTypography-body1 css-9md421-MuiTypography-root"
                 id="ref_count"
               >
-                関連づけられたエントリ(計1)
+                関連づけられたアイテム(計1)
               </p>
               <div
                 class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-miwl14-MuiFormControl-root-MuiTextField-root"
@@ -684,7 +684,7 @@ exports[`should match snapshot 1`] = `
                     aria-invalid="false"
                     class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
                     id=":r0:"
-                    placeholder="エントリを絞り込む"
+                    placeholder="アイテムを絞り込む"
                     type="text"
                     value=""
                   />

--- a/frontend/src/pages/__snapshots__/EntryEditPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryEditPage.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`EntryEditPage should match snapshot 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                       href="/ui/entities"
                     >
-                      エンティティ一覧
+                      モデル一覧
                     </a>
                   </li>
                   <li
@@ -151,7 +151,7 @@ exports[`EntryEditPage should match snapshot 1`] = `
                 class="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
                 id="description"
               >
-                エントリ編集
+                アイテム編集
               </h6>
               <div
                 class="MuiBox-root css-1b3gh38"
@@ -228,7 +228,7 @@ exports[`EntryEditPage should match snapshot 1`] = `
                     class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     href="/ui/entities"
                   >
-                    エンティティ一覧
+                    モデル一覧
                   </a>
                 </li>
                 <li
@@ -332,7 +332,7 @@ exports[`EntryEditPage should match snapshot 1`] = `
               class="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
               id="description"
             >
-              エントリ編集
+              アイテム編集
             </h6>
             <div
               class="MuiBox-root css-1b3gh38"

--- a/frontend/src/pages/__snapshots__/EntryHistoryListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryHistoryListPage.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`should match snapshot 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                       href="/ui/entities"
                     >
-                      エンティティ一覧
+                      モデル一覧
                     </a>
                   </li>
                   <li
@@ -360,7 +360,7 @@ exports[`should match snapshot 1`] = `
                     class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     href="/ui/entities"
                   >
-                    エンティティ一覧
+                    モデル一覧
                   </a>
                 </li>
                 <li

--- a/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`should match snapshot 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                       href="/ui/entities"
                     >
-                      エンティティ一覧
+                      モデル一覧
                     </a>
                   </li>
                   <li
@@ -105,7 +105,7 @@ exports[`should match snapshot 1`] = `
                 class="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
                 id="description"
               >
-                エントリ一覧
+                アイテム一覧
               </h6>
               <div
                 class="MuiBox-root css-1b3gh38"
@@ -184,7 +184,7 @@ exports[`should match snapshot 1`] = `
                       aria-invalid="false"
                       class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
                       id=":r0:"
-                      placeholder="エントリを絞り込む"
+                      placeholder="アイテムを絞り込む"
                       type="text"
                       value=""
                     />
@@ -221,7 +221,7 @@ exports[`should match snapshot 1`] = `
                     d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
                   />
                 </svg>
-                新規エントリを作成
+                新規アイテムを作成
                 <span
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
@@ -573,7 +573,7 @@ exports[`should match snapshot 1`] = `
                     class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     href="/ui/entities"
                   >
-                    エンティティ一覧
+                    モデル一覧
                   </a>
                 </li>
                 <li
@@ -631,7 +631,7 @@ exports[`should match snapshot 1`] = `
               class="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
               id="description"
             >
-              エントリ一覧
+              アイテム一覧
             </h6>
             <div
               class="MuiBox-root css-1b3gh38"
@@ -710,7 +710,7 @@ exports[`should match snapshot 1`] = `
                     aria-invalid="false"
                     class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
                     id=":r0:"
-                    placeholder="エントリを絞り込む"
+                    placeholder="アイテムを絞り込む"
                     type="text"
                     value=""
                   />
@@ -747,7 +747,7 @@ exports[`should match snapshot 1`] = `
                   d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
                 />
               </svg>
-              新規エントリを作成
+              新規アイテムを作成
               <span
                 class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
               />

--- a/frontend/src/pages/__snapshots__/EntryRestorePage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryRestorePage.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`should match snapshot 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                       href="/ui/entities"
                     >
-                      エンティティ一覧
+                      モデル一覧
                     </a>
                   </li>
                   <li
@@ -120,7 +120,7 @@ exports[`should match snapshot 1`] = `
                 class="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
                 id="description"
               >
-                削除エントリの復旧
+                削除アイテムの復旧
               </h6>
               <div
                 class="MuiBox-root css-1b3gh38"
@@ -199,7 +199,7 @@ exports[`should match snapshot 1`] = `
                       aria-invalid="false"
                       class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
                       id=":r0:"
-                      placeholder="エントリを絞り込む"
+                      placeholder="アイテムを絞り込む"
                       type="text"
                       value=""
                     />
@@ -516,7 +516,7 @@ exports[`should match snapshot 1`] = `
                     class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
                     href="/ui/entities"
                   >
-                    エンティティ一覧
+                    モデル一覧
                   </a>
                 </li>
                 <li
@@ -589,7 +589,7 @@ exports[`should match snapshot 1`] = `
               class="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
               id="description"
             >
-              削除エントリの復旧
+              削除アイテムの復旧
             </h6>
             <div
               class="MuiBox-root css-1b3gh38"
@@ -668,7 +668,7 @@ exports[`should match snapshot 1`] = `
                     aria-invalid="false"
                     class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
                     id=":r0:"
-                    placeholder="エントリを絞り込む"
+                    placeholder="アイテムを絞り込む"
                     type="text"
                     value=""
                   />

--- a/frontend/src/pages/__snapshots__/JobListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/JobListPage.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`should match snapshot 1`] = `
                   class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-he8p15-MuiTableCell-root"
                   scope="col"
                 >
-                  対象エンティティ
+                  対象モデル
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1fyhwmv-MuiTableCell-root"
@@ -518,7 +518,7 @@ exports[`should match snapshot 1`] = `
                 class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-he8p15-MuiTableCell-root"
                 scope="col"
               >
-                対象エンティティ
+                対象モデル
               </th>
               <th
                 class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1fyhwmv-MuiTableCell-root"

--- a/frontend/src/pages/__snapshots__/TriggerEditPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/TriggerEditPage.test.tsx.snap
@@ -130,7 +130,7 @@ exports[`EditTriggerPage should match snapshot 1`] = `
             <h4
               class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
             >
-              設定対象のエンティティ
+              設定対象のモデル
             </h4>
             <div
               class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasPopupIcon css-1kkal6p-MuiAutocomplete-root"
@@ -150,7 +150,7 @@ exports[`EditTriggerPage should match snapshot 1`] = `
                     class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
                     disabled=""
                     id=":r0:"
-                    placeholder="エンティティを選択"
+                    placeholder="モデルを選択"
                     role="combobox"
                     spellcheck="false"
                     type="text"
@@ -328,7 +328,7 @@ exports[`EditTriggerPage should match snapshot 1`] = `
           <h4
             class="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
           >
-            設定対象のエンティティ
+            設定対象のモデル
           </h4>
           <div
             class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasPopupIcon css-1kkal6p-MuiAutocomplete-root"
@@ -348,7 +348,7 @@ exports[`EditTriggerPage should match snapshot 1`] = `
                   class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
                   disabled=""
                   id=":r0:"
-                  placeholder="エンティティを選択"
+                  placeholder="モデルを選択"
                   role="combobox"
                   spellcheck="false"
                   type="text"

--- a/frontend/src/pages/__snapshots__/TriggerListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/TriggerListPage.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`TriggerPage should match snapshot 1`] = `
                     scope="col"
                     width="200px"
                   >
-                    エンティティ
+                    モデル
                   </th>
                   <th
                     class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-flimy0-MuiTableCell-root"
@@ -422,7 +422,7 @@ exports[`TriggerPage should match snapshot 1`] = `
                   scope="col"
                   width="200px"
                 >
-                  エンティティ
+                  モデル
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-flimy0-MuiTableCell-root"


### PR DESCRIPTION
This PR changes following words in accordance with understandability, but only at NewUI pages.
* `エンティティ` →  `モデル`
* `エントリ` → `アイテム`