### PR TITLE
Added exact option in custom route settings

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -87,7 +87,7 @@ export const AppRouter: FC<Props> = ({ customRoutes }) => {
               <Switch>
                 {customRoutes &&
                   customRoutes.map((r) => (
-                    <Route key={r.path} path={r.path}>
+                    <Route key={r.path} path={r.path} exact>
                       <Switch>
                         <Route
                           path={r.routePath}
@@ -165,7 +165,7 @@ export const AppRouter: FC<Props> = ({ customRoutes }) => {
                 <Route path={newRolePath()} component={RoleEditPage} />
                 <Route path={rolePath(":roleId")} component={RoleEditPage} />
                 <Route path={rolesPath()} component={RoleListPage} />
-                <Route exact path={topPath()} component={DashboardPage} />
+                <Route path={topPath()} component={DashboardPage} exact />
                 <Route component={NotFoundErrorPage} />
               </Switch>
             </Route>

--- a/frontend/src/Routes.ts
+++ b/frontend/src/Routes.ts
@@ -13,7 +13,7 @@ export const aclHistoryPath = (objectId: number | string) =>
   basePath + `acl/${objectId}/history`;
 export const searchPath = () => basePath + "search";
 
-// entris
+// entries
 export const newEntryPath = (entityId: number | string) =>
   basePath + `entities/${entityId}/entries/new`;
 export const copyEntryPath = (


### PR DESCRIPTION
If there is a route in the entry list in the custom route, the route for the entry details will be overwritten.

e.g. `entities/9999/entries/entries/1111/details`

custom_entries_path: `entities/${custom_entityId}/entries` ←catch
entry_details_path: `entities/${custom_entityId}/entries/${entryId}/details`