### PR TITLE
Added a helper components that is often used to adapt flex style

### DIFF
--- a/frontend/src/components/common/FlexBox.tsx
+++ b/frontend/src/components/common/FlexBox.tsx
@@ -1,7 +1,14 @@
 import { Box } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
-export const RightAlignedBox = styled(Box)(({}) => ({
+export const FlexBox = styled(Box)(({}) => ({
   display: "flex",
+}));
+
+export const RightAlignedBox = styled(FlexBox)(({}) => ({
   justifyContent: "end",
+}));
+
+export const CenterAlignedBox = styled(FlexBox)(({}) => ({
+  justifyContent: "center",
 }));

--- a/frontend/src/components/common/FlexBox.tsx
+++ b/frontend/src/components/common/FlexBox.tsx
@@ -1,8 +1,7 @@
 import { Box } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
-export const FlexBox = styled(Box)(({}) => ({
+export const RightAlignedBox = styled(Box)(({}) => ({
   display: "flex",
-  flexDirection: "column",
-  flexGrow: "1",
+  justifyContent: "end",
 }));

--- a/frontend/src/components/common/PaginationFooter.tsx
+++ b/frontend/src/components/common/PaginationFooter.tsx
@@ -1,10 +1,10 @@
-import { Box, Pagination, Stack, Typography } from "@mui/material";
+import { Pagination, Stack, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import React, { FC } from "react";
 
-const StyledBox = styled(Box)(({}) => ({
-  display: "flex",
-  justifyContent: "center",
+import { CenterAlignedBox } from "components/common/FlexBox";
+
+const StyledBox = styled(CenterAlignedBox)(({}) => ({
   alignItems: "center",
   margin: "30px 0",
 }));

--- a/frontend/src/components/common/SubmitButton.tsx
+++ b/frontend/src/components/common/SubmitButton.tsx
@@ -1,11 +1,8 @@
-import { Box, Button, CircularProgress } from "@mui/material";
+import { Button, CircularProgress } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import React, { FC } from "react";
 
-const StyledBox = styled(Box)({
-  display: "flex",
-  justifyContent: "center",
-});
+import { CenterAlignedBox } from "components/common/FlexBox";
 
 const StyledButton = styled(Button)({
   margin: "0 4px",
@@ -27,7 +24,7 @@ export const SubmitButton: FC<Props> = ({
   handleCancel,
 }) => {
   return (
-    <StyledBox>
+    <CenterAlignedBox>
       <StyledButton
         variant="contained"
         color="secondary"
@@ -42,6 +39,6 @@ export const SubmitButton: FC<Props> = ({
           キャンセル
         </StyledButton>
       )}
-    </StyledBox>
+    </CenterAlignedBox>
   );
 };

--- a/frontend/src/components/entity/EntityBreadcrumbs.tsx
+++ b/frontend/src/components/entity/EntityBreadcrumbs.tsx
@@ -1,16 +1,12 @@
 import { EntityDetail } from "@dmm-com/airone-apiclient-typescript-fetch";
 import LockIcon from "@mui/icons-material/Lock";
-import { Box, Typography } from "@mui/material";
-import { styled } from "@mui/material/styles";
+import { Typography } from "@mui/material";
 import React, { FC } from "react";
 import { Link } from "react-router-dom";
 
 import { topPath, entitiesPath, entityEntriesPath } from "Routes";
 import { AironeBreadcrumbs } from "components/common/AironeBreadcrumbs";
-
-const StyledBox = styled(Box)({
-  display: "flex",
-});
+import { FlexBox } from "components/common/FlexBox";
 
 interface Props {
   entity?: EntityDetail;
@@ -28,12 +24,12 @@ export const EntityBreadcrumbs: FC<Props> = ({ entity, attr, title }) => {
         モデル一覧
       </Typography>
       {entity && (
-        <StyledBox>
+        <FlexBox>
           <Typography component={Link} to={entityEntriesPath(entity.id)}>
             {entity.name}
           </Typography>
           {!entity.isPublic && <LockIcon />}
-        </StyledBox>
+        </FlexBox>
       )}
       {attr && <Typography color="textPrimary">{attr}</Typography>}
       {title && <Typography color="textPrimary">{title}</Typography>}

--- a/frontend/src/components/entry/EntryBreadcrumbs.tsx
+++ b/frontend/src/components/entry/EntryBreadcrumbs.tsx
@@ -1,7 +1,6 @@
 import { EntryRetrieve } from "@dmm-com/airone-apiclient-typescript-fetch";
 import LockIcon from "@mui/icons-material/Lock";
-import { Box, Typography } from "@mui/material";
-import { styled } from "@mui/material/styles";
+import { Typography } from "@mui/material";
 import React, { FC } from "react";
 import { Link } from "react-router-dom";
 
@@ -12,10 +11,7 @@ import {
   entryDetailsPath,
 } from "Routes";
 import { AironeBreadcrumbs } from "components/common/AironeBreadcrumbs";
-
-const StyledBox = styled(Box)({
-  display: "flex",
-});
+import { FlexBox } from "components/common/FlexBox";
 
 interface Props {
   entry?: EntryRetrieve;
@@ -32,15 +28,15 @@ export const EntryBreadcrumbs: FC<Props> = ({ entry, title }) => {
         モデル一覧
       </Typography>
       {entry && (
-        <StyledBox>
+        <FlexBox>
           <Typography component={Link} to={entityEntriesPath(entry.schema.id)}>
             {entry.schema.name}
           </Typography>
           {!entry.schema.isPublic && <LockIcon />}
-        </StyledBox>
+        </FlexBox>
       )}
       {entry && (
-        <StyledBox>
+        <FlexBox>
           <Typography
             component={Link}
             to={entryDetailsPath(entry.schema.id, entry.id)}
@@ -48,7 +44,7 @@ export const EntryBreadcrumbs: FC<Props> = ({ entry, title }) => {
             {entry.name}
           </Typography>
           {!entry.isPublic && <LockIcon />}
-        </StyledBox>
+        </FlexBox>
       )}
       {title && <Typography color="textPrimary">{title}</Typography>}
     </AironeBreadcrumbs>


### PR DESCRIPTION
In many React components, we were made many StyledBox according to the purpose. But most of them are just a `Box` that `display:flex` is applied. 

This commit commoditize them as `FlexBox` and made derived ones `RightAlignedBox` and `CenterAlignedBox`. They might go on increasing, but I made simple cases so far.