### PR TITLE
Put advanced search index in MySQL

### DIFF
--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -483,3 +483,6 @@ class Common(Configuration):
     MAX_USERS: int | None = env.int("AIRONE_MAX_USERS", None)
     MAX_GROUPS: int | None = env.int("AIRONE_MAX_GROUPS", None)
     MAX_ROLES: int | None = env.int("AIRONE_MAX_ROLES", None)
+
+    # TODO enable experimental ES-less advanced search; TODO it must be removed
+    ENABLE_ESLESS_ADVANCED_SEARCH: bool = env.bool("AIRONE_ENABLE_ESLESS_ADVANCED_SEARCH", True)

--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -485,4 +485,4 @@ class Common(Configuration):
     MAX_ROLES: int | None = env.int("AIRONE_MAX_ROLES", None)
 
     # TODO enable experimental ES-less advanced search; TODO it must be removed
-    ENABLE_ESLESS_ADVANCED_SEARCH: bool = env.bool("AIRONE_ENABLE_ESLESS_ADVANCED_SEARCH", True)
+    ENABLE_ESLESS_ADVANCED_SEARCH: bool = env.bool("AIRONE_ENABLE_ESLESS_ADVANCED_SEARCH", False)

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -2,6 +2,7 @@ import re
 from copy import deepcopy
 from datetime import datetime, timedelta
 
+from django.conf import settings
 from django.db.models import Q
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
@@ -369,16 +370,29 @@ class AdvancedSearchAPI(generics.GenericAPIView):
             if entity and request.user.has_permission(entity, ACLType.Readable):
                 hint_entity_ids.append(entity.id)
 
-        resp = AdvancedSearchService.search_entries_v2(
-            request.user,
-            hint_entity_ids,
-            hint_attrs,
-            entry_limit,
-            hint_entry_name,
-            hint_referral,
-            is_output_all,
-            offset=entry_offset,
-        )
+        if settings.ENABLE_ESLESS_ADVANCED_SEARCH:
+            resp = AdvancedSearchService.search_entries_v2(
+                request.user,
+                hint_entity_ids,
+                hint_attrs,
+                entry_limit,
+                hint_entry_name,
+                hint_referral,
+                is_output_all,
+                offset=entry_offset,
+            )
+        else:
+            resp = AdvancedSearchService.search_entries(
+                request.user,
+                hint_entity_ids,
+                hint_attrs,
+                entry_limit,
+                hint_entry_name,
+                hint_referral,
+                is_output_all,
+                offset=entry_offset,
+            )
+
         # save total population number
         total_count = deepcopy(resp.ret_count)
 

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -369,7 +369,7 @@ class AdvancedSearchAPI(generics.GenericAPIView):
             if entity and request.user.has_permission(entity, ACLType.Readable):
                 hint_entity_ids.append(entity.id)
 
