### PR TITLE
deleted users are not displayed

### DIFF
--- a/role/api_v2/serializers.py
+++ b/role/api_v2/serializers.py
@@ -27,9 +27,9 @@ class RoleGroupSerializer(serializers.ModelSerializer):
 
 
 class RoleSerializer(serializers.ModelSerializer):
-    users = RoleUserSerializer(many=True)
+    users = serializers.SerializerMethodField()
     groups = RoleGroupSerializer(many=True)
-    admin_users = RoleUserSerializer(many=True)
+    admin_users = serializers.SerializerMethodField()
     admin_groups = RoleGroupSerializer(many=True)
     is_editable = serializers.SerializerMethodField(method_name="get_is_editable", read_only=True)
 
@@ -46,6 +46,12 @@ class RoleSerializer(serializers.ModelSerializer):
             "admin_groups",
             "is_editable",
         ]
+
+    def get_users(self, obj):
+        return RoleUserSerializer(obj.users.filter(is_active=True), many=True).data
+
+    def get_admin_users(self, obj):
+        return RoleUserSerializer(obj.admin_users.filter(is_active=True), many=True).data
 
     def get_is_editable(self, obj: Role) -> bool:
         current_user: User = self.context["request"].user

--- a/role/tests/test_api_v2.py
+++ b/role/tests/test_api_v2.py
@@ -359,6 +359,7 @@ class ViewTest(AironeViewTest):
         )
 
     def test_deleted_users_are_not_displayed(self):
+        self.admin_login()
         user = User.objects.create(username="test_user")
         role = Role.objects.create(name="test-role")
 

--- a/role/tests/test_api_v2.py
+++ b/role/tests/test_api_v2.py
@@ -359,7 +359,6 @@ class ViewTest(AironeViewTest):
         )
 
     def test_deleted_users_are_not_displayed(self):
-        admin = self.admin_login()
         user = User.objects.create(username="test_user")
         role = Role.objects.create(name="test-role")
 

--- a/role/tests/test_api_v2.py
+++ b/role/tests/test_api_v2.py
@@ -357,3 +357,22 @@ class ViewTest(AironeViewTest):
                 }
             ],
         )
+
+    def test_deleted_users_are_displayed(self):
+        admin = self.admin_login()
+        user: User = User.objects.create(username="test_user")
+        params = {
+            "name": "test-role",
+            "description": "test-description",
+            "users": [user.id],
+            "groups": [self.group1.id],
+            "admin_users": [admin.id],
+            "admin_groups": [self.group2.id],
+        }
+        self.client.post("/role/api/v2/", json.dumps(params), "application/json")
+        self.client.delete("/user/api/v2/%d/" % user.id)
+        role = Role.objects.filter(name="test-role").first()
+        role_get = self.client.get(f"/role/api/v2/{role.id}")
+        role_data = role_get.json()
+        # Assert that the users list is empty
+        self.assertEqual(role_data['users'], [])

--- a/role/tests/test_api_v2.py
+++ b/role/tests/test_api_v2.py
@@ -358,21 +358,20 @@ class ViewTest(AironeViewTest):
             ],
         )
 
-    def test_deleted_users_are_displayed(self):
+    def test_deleted_users_are_not_displayed(self):
         admin = self.admin_login()
-        user: User = User.objects.create(username="test_user")
-        params = {
-            "name": "test-role",
-            "description": "test-description",
-            "users": [user.id],
-            "groups": [self.group1.id],
-            "admin_users": [admin.id],
-            "admin_groups": [self.group2.id],
-        }
-        self.client.post("/role/api/v2/", json.dumps(params), "application/json")
-        self.client.delete("/user/api/v2/%d/" % user.id)
-        role = Role.objects.filter(name="test-role").first()
-        role_get = self.client.get(f"/role/api/v2/{role.id}")
-        role_data = role_get.json()
+        user = User.objects.create(username="test_user")
+        role = Role.objects.create(name="test-role")
+
+        # Associate user with the role
+        role.users.set([user.id])
+
+        # Delete the user
+        user.delete()
+
+        # Retrieve the role after the user is deleted
+        role_get_response = self.client.get(f"/role/api/v2/{role.id}")
+        role_data = role_get_response.json()
+
         # Assert that the users list is empty
-        self.assertEqual(role_data['users'], [])
+        self.assertEqual(role_data["users"], [])


### PR DESCRIPTION
Fixed issue where deleted users were still displayed in the role management screen.