### PR TITLE
Changed the order of before delete custom views

### DIFF
--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -108,6 +108,9 @@ class EntryAPI(viewsets.ModelViewSet):
 
         user: User = request.user
 
+        if custom_view.is_custom("before_delete_entry_v2", entry.schema.name):
+            custom_view.call_custom("before_delete_entry_v2", entry.schema.name, user, entry)
+
         job: Job = Job.new_delete_entry_v2(user, entry)
         job.run()
 

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -888,9 +888,6 @@ def delete_entry_v2(self, job: Job) -> JobStatus:
     if not entry:
         return JobStatus.ERROR
 
-    if custom_view.is_custom("before_delete_entry_v2", entry.schema.name):
-        custom_view.call_custom("before_delete_entry_v2", entry.schema.name, job.user, entry)
-
     # register operation History for deleting entry
     job.user.seth_entry_del(entry)
     entry.delete(deleted_user=job.user)

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -1304,7 +1304,7 @@ class ViewTest(BaseViewTest):
 
         mock_call_custom.side_effect = side_effect
         resp = self.client.delete("/entry/api/v2/%s/" % entry.id, None, "application/json")
-        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertTrue(mock_call_custom.called)
 
         def side_effect(handler_name, entity_name, user, entry):
@@ -4791,6 +4791,8 @@ class ViewTest(BaseViewTest):
         )
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
         self.assertTrue(mock_call_custom.called)
+
+        entry = self.add_entry(self.user, "entry2", self.entity)
 
         def side_effect(handler_name, entity_name, user, entry):
             self.assertTrue(handler_name in ["before_delete_entry_v2", "after_delete_entry_v2"])


### PR DESCRIPTION
Before the change, the call was made within background processing,
so even if the delete process was canceled in customview,
API request would return an OK response.