-        resp = AdvancedSearchService.search_entries(
+        resp = AdvancedSearchService.search_entries_v2(
             request.user,
             hint_entity_ids,
             hint_attrs,

--- a/entry/models.py
+++ b/entry/models.py
@@ -2293,14 +2293,12 @@ class AdvancedSearchAttributeIndex(models.Model):
     entity = models.ForeignKey(Entity, on_delete=models.CASCADE)
     entity_attr = models.ForeignKey(EntityAttr, on_delete=models.CASCADE)
     entry = models.ForeignKey(Entry, on_delete=models.CASCADE)
-    attr = models.ForeignKey(Attribute, on_delete=models.CASCADE)
+    attr = models.ForeignKey(Attribute, on_delete=models.CASCADE, null=True)
 
     type = models.IntegerField()
     entry_name = models.CharField(max_length=200)
     key = models.CharField(max_length=1024, null=True)
     raw_value = models.JSONField(null=True)
-
-    # TODO probably should have entry name
 
     class Meta:
         indexes = [
@@ -2309,13 +2307,13 @@ class AdvancedSearchAttributeIndex(models.Model):
 
     @classmethod
     def create_instance(
-        cls, entry: Entry, attr: Attribute, attrv: AttributeValue | None
+        cls, entry: Entry, entity_attr: EntityAttr, attrv: AttributeValue | None
     ) -> "AdvancedSearchAttributeIndex":
         key: str | None = None
         value: dict[str, Any] | list[Any] | None = None
 
         if attrv:
-            match attr.schema.type:
+            match entity_attr.type:
                 case AttrType.STRING | AttrType.TEXT:
                     key = attrv.value
                 case AttrType.BOOLEAN:
@@ -2377,10 +2375,10 @@ class AdvancedSearchAttributeIndex(models.Model):
 
         return AdvancedSearchAttributeIndex(
             entity=entry.schema,
-            entity_attr=attr.schema,
+            entity_attr=entity_attr,
             entry=entry,
-            attr=attr,
-            type=attr.schema.type,
+            attr=attrv.parent_attr if attrv else None,
+            type=entity_attr.type,
             entry_name=entry.name,
             key=key,
             raw_value=value,

--- a/entry/models.py
+++ b/entry/models.py
@@ -2319,12 +2319,16 @@ class AdvancedSearchAttributeIndex(models.Model):
                 case AttrType.BOOLEAN:
                     key = "true" if attrv.boolean else "false"
                 case AttrType.DATE:
-                    key = attrv.date.isoformat()
+                    key = attrv.date.isoformat() if attrv.date else None
                 case AttrType.DATETIME:
-                    key = attrv.datetime.isoformat()
+                    key = attrv.datetime.isoformat() if attrv.datetime else None
                 case AttrType.OBJECT:
-                    key = attrv.referral.name
-                    value = {"id": attrv.referral.id, "name": attrv.referral.name}
+                    key = attrv.referral.name if attrv.referral else None
+                    value = (
+                        {"id": attrv.referral.id, "name": attrv.referral.name}
+                        if attrv.referral
+                        else None
+                    )
                 case AttrType.NAMED_OBJECT:
                     key = attrv.value
                     value = {
@@ -2332,13 +2336,17 @@ class AdvancedSearchAttributeIndex(models.Model):
                             "id": attrv.referral.id,
                             "name": attrv.referral.name,
                         }
+                        if attrv.referral
+                        else None
                     }
                 case AttrType.GROUP:
-                    key = attrv.group.name
-                    value = {"id": attrv.group.id, "name": attrv.group.name}
+                    key = attrv.group.name if attrv.group else None
+                    value = (
+                        {"id": attrv.group.id, "name": attrv.group.name} if attrv.group else None
+                    )
                 case AttrType.ROLE:
-                    key = attrv.role.name
-                    value = {"id": attrv.role.id, "name": attrv.role.name}
+                    key = attrv.role.name if attrv.role else None
+                    value = {"id": attrv.role.id, "name": attrv.role.name} if attrv.role else None
                 case AttrType.ARRAY_STRING:
                     value = [v.value for v in attrv.data_array.all()]
                     key = ",".join(value)

--- a/entry/models.py
+++ b/entry/models.py
@@ -2297,7 +2297,7 @@ class AdvancedSearchAttributeIndex(models.Model):
 
     type = models.IntegerField()
     entry_name = models.CharField(max_length=200)
-    key = models.CharField(max_length=1024, null=True)
+    key = models.CharField(max_length=512, null=True)
     raw_value = models.JSONField(null=True)
 
     class Meta:

--- a/entry/services.py
+++ b/entry/services.py
@@ -306,7 +306,7 @@ class AdvancedSearchService:
         indexes: list[AdvancedSearchAttributeIndex] = []
         for entry in entry_list:
             for entity_attr in entity_attrs:
-                attr = next((a for a in entry.prefetched_attrs if a.schema == entity_attr), None)
+                attr = next((a for a in entry.prefetch_attrs if a.schema == entity_attr), None)
                 attrv: AttributeValue | None = None
                 if attr:
                     attrv = next(iter(attr.prefetch_values), None)


### PR DESCRIPTION
# Overview

As an alternative way to realize the advanced search feature, having search index in MySQL simply.
Its a PoC continued from https://github.com/dmm-com/pagoda/pull/1202

- Currently supported
  - basic search condition, entity & entities attrs 
  - basic attr filters, empty, not-empty, contains, not-contais
  - entry name filter
- NOT supported
  - including referrals
  - select from all entities
  - DUPLICATED attr filter
  - care for join_attrs, search chain
  - some special symbols (implicitly) control behavior of the search 

# Performance

With 10000+ entries, 14 attrs in an entry, the advanced search E2E latency is **about 2.5s**

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/5bf67620-a347-47b7-8c03-2cbce64854de">

The details of the search query to DB. Basically it uses index effectively. The core search scan is so slow, we can speed up if any improve ideas for that.

<img width="2303" alt="image" src="https://github.com/user-attachments/assets/3705d739-2bed-4f7e-b212-bdf0f42158ff">

(However, current ES based search for the same data is faster, **1.3s** )

# How to use

Its enabled by default in this PR! If hope to disable, set `AIRONE_ENABLE_ESLESS_ADVANCED_SEARCH=false`