### PR TITLE
Fixed an error of auto-generate script by formality setting of DRF configuration

### DIFF
--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -822,6 +822,11 @@ class EntryAttributeValueRestoreAPI(generics.UpdateAPIView):
     ],
 )
 class EntryBulkDeleteAPI(generics.DestroyAPIView):
+    # (Execuse)
+    # Specifying serializer_class is necessary for passing processing
+    # of npm run generate
+    serializer_class = EntryUpdateSerializer
+
     def delete(self, request: Request, *args, **kwargs) -> Response:
         ids: list[str] = self.request.query_params.getlist("ids", [])
         if len(ids) == 0 or not all([id.isdecimal() for id in ids]):


### PR DESCRIPTION
This fixed following error that will be revealed when I run `npm run generate:client` command.

airone/entry/api_v2/views.py:817: Error [EntryBulkDeleteAPI]: exception raised while getting serializer. Hint: Is get_serializer_class() returning None or is get_queryset() not working without a request? Ignoring the view for now. (Exception: 'EntryBulkDeleteAPI' should either include a `serializer_class`
 attribute, or override the `get_serializer_class()` method.) 

As a result, there is no error by running same command in my environment 👍 
```
Schema generation summary:                                                                                                                                     
Warnings: 17 (9 unique)                                                                                                                                        
Errors:   0 (0 unique) 
```