### PR TITLE
Reduce N+1 on entry history API

### DIFF
--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -1005,7 +1005,9 @@ class EntryHistoryAttributeValueSerializer(serializers.ModelSerializer):
                         }
                         if x.referral and x.referral.is_active
                         else None
-                        for x in obj.data_array.all()
+                        for x in obj.data_array.all().select_related(
+                            "referral", "referral__entry__schema"
+                        )
                     ]
                 }
 
@@ -1024,7 +1026,9 @@ class EntryHistoryAttributeValueSerializer(serializers.ModelSerializer):
                         if x.referral and x.referral.is_active
                         else None,
                     }
-                    for x in obj.data_array.all()
+                    for x in obj.data_array.all().select_related(
+                        "referral", "referral__entry__schema"
+                    )
                 ]
                 return {"as_array_named_object": array_named_object}
 

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -186,7 +186,7 @@ class EntryAPI(viewsets.ModelViewSet):
                 parent_attrv__isnull=True,
             )
             .order_by("-created_time")
-            .select_related("parent_attr")
+            .select_related("parent_attr__schema", "created_user")
         )
 
         return super(EntryAPI, self).list(request, *args, **kwargs)


### PR DESCRIPTION
A small tuning to avoid N+1 occured on `x.referral.entry.schema.name`, similar to https://github.com/dmm-com/pagoda/pull/1284