### PR TITLE
Changed git command for display the version

### DIFF
--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -270,7 +270,7 @@ class Common(Configuration):
 
     try:
         proc = subprocess.Popen(
-            "cd %s && git describe --tags" % BASE_DIR,
+            "cd %s && git tag --points-at | grep -v pagoda-core- | head -1" % BASE_DIR,
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,


### PR DESCRIPTION
It was excluded because it would be confused with the pagoda-core tag.