### PR TITLE
Allow to change header color to show environment deferences etc

### DIFF
--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -235,6 +235,7 @@ class Common(Configuration):
         "PASSWORD_RESET_DISABLED": env.bool("AIRONE_PASSWORD_RESET_DISABLED", False),
         "CHECK_TERM_SERVICE": env.bool("AIRONE_CHECK_TERM_SERVICE", False),
         "TERMS_OF_SERVICE_URL": env.str("AIRONE_TERMS_OF_SERVICE_URL", "#"),
+        "HEADER_COLOR": env.str("AIRONE_HEADER_COLOR", None),
         "EXTENDED_HEADER_MENUS": json.loads(
             env.str(
                 "EXTENDED_HEADER_MENUS",

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -160,8 +160,12 @@ export const Header: FC = () => {
 
   return (
     <Frame>
-      <Fixed>
-        <StyledAppBar position="static" elevation={0}>
+      <Fixed style={{ backgroundColor: serverContext?.headerColor }}>
+        <StyledAppBar
+          position="static"
+          elevation={0}
+          style={{ backgroundColor: serverContext?.headerColor }}
+        >
           <StyledToolbar variant="dense">
             <TitleBox>
               <Title fontSize="24px" component={Link} to={topPath()}>

--- a/frontend/src/services/ServerContext.ts
+++ b/frontend/src/services/ServerContext.ts
@@ -37,6 +37,7 @@ export class ServerContext {
     name: string;
     children: { name: string; url: string }[];
   }[];
+  headerColor?: string;
   flags: Record<FlagKey, boolean>;
 
   private static _instance: ServerContext | undefined;
@@ -55,6 +56,7 @@ export class ServerContext {
     this.checkTermService = context.checkTermService;
     this.termsOfServiceUrl = context.termsOfServiceUrl;
     this.extendedHeaderMenus = context.extendedHeaderMenus;
+    this.headerColor = context.headerColor;
     this.flags = context.flags ?? { webhook: true };
   }
 

--- a/templates/frontend/index.html
+++ b/templates/frontend/index.html
@@ -34,6 +34,7 @@
           legacyUiDisabled: {{airone.LEGACY_UI_DISABLED|yesno:"true,false"}},
           checkTermService: {{airone.CHECK_TERM_SERVICE|yesno:"true,false"}},
           extendedHeaderMenus: {{ airone.EXTENDED_HEADER_MENUS|safe }},
+          headerColor: {% if airone.HEADER_COLOR %}"{{ airone.HEADER_COLOR|safe }}"{% else %}null{% endif %},
           flags: {
               webhook: {{ airone_flags.WEBHOOK|yesno:"true,false" }},
           },


### PR DESCRIPTION
SSIA, to identify the pagoda environment if we have some pagoda instances.

For e.g. with `AIRONE_HEADER_COLOR=red`:
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/038b47f1-55c6-43c2-a145-2af77d260f92">

The main use case is to show the environment. Today tech company serves multiple environments lilke development, qa, staging, production, etc. Its easy to show the difference, e.g. with `qa=default`, `staging=yellow`, `production=red`