### PR TITLE
Use datepicker in datetime type too

### DIFF
--- a/frontend/src/components/entry/SearchResultControlMenu.tsx
+++ b/frontend/src/components/entry/SearchResultControlMenu.tsx
@@ -167,8 +167,9 @@ export const SearchResultControlMenu: FC<Props> = ({
         <Typography>重複</Typography>
       </MenuItem>
 
-      {/* date-type specific text selector */}
-      {attrType === EntryAttributeTypeTypeEnum.DATE && (
+      {/* date-like-type specific text selector */}
+      {(attrType === EntryAttributeTypeTypeEnum.DATE ||
+        attrType === EntryAttributeTypeTypeEnum.DATETIME) && (
         <Box>
           <StyledBox display="flex" flexDirection="column">
             <StyledTypography variant="caption">次を含む日付</StyledTypography>
@@ -283,7 +284,8 @@ export const SearchResultControlMenu: FC<Props> = ({
 
       {/* default text selector */}
       {attrType !== EntryAttributeTypeTypeEnum.DATE &&
-        attrType !== EntryAttributeTypeTypeEnum.BOOLEAN && (
+        attrType !== EntryAttributeTypeTypeEnum.BOOLEAN &&
+        attrType !== EntryAttributeTypeTypeEnum.DATETIME && (
           <Box>
             <Box>
               <StyledTextField


### PR DESCRIPTION
Just apply the date picker in the advanced search page to datetime attr filter.

<img width="853" alt="image" src="https://github.com/user-attachments/assets/385469ad-7e13-424d-818d-c79bf9b33753">

Its NOT date TIME picker, excludes time(HH:mm:ss) part because most of users don't hope to filter with such exact condition, in my expectation.