### PR TITLE
Rename object-like attr types

### DIFF
--- a/frontend/src/services/Constants.ts
+++ b/frontend/src/services/Constants.ts
@@ -47,7 +47,7 @@ export const BaseAttributeTypes = {
 
 export const AttributeTypes: Record<string, { name: string; type: number }> = {
   object: {
-    name: "entry",
+    name: "object",
     type: BaseAttributeTypes.object,
   },
   string: {
@@ -55,11 +55,11 @@ export const AttributeTypes: Record<string, { name: string; type: number }> = {
     type: BaseAttributeTypes.string,
   },
   named_object: {
-    name: "named_entry",
+    name: "named_object",
     type: BaseAttributeTypes.object | BaseAttributeTypes.named,
   },
   array_object: {
-    name: "array_entry",
+    name: "array_object",
     type: BaseAttributeTypes.object | BaseAttributeTypes.array,
   },
   array_string: {
@@ -67,7 +67,7 @@ export const AttributeTypes: Record<string, { name: string; type: number }> = {
     type: BaseAttributeTypes.string | BaseAttributeTypes.array,
   },
   array_named_object: {
-    name: "array_named_entry",
+    name: "array_named_object",
     type:
       BaseAttributeTypes.object |
       BaseAttributeTypes.named |


### PR DESCRIPTION
Rename display attr types from `*entry` to `*object` to suite the legacy UI
<img width="399" alt="image" src="https://github.com/user-attachments/assets/2e7fac9e-ce80-48d9-a69c-4dda0aec5804">
