### PR TITLE
Introduced isDisabled at the AttributeValueField components and its sub-ordinate ones

### DIFF
--- a/frontend/src/components/entry/entryForm/AttributeValueField.tsx
+++ b/frontend/src/components/entry/entryForm/AttributeValueField.tsx
@@ -24,6 +24,7 @@ interface Props {
   setValue: UseFormSetValue<Schema>;
   type: number;
   schemaId: number;
+  isDisabled?: boolean;
 }
 
 export const AttributeValueField: FC<Props> = ({
@@ -31,16 +32,24 @@ export const AttributeValueField: FC<Props> = ({
   setValue,
   type,
   schemaId,
+  isDisabled = false,
 }) => {
   switch (type) {
     case EntryAttributeTypeTypeEnum.STRING:
-      return <StringAttributeValueField control={control} attrId={schemaId} />;
+      return (
+        <StringAttributeValueField
+          control={control}
+          attrId={schemaId}
+          isDisabled={isDisabled}
+        />
+      );
 
     case EntryAttributeTypeTypeEnum.TEXT:
       return (
         <StringAttributeValueField
           control={control}
           attrId={schemaId}
+          isDisabled={isDisabled}
           multiline
         />
       );
@@ -51,6 +60,7 @@ export const AttributeValueField: FC<Props> = ({
           attrId={schemaId}
           control={control}
           setValue={setValue}
+          isDisabled={isDisabled}
         />
       );
 
@@ -60,11 +70,18 @@ export const AttributeValueField: FC<Props> = ({
           attrId={schemaId}
           control={control}
           setValue={setValue}
+          isDisabled={isDisabled}
         />
       );
 
     case EntryAttributeTypeTypeEnum.BOOLEAN:
-      return <BooleanAttributeValueField attrId={schemaId} control={control} />;
+      return (
+        <BooleanAttributeValueField
+          attrId={schemaId}
+          control={control}
+          isDisabled={isDisabled}
+        />
+      );
 
     case EntryAttributeTypeTypeEnum.OBJECT:
       return (
@@ -72,6 +89,7 @@ export const AttributeValueField: FC<Props> = ({
           attrId={schemaId}
           control={control}
           setValue={setValue}
+          isDisabled={isDisabled}
         />
       );
 
@@ -81,6 +99,7 @@ export const AttributeValueField: FC<Props> = ({
           attrId={schemaId}
           control={control}
           setValue={setValue}
+          isDisabled={isDisabled}
         />
       );
 
@@ -90,6 +109,7 @@ export const AttributeValueField: FC<Props> = ({
           attrId={schemaId}
           control={control}
           setValue={setValue}
+          isDisabled={isDisabled}
         />
       );
 
@@ -99,6 +119,7 @@ export const AttributeValueField: FC<Props> = ({
           attrId={schemaId}
           control={control}
           setValue={setValue}
+          isDisabled={isDisabled}
         />
       );
 
@@ -108,6 +129,7 @@ export const AttributeValueField: FC<Props> = ({
           attrId={schemaId}
           control={control}
           setValue={setValue}
+          isDisabled={isDisabled}
           multiple
         />
       );
@@ -118,6 +140,7 @@ export const AttributeValueField: FC<Props> = ({
           attrId={schemaId}
           control={control}
           setValue={setValue}
+          isDisabled={isDisabled}
           multiple
         />
       );
@@ -128,6 +151,7 @@ export const AttributeValueField: FC<Props> = ({
           attrId={schemaId}
           control={control}
           setValue={setValue}
+          isDisabled={isDisabled}
           multiple
         />
       );
@@ -143,6 +167,7 @@ export const AttributeValueField: FC<Props> = ({
           attrId={schemaId}
           control={control}
           setValue={setValue}
+          isDisabled={isDisabled}
         />
       );
 
@@ -152,6 +177,7 @@ export const AttributeValueField: FC<Props> = ({
           attrId={schemaId}
           control={control}
           setValue={setValue}
+          isDisabled={isDisabled}
           withBoolean
         />
       );

--- a/frontend/src/components/entry/entryForm/BooleanAttributeValueField.tsx
+++ b/frontend/src/components/entry/entryForm/BooleanAttributeValueField.tsx
@@ -7,9 +7,14 @@ import { Schema } from "./EntryFormSchema";
 interface Props {
   attrId: number;
   control: Control<Schema>;
+  isDisabled?: boolean;
 }
 
-export const BooleanAttributeValueField: FC<Props> = ({ attrId, control }) => {
+export const BooleanAttributeValueField: FC<Props> = ({
+  attrId,
+  control,
+  isDisabled = false,
+}) => {
   return (
     <Controller
       name={`attrs.${attrId}.value.asBoolean`}
@@ -19,6 +24,7 @@ export const BooleanAttributeValueField: FC<Props> = ({ attrId, control }) => {
         <Checkbox
           checked={field.value}
           onChange={(e) => field.onChange(e.target.checked)}
+          disabled={isDisabled}
         />
       )}
     />

--- a/frontend/src/components/entry/entryForm/DateAttributeValueField.tsx
+++ b/frontend/src/components/entry/entryForm/DateAttributeValueField.tsx
@@ -23,12 +23,14 @@ interface Props {
   attrId: number;
   control: Control<Schema>;
   setValue: UseFormSetValue<Schema>;
+  isDisabled?: boolean;
 }
 
 export const DateAttributeValueField: FC<Props> = ({
   attrId,
   control,
   setValue,
+  isDisabled = false,
 }) => {
   return (
     <StyledBox>
@@ -63,6 +65,7 @@ export const DateAttributeValueField: FC<Props> = ({
                   fullWidth={false}
                 />
               )}
+              disabled={isDisabled}
             />
           </LocalizationProvider>
         )}

--- a/frontend/src/components/entry/entryForm/DateTimeAttributeValueField.tsx
+++ b/frontend/src/components/entry/entryForm/DateTimeAttributeValueField.tsx
@@ -23,12 +23,14 @@ interface Props {
   attrId: number;
   control: Control<Schema>;
   setValue: UseFormSetValue<Schema>;
+  isDisabled?: boolean;
 }
 
 export const DateTimeAttributeValueField: FC<Props> = ({
   attrId,
   control,
   setValue,
+  isDisabled = false,
 }) => {
   return (
     <StyledBox>
@@ -66,6 +68,7 @@ export const DateTimeAttributeValueField: FC<Props> = ({
                   fullWidth={false}
                 />
               )}
+              disabled={isDisabled}
             />
           </LocalizationProvider>
         )}

--- a/frontend/src/components/entry/entryForm/GroupAttributeValueField.tsx
+++ b/frontend/src/components/entry/entryForm/GroupAttributeValueField.tsx
@@ -23,6 +23,7 @@ interface Props {
   control: Control<Schema>;
   setValue: UseFormSetValue<Schema>;
   multiple?: boolean;
+  isDisabled?: boolean;
 }
 
 export const GroupAttributeValueField: FC<Props> = ({
@@ -30,6 +31,7 @@ export const GroupAttributeValueField: FC<Props> = ({
   attrId,
   control,
   setValue,
+  isDisabled = false,
 }) => {
   const groups = useAsyncWithThrow(async () => {
     const _groups = await aironeApiClient.getGroups();
@@ -90,6 +92,7 @@ export const GroupAttributeValueField: FC<Props> = ({
                   placeholder={multiple ? "" : "-NOT SET-"}
                 />
               )}
+              disabled={isDisabled}
             />
           )}
         />

--- a/frontend/src/components/entry/entryForm/ObjectAttributeValueField.tsx
+++ b/frontend/src/components/entry/entryForm/ObjectAttributeValueField.tsx
@@ -57,13 +57,14 @@ interface CommonProps {
   attrId: number;
   control: Control<Schema>;
   setValue: UseFormSetValue<Schema>;
+  isDisabled?: boolean;
 }
 
 export const ObjectAttributeValueField: FC<
   CommonProps & {
     multiple?: boolean;
   }
-> = ({ multiple, attrId, control, setValue }) => {
+> = ({ multiple, attrId, control, setValue, isDisabled = false }) => {
   const handleChange = (
     value: GetEntryAttrReferral | GetEntryAttrReferral[] | null
   ) => {
@@ -116,6 +117,7 @@ export const ObjectAttributeValueField: FC<
               handleChange={handleChange}
               multiple={multiple}
               error={error}
+              isDisabled={isDisabled}
             />
           )}
         />

--- a/frontend/src/components/entry/entryForm/ReferralsAutocomplete.tsx
+++ b/frontend/src/components/entry/entryForm/ReferralsAutocomplete.tsx
@@ -19,6 +19,7 @@ interface Props {
   ) => void;
   multiple?: boolean;
   error?: { message?: string };
+  isDisabled?: boolean;
 }
 
 export const ReferralsAutocomplete: FC<Props> = ({
@@ -27,6 +28,7 @@ export const ReferralsAutocomplete: FC<Props> = ({
   handleChange,
   multiple,
   error,
+  isDisabled = false,
 }) => {
   const [inputValue, setInputValue] = useState<string>(
     !multiple ? (value as GetEntryAttrReferral | null)?.name ?? "" : ""
@@ -95,6 +97,7 @@ export const ReferralsAutocomplete: FC<Props> = ({
           helperText={error?.message}
           size="small"
           placeholder={multiple ? "" : "-NOT SET-"}
+          disabled={isDisabled}
         />
       )}
     />

--- a/frontend/src/components/entry/entryForm/RoleAttributeValueField.tsx
+++ b/frontend/src/components/entry/entryForm/RoleAttributeValueField.tsx
@@ -23,6 +23,7 @@ interface Props {
   control: Control<Schema>;
   setValue: UseFormSetValue<Schema>;
   multiple?: boolean;
+  isDisabled?: boolean;
 }
 
 export const RoleAttributeValueField: FC<Props> = ({
@@ -30,6 +31,7 @@ export const RoleAttributeValueField: FC<Props> = ({
   attrId,
   control,
   setValue,
+  isDisabled = false,
 }) => {
   const roles = useAsyncWithThrow(async () => {
     const _roles = await aironeApiClient.getRoles();
@@ -88,8 +90,10 @@ export const RoleAttributeValueField: FC<Props> = ({
                   helperText={error?.message}
                   size="small"
                   placeholder={multiple ? "" : "-NOT SET-"}
+                  disabled={isDisabled}
                 />
               )}
+              disabled={isDisabled}
             />
           )}
         />

--- a/frontend/src/components/entry/entryForm/StringAttributeValueField.tsx
+++ b/frontend/src/components/entry/entryForm/StringAttributeValueField.tsx
@@ -21,6 +21,7 @@ interface CommonProps {
   attrId: number;
   index?: number;
   control: Control<Schema>;
+  isDisabled?: boolean;
 }
 
 export const StringAttributeValueField: FC<
@@ -36,6 +37,7 @@ export const StringAttributeValueField: FC<
   handleClickDeleteListItem,
   handleClickAddListItem,
   multiline,
+  isDisabled = false,
 }) => {
   return (
     <StyledBox>
@@ -56,6 +58,7 @@ export const StringAttributeValueField: FC<
             fullWidth
             multiline={multiline}
             minRows={multiline === true ? 5 : 1}
+            disabled={isDisabled}
           />
         )}
       />


### PR DESCRIPTION
The `isDisabled` parameter is humble, not be forward usually.
When an attribute want to be prohibited to change but just showing, this parameter is useful for its use-case like this.
<img width="1055" alt="スクリーンショット 2024-11-15 11 52 24" src="https://github.com/user-attachments/assets/c5465388-4be5-4eea-978c-becf9559e989">
