### PR TITLE
Disable attrs field on loading, instead of just hiding

### DIFF
--- a/frontend/src/pages/AdvancedSearchPage.tsx
+++ b/frontend/src/pages/AdvancedSearchPage.tsx
@@ -167,26 +167,25 @@ export const AdvancedSearchPage: FC = () => {
         <StyledFlexColumnBox>
           <StyledTypography variant="h4">属性</StyledTypography>
 
-          {!attrs.loading && (
-            <AutocompleteWithAllSelector
-              selectAllLabel="すべて選択"
-              options={attrs.value ?? []}
-              value={selectedAttrs}
-              inputValue={attrName}
-              onChange={(_, value: Array<string>) => setSelectedAttrs(value)}
-              onInputChange={handleChangeInputAttrName}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  variant="outlined"
-                  placeholder="属性を選択"
-                />
-              )}
-              multiple
-              disableCloseOnSelect
-              fullWidth
-            />
-          )}
+          <AutocompleteWithAllSelector
+            selectAllLabel="すべて選択"
+            options={attrs.value ?? []}
+            value={selectedAttrs}
+            inputValue={attrName}
+            onChange={(_, value: Array<string>) => setSelectedAttrs(value)}
+            onInputChange={handleChangeInputAttrName}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                variant="outlined"
+                placeholder="属性を選択"
+              />
+            )}
+            disabled={attrs.loading}
+            multiple
+            disableCloseOnSelect
+            fullWidth
+          />
           <Box>
             参照アイテムも含める
             <Checkbox


### PR DESCRIPTION
Just switching disable state is more user-friendly, rather than show/hide the component causes flicking