### PR TITLE
Fix Elasticsearch update on entry deletion

### DIFF
--- a/entry/models.py
+++ b/entry/models.py
@@ -1993,9 +1993,6 @@ class Entry(ACLBase):
                     if group.is_active:
                         attrinfo["value"] = truncate(group.name)
                         attrinfo["referral_id"] = group.id
-                    else:
-                        attrinfo["key"] = ""
-                        attrinfo["value"] = ""
 
             elif entity_attr.type & AttrType.ROLE:
                 role = attrv.role
@@ -2003,9 +2000,6 @@ class Entry(ACLBase):
                     if role.is_active:
                         attrinfo["value"] = truncate(role.name)
                         attrinfo["referral_id"] = role.id
-                    else:
-                        attrinfo["key"] = ""
-                        attrinfo["value"] = ""
 
             # Basically register attribute information whatever value doesn't exist
             if not (entity_attr.type & AttrType._ARRAY and not is_recursive):

--- a/entry/models.py
+++ b/entry/models.py
@@ -1990,14 +1990,22 @@ class Entry(ACLBase):
             elif entity_attr.type & AttrType.GROUP:
                 group = attrv.group
                 if group:
-                    attrinfo["value"] = truncate(group.name)
-                    attrinfo["referral_id"] = group.id
+                    if group.is_active:
+                        attrinfo["value"] = truncate(group.name)
+                        attrinfo["referral_id"] = group.id
+                    else:
+                        attrinfo["key"] = ""
+                        attrinfo["value"] = ""
 
             elif entity_attr.type & AttrType.ROLE:
                 role = attrv.role
                 if role:
-                    attrinfo["value"] = truncate(role.name)
-                    attrinfo["referral_id"] = role.id
+                    if role.is_active:
+                        attrinfo["value"] = truncate(role.name)
+                        attrinfo["referral_id"] = role.id
+                    else:
+                        attrinfo["key"] = ""
+                        attrinfo["value"] = ""
 
             # Basically register attribute information whatever value doesn't exist
             if not (entity_attr.type & AttrType._ARRAY and not is_recursive):

--- a/group/models.py
+++ b/group/models.py
@@ -48,7 +48,6 @@ class Group(DjangoGroup):
         user = auto_complement.get_auto_complement_user(None)
         if not user:
             user = User.objects.create(username=settings.AIRONE["AUTO_COMPLEMENT_USER"])
-        job_register_referrals = None
 
         job_register_referrals = Job.new_register_referrals(
             user,
@@ -57,8 +56,7 @@ class Group(DjangoGroup):
             params={"group_id": self.id},
         )
 
-        if job_register_referrals:
-            job_register_referrals.run()
+        job_register_referrals.run()
 
     def has_permission(self, target_obj, permission_level):
         """[NOTE]

--- a/role/models.py
+++ b/role/models.py
@@ -122,7 +122,7 @@ class Role(models.Model):
             user,
             None,
             operation_value=JobOperation.ROLE_REGISTER_REFERRAL.value,
-            params={"role": self.id},
+            params={"role_id": self.id},
         )
 
         if job_register_referrals:

--- a/role/models.py
+++ b/role/models.py
@@ -116,7 +116,6 @@ class Role(models.Model):
         user = auto_complement.get_auto_complement_user(None)
         if not user:
             user = User.objects.create(username=settings.AIRONE["AUTO_COMPLEMENT_USER"])
-        job_register_referrals = None
 
         job_register_referrals = Job.new_register_referrals(
             user,
@@ -125,8 +124,7 @@ class Role(models.Model):
             params={"role_id": self.id},
         )
 
-        if job_register_referrals:
-            job_register_referrals.run()
+        job_register_referrals.run()
 
     def get_current_permission(self, aclbase) -> int:
         permissions = [x for x in self.permissions.all() if x.get_objid() == aclbase.id]

--- a/role/models.py
+++ b/role/models.py
@@ -99,6 +99,10 @@ class Role(models.Model):
         return super(Role, self).save(*args, **kwargs)
 
     def delete(self):
+        from airone.lib import auto_complement
+        from job.models import Job, JobOperation
+        from user.models import User
+
         """
         Override Model.delete method of Django
         """
@@ -109,8 +113,20 @@ class Role(models.Model):
         )
         self.save(update_fields=["is_active", "name"])
 
-        for entry in self.get_referred_entries():
-            entry.register_es()
+        user = auto_complement.get_auto_complement_user(None)
+        if not user:
+            user = User.objects.create(username=settings.AIRONE["AUTO_COMPLEMENT_USER"])
+        job_register_referrals = None
+
+        job_register_referrals = Job.new_register_referrals(
+            user,
+            None,
+            operation_value=JobOperation.ROLE_REGISTER_REFERRAL.value,
+            params={"role": self.id},
+        )
+
+        if job_register_referrals:
+            job_register_referrals.run()
 
     def get_current_permission(self, aclbase) -> int:
         permissions = [x for x in self.permissions.all() if x.get_objid() == aclbase.id]

--- a/role/tasks.py
+++ b/role/tasks.py
@@ -10,7 +10,7 @@ from role.models import Role
 @may_schedule_until_job_is_ready
 def edit_role_referrals(self, job: Job) -> JobStatus:
     params = json.loads(job.params)
-    role = Role.objects.get(id=params["role_id"])
+    role = Role.objects.get(id=params["role"])
 
     for entry in [x for x in role.get_referred_entries()]:
         entry.register_es()

--- a/role/tasks.py
+++ b/role/tasks.py
@@ -10,7 +10,7 @@ from role.models import Role
 @may_schedule_until_job_is_ready
 def edit_role_referrals(self, job: Job) -> JobStatus:
     params = json.loads(job.params)
-    role = Role.objects.get(id=params["role"])
+    role = Role.objects.get(id=params["role_id"])
 
     for entry in [x for x in role.get_referred_entries()]:
         entry.register_es()


### PR DESCRIPTION
The process triggered when an entry is deleted has been moved to the background. 
This fix resolves the issue where Elasticsearch was not updated correctly upon entry deletion.