### PR TITLE
Simplify Entry - Attribute relation 1:N

### DIFF
--- a/airone/tests/test_elasticsearch.py
+++ b/airone/tests/test_elasticsearch.py
@@ -403,7 +403,6 @@ class ElasticSearchTest(TestCase):
         attr_value = AttributeValue.objects.create(
             value="test_attr_value", created_user=self._user, parent_attr=attr
         )
-        entry.attrs.add(attr)
         attr.values.add(attr_value)
         attr.save()
 

--- a/dashboard/tests/test_view.py
+++ b/dashboard/tests/test_view.py
@@ -1130,10 +1130,6 @@ class ViewTest(AironeViewTest):
                 parent_entry=test_entry,
             )
 
-            test_attr.save()
-            test_entry.attrs.add(test_attr)
-            test_entry.save()
-
             test_val = None
 
             if type & AttrType._ARRAY == 0:

--- a/entry/admin.py
+++ b/entry/admin.py
@@ -156,7 +156,6 @@ class AttrResource(AironeModelResource):
             entry = instance.parent_entry
 
             if not entry.attrs.filter(id=instance.id).exists():
-                entry.attrs.add(instance)
                 entry.register_es()
 
 

--- a/entry/models.py
+++ b/entry/models.py
@@ -521,7 +521,7 @@ class Attribute(ACLBase):
 
     # This parameter is needed to make a relationship with corresponding EntityAttr
     schema = models.ForeignKey(EntityAttr, on_delete=models.DO_NOTHING)
-    parent_entry = models.ForeignKey("Entry", on_delete=models.DO_NOTHING)
+    parent_entry = models.ForeignKey("Entry", related_name="attrs", on_delete=models.DO_NOTHING)
 
     class Meta:
         constraints = [
@@ -1448,7 +1448,6 @@ class Entry(ACLBase):
     STATUS_EDITING = 1 << 1
     STATUS_COMPLEMENTING_ATTRS = 1 << 2
 
-    attrs = models.ManyToManyField(Attribute)
     schema = models.ForeignKey(Entity, on_delete=models.DO_NOTHING)
 
     history = HistoricalRecords(excluded_fields=["status", "updated_time"])
@@ -1475,8 +1474,6 @@ class Entry(ACLBase):
                 "created_user": request_user,
             },
         )
-        if is_created:
-            self.attrs.add(attr)
         return attr
 
     def get_prev_refers_objects(self) -> QuerySet:
@@ -1856,10 +1853,7 @@ class Entry(ACLBase):
         cloned_entry.save()
 
         for attr in self.attrs.filter(is_active=True):
-            cloned_attr = attr.clone(user, parent_entry=cloned_entry)
-
-            if cloned_attr:
-                cloned_entry.attrs.add(cloned_attr)
+            attr.clone(user, parent_entry=cloned_entry)
 
         cloned_entry.del_status(Entry.STATUS_CREATING)
         return cloned_entry

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -2364,10 +2364,6 @@ class ViewTest(BaseViewTest):
                 parent_entry=test_entry,
             )
 
-            test_attr.save()
-            test_entry.attrs.add(test_attr)
-            test_entry.save()
-
             test_val = None
 
             if type & AttrType._ARRAY == 0:
@@ -3844,10 +3840,6 @@ class ViewTest(BaseViewTest):
                 created_user=user,
                 parent_entry=test_entry,
             )
-
-            test_attr.save()
-            test_entry.attrs.add(test_attr)
-            test_entry.save()
 
             test_val = None
 

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -164,7 +164,6 @@ class ModelTest(AironeTestCase):
         entry.save()
 
         attr = self.make_attr("attr", entry=entry)
-        entry.attrs.add(attr)
 
         self.assertEqual(Entry.objects.count(), 2)
         self.assertEqual(Entry.objects.last().created_user, self._user)
@@ -679,9 +678,6 @@ class ModelTest(AironeTestCase):
         # set another referral value to the 'attr_arr_ref' attr
         arr_attr.add_value(self._user, [entry1, entry2])
 
-        self._entry.attrs.add(attr)
-        self._entry.attrs.add(arr_attr)
-
         # This function checks that this get_referred_objects method only get
         # unique reference objects except for the self referred object.
         for entry in [entry1, entry2]:
@@ -758,8 +754,6 @@ class ModelTest(AironeTestCase):
                 )
             )
 
-            entry.attrs.add(attr)
-
         # This function checks that this get_referred_objects method only get
         # unique reference objects except for the self referred object.
         referred_entries = self._entry.get_referred_objects()
@@ -785,7 +779,7 @@ class ModelTest(AironeTestCase):
         # create new attributes which are appended after creation of Entity
         self._entry.complement_attrs(self._user)
 
-        self.assertEqual(self._entry.attrs.count(), 1)
+        self.assertEqual(self._entry.attrs.count(), 2)
         self.assertEqual(self._entry.attrs.last().schema, newattr)
 
     def test_get_value_history(self):
