### PR TITLE
Keep to use our own ErrorBoundary

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -5,6 +5,7 @@ import {
   Outlet,
   Route,
   RouterProvider,
+  useRouteError,
 } from "react-router-dom";
 
 import { ACLHistoryPage } from "./pages/ACLHistoryPage";
@@ -67,6 +68,11 @@ import { TriggerListPage } from "pages/TriggerListPage";
 import { UserEditPage } from "pages/UserEditPage";
 import { UserListPage } from "pages/UserListPage";
 
+// re-throw error to be caught by the root error boundary
+const ErrorBridge: FC = () => {
+  throw useRouteError();
+};
+
 interface Props {
   customRoutes?: {
     path: string;
@@ -77,7 +83,7 @@ interface Props {
 export const AppRouter: FC<Props> = ({ customRoutes }) => {
   const router = createBrowserRouter(
     createRoutesFromElements(
-      <Route>
+      <Route errorElement={<ErrorBridge />}>
         <Route path={loginPath()} element={<LoginPage />} />
         <Route
           path="/"

--- a/frontend/src/ErrorHandler.tsx
+++ b/frontend/src/ErrorHandler.tsx
@@ -9,7 +9,7 @@ import {
 import { styled } from "@mui/material/styles";
 import React, { FC, useCallback, useEffect, useState } from "react";
 import { ErrorBoundary, FallbackProps } from "react-error-boundary";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useError } from "react-use";
 
 import { ForbiddenErrorPage } from "./pages/ForbiddenErrorPage";
@@ -96,11 +96,15 @@ const GenericError: FC<GenericErrorProps> = ({ children }) => {
 };
 
 const ErrorFallback: FC<FallbackProps> = ({ error, resetErrorBoundary }) => {
-  const location = useLocation();
-
   useEffect(() => {
-    resetErrorBoundary();
-  }, [location, resetErrorBoundary]);
+    const handlePopState = () => {
+      resetErrorBoundary();
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [resetErrorBoundary]);
 
   switch (error.name) {
     case ForbiddenError.errorName:


### PR DESCRIPTION
react router v6 has the specific default ErrorBoundary in the module side, and its called before our's. We prefer to be called our one, so I insert a bridge to re-throw errors as an ErrorBoundary to react router.