### PR TITLE
Fixed problem that might raise ElasticsearchException depends on context by SearchChain processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ### Changed
 
 ### Fixed
+* Fixed problem that might raise ElasticsearchException depends on context by
+  SearchChain processing.
+  Contributed by @hinashi, @userlocalhost
 
 ## v3.110.0
 

--- a/api_v1/entry/serializer.py
+++ b/api_v1/entry/serializer.py
@@ -317,7 +317,7 @@ class EntrySearchChainSerializer(serializers.Serializer):
             # All results of this request would be joined and pass to next request. It might be
             # huge request and leads to glitch of Elasticsearch by just a single request.
             # This is our original curcit breaker to prevent overload because of them.
-            if search_result.ret_count > CONFIG.SEARCH_CHAIN_ACCEPTABLE_RESULT_COUNT:
+            if len(search_result.ret_values) > CONFIG.SEARCH_CHAIN_ACCEPTABLE_RESULT_COUNT:
                 Logger.warning("Search Chain API error: SEARCH_CHAIN_ACCEPTABLE_RESULT_COUNT")
                 raise ElasticsearchException()
 

--- a/api_v1/entry/serializer.py
+++ b/api_v1/entry/serializer.py
@@ -302,14 +302,21 @@ class EntrySearchChainSerializer(serializers.Serializer):
             ]
 
             # get Entry informations from result
+            # NOTE: small limit(=1000) is workaround to prevent overload
             try:
                 search_result = AdvancedSearchService.search_entries(
-                    user, entity_id_list, hint_attrs, limit=99999
+                    user,
+                    entity_id_list,
+                    hint_attrs,
+                    limit=CONFIG.SEARCH_CHAIN_ACCEPTABLE_RESULT_COUNT,
                 )
             except Exception as e:
                 Logger.warning("Search Chain API error:%s" % e)
                 raise ElasticsearchException()
 
+            # All results of this request would be joined and pass to next request. It might be
+            # huge request and leads to glitch of Elasticsearch by just a single request.
+            # This is our original curcit breaker to prevent overload because of them.
             if search_result.ret_count > CONFIG.SEARCH_CHAIN_ACCEPTABLE_RESULT_COUNT:
                 Logger.warning("Search Chain API error: SEARCH_CHAIN_ACCEPTABLE_RESULT_COUNT")
                 raise ElasticsearchException()

--- a/api_v1/tests/entry/test_api_search_chain.py
+++ b/api_v1/tests/entry/test_api_search_chain.py
@@ -1,6 +1,6 @@
 import copy
 import json
-from unittest import mock
+from unittest import mock, skip
 
 from airone.lib.test import AironeViewTest
 from airone.lib.types import AttrType
@@ -1326,6 +1326,10 @@ class APITest(AironeViewTest):
             ),
         )
 
+    @skip("""
+    A situation that raises ElasticsearchException because of exceeding search count because of
+    installing workaround limitation cap won't be happened.
+    """)
     def test_search_chain_when_result_exceeds_acceptable_count(self):
         # Change configuration to test processing for acceptable result from elasticsearch
         ENTRY_CONFIG.conf["SEARCH_CHAIN_ACCEPTABLE_RESULT_COUNT"] = 2


### PR DESCRIPTION
But this is a workaround of it.