### PR TITLE
Enable to pass external parameters to React-UI implementation via Django template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## In development
 
 ### Added
+* Enable to pass general external parameters(`extendedGeneralParameters`) to React-UI
+  implementation via Django template.
+  Contributed by @userlocalhost, @hinashi
 
 ### Changed
 

--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -246,7 +246,7 @@ class Common(Configuration):
         "EXTENDED_GENERAL_PARAMETERS": json.loads(
             env.str(
                 "EXTENDED_GENERAL_PARAMETERS",
-                json.dumps([]),
+                json.dumps({}),
             )
         ),
         # This is an example to set EXTENDED_HEADER_MENUS

--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -242,6 +242,13 @@ class Common(Configuration):
                 json.dumps([]),
             )
         ),
+        # This is the general parameter that would be passed to custom-views from external world
+        "EXTENDED_GENERAL_PARAMETERS": json.loads(
+            env.str(
+                "EXTENDED_GENERAL_PARAMETERS",
+                json.dumps([]),
+            )
+        ),
         # This is an example to set EXTENDED_HEADER_MENUS
         # "EXTENDED_HEADER_MENUS": json.loads(env.str(
         #    "EXTENDED_HEADER_MENUS",

--- a/frontend/src/services/ServerContext.ts
+++ b/frontend/src/services/ServerContext.ts
@@ -33,6 +33,7 @@ export class ServerContext {
   passwordResetDisabled?: boolean;
   checkTermService?: boolean;
   termsOfServiceUrl?: string;
+  extendedGeneralParameters: { [key: string]: any };
   extendedHeaderMenus: {
     name: string;
     children: { name: string; url: string }[];
@@ -55,6 +56,7 @@ export class ServerContext {
     this.passwordResetDisabled = context.password_reset_disabled;
     this.checkTermService = context.checkTermService;
     this.termsOfServiceUrl = context.termsOfServiceUrl;
+    this.extendedGeneralParameters = context.extendedGeneralParameters;
     this.extendedHeaderMenus = context.extendedHeaderMenus;
     this.headerColor = context.headerColor;
     this.flags = context.flags ?? { webhook: true };

--- a/templates/frontend/index.html
+++ b/templates/frontend/index.html
@@ -33,6 +33,7 @@
           },
           legacyUiDisabled: {{airone.LEGACY_UI_DISABLED|yesno:"true,false"}},
           checkTermService: {{airone.CHECK_TERM_SERVICE|yesno:"true,false"}},
+          extendedGeneralParameters: {{ airone.EXTENDED_GENERAL_PARAMETERS|safe }},
           extendedHeaderMenus: {{ airone.EXTENDED_HEADER_MENUS|safe }},
           headerColor: {% if airone.HEADER_COLOR %}"{{ airone.HEADER_COLOR|safe }}"{% else %}null{% endif %},
           flags: {


### PR DESCRIPTION
This commit introduced new parameter `extendedGeneralParameters` that is expected to be used for general use-cases especially for specifying some value to custom-view.