### PR TITLE
Remove dependency on react router from error handler

### DIFF
--- a/frontend/src/ErrorHandler.tsx
+++ b/frontend/src/ErrorHandler.tsx
@@ -9,7 +9,6 @@ import {
 import { styled } from "@mui/material/styles";
 import React, { FC, useCallback, useEffect, useState } from "react";
 import { ErrorBoundary, FallbackProps } from "react-error-boundary";
-import { useNavigate } from "react-router-dom";
 import { useError } from "react-use";
 
 import { ForbiddenErrorPage } from "./pages/ForbiddenErrorPage";
@@ -46,16 +45,15 @@ interface GenericErrorProps {
 }
 
 const GenericError: FC<GenericErrorProps> = ({ children }) => {
-  const navigate = useNavigate();
   const [open, setOpen] = useState(true);
 
   const handleGoToTop = useCallback(() => {
-    navigate(topPath(), { replace: true });
-  }, [navigate]);
+    window.location.href = topPath();
+  }, []);
 
   const handleReload = useCallback(() => {
-    navigate(0);
-  }, [navigate]);
+    window.location.reload();
+  }, []);
 
   return (
     <Dialog open={open} onClose={() => setOpen(false)}>


### PR DESCRIPTION
`useNavigate()` should be called within react router `Router` context, but the `ErrorHandler` will not follow. So I remove dependency on the library from the component.

Currently the component doesn't work correctly:
```
router.js:284 Uncaught Error: useNavigate() may be used only in the context of a <Router> component.
    at invariant (router.js:284:11)
    at useNavigateUnstable (index.js:262:102)
    at useNavigate (index.js:259:46)
    at GenericError (ErrorHandler.tsx:64:55)
```