@@ -827,8 +821,6 @@ class ModelTest(AironeTestCase):
         entry = Entry.objects.create(name="entry", created_user=self._user, schema=entity)
 
         attr = self.make_attr("attr_ref", attrtype=AttrType.OBJECT)
-
-        self._entry.attrs.add(attr)
 
         # make a self reference value
         attr.values.add(
@@ -1336,7 +1328,6 @@ class ModelTest(AironeTestCase):
 
     def test_get_available_attrs_with_multi_attribute_value(self):
         self._entity.attrs.add(self._attr.schema)
-        self._entry.attrs.add(self._attr)
 
         attr = self._entry.attrs.filter(schema=self._attr.schema, is_active=True).first()
         attr.add_value(self._user, "hoge")
@@ -4453,7 +4444,6 @@ class ModelTest(AironeTestCase):
 
     def test_search_entries_with_is_output_all(self):
         self._entity.attrs.add(self._attr.schema)
-        self._entry.attrs.add(self._attr)
         self._entry.attrs.first().add_value(self._user, "hoge")
         self._entry.register_es()
         ret = Entry.search_entries(self._user, [self._entity.id], is_output_all=True)
@@ -4520,7 +4510,6 @@ class ModelTest(AironeTestCase):
 
     def test_search_entries_for_simple(self):
         self._entity.attrs.add(self._attr.schema)
-        self._entry.attrs.add(self._attr)
         self._entry.attrs.first().add_value(self._user, "hoge")
         self._entry.register_es()
 
@@ -4811,7 +4800,6 @@ class ModelTest(AironeTestCase):
 
         # If the AttributeValue does not exist, permission returns the default
         self._entity.attrs.add(self._attr.schema)
-        self._entry.attrs.add(self._attr)
 
         result = self._entry.get_es_document()
         self.assertEqual(

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -698,8 +698,6 @@ class ViewTest(AironeViewTest):
 
                 attr.values.add(attr_value)
 
-            entry.attrs.add(attr)
-
         # with invalid entry-id
         resp = self.client.get(reverse("entry:edit", args=[entry.id]))
         self.assertEqual(resp.status_code, 200)
@@ -711,8 +709,7 @@ class ViewTest(AironeViewTest):
         entry = Entry(name="fuga", schema=self._entity, created_user=user)
         entry.save()
 
-        attr = self.make_attr(name="attr", created_user=user, parent_entry=entry)
-        entry.attrs.add(attr)
+        self.make_attr(name="attr", created_user=user, parent_entry=entry)
 
         # with invalid entry-id
         resp = self.client.get(reverse("entry:edit", args=[entry.id]))
@@ -954,7 +951,6 @@ class ViewTest(AironeViewTest):
         for attr_name in ["foo", "bar", "baz"]:
             attr = self.make_attr(name=attr_name, created_user=user, parent_entry=entry)
             self._entity.attrs.add(attr.schema)
-            entry.attrs.add(attr)
 
         params = {
             "entry_name": entry.name,
@@ -1212,8 +1208,6 @@ class ViewTest(AironeViewTest):
 
                 attr.values.add(attr_value)
 
-            entry.attrs.add(attr)
-
         resp = self.client.get(reverse("entry:show", args=[entry.id]))
         self.assertEqual(resp.status_code, 200)
 
@@ -1320,7 +1314,6 @@ class ViewTest(AironeViewTest):
             name="attr", attrtype=AttrType.OBJECT, created_user=user, parent_entry=entry
         )
         self._entity.attrs.add(attr.schema)
-        entry.attrs.add(attr)
 
         attr_value = AttributeValue.objects.create(
             referral=entry, created_user=user, parent_attr=attr
@@ -1513,10 +1506,6 @@ class ViewTest(AironeViewTest):
                 parent_entry=test_entry,
             )
 
-            test_attr.save()
-            test_entry.attrs.add(test_attr)
-            test_entry.save()
-
             test_val = None
 
             if type & AttrType._ARRAY == 0:
@@ -1581,7 +1570,7 @@ class ViewTest(AironeViewTest):
         user = self.admin_login()
 
         entry = Entry.objects.create(name="fuga", schema=self._entity, created_user=user)
-        entry.attrs.add(self.make_attr(name="attr-test", parent_entry=entry, created_user=user))
+        self.make_attr(name="attr-test", parent_entry=entry, created_user=user)
 
         entry_count = Entry.objects.count()
 
@@ -5181,7 +5170,7 @@ class ViewTest(AironeViewTest):
         entry.complement_attrs(user)
 
         # Added another Attribute to entry to test to be able to detect this abnormal situation
-        entry.attrs.add(self.make_attr("test", parent_entry=entry, created_user=user))
+        self.make_attr("test", parent_entry=entry, created_user=user)
 
         # Send a request to import entry
         with self.assertLogs(logger=Logger, level=logging.ERROR) as cm:


### PR DESCRIPTION
Similar to https://github.com/dmm-com/pagoda/pull/1237, the relation looks redundant; in my understanding, single Attribute instance doesn't belong to multiple Entry instances.