### PR TITLE
Fix filtering of inactive users and groups in RoleExportAPI

### DIFF
--- a/role/api_v2/serializers.py
+++ b/role/api_v2/serializers.py
@@ -149,10 +149,10 @@ class RoleImportExportChildSerializer(serializers.ModelSerializer):
             "id": instance.id,
             "name": instance.name,
             "description": instance.description,
-            "users": [x.username for x in instance.users.all()],
-            "groups": [x.name for x in instance.groups.all()],
-            "admin_users": [x.username for x in instance.admin_users.all()],
-            "admin_groups": [x.name for x in instance.admin_groups.all()],
+            "users": [x.username for x in instance.users.filter(is_active=True)],
+            "groups": [x.name for x in instance.groups.filter(is_active=True)],
+            "admin_users": [x.username for x in instance.admin_users.filter(is_active=True)],
+            "admin_groups": [x.name for x in instance.admin_groups.filter(is_active=True)],
             "permissions": [_get_permission_data(x) for x in instance.permissions.all()],
         }
 

--- a/role/tests/test_api_v2.py
+++ b/role/tests/test_api_v2.py
@@ -332,6 +332,16 @@ class ViewTest(AironeViewTest):
         role = self._create_role("test-role")
         entity = self.create_entity(admin, "Entity")
         entity.full.roles.add(role)
+        user = User.objects.create(username="test_user")
+        group = Group.objects.create(name="test_group")
+
+        # Associate user and group with the role
+        role.users.set([user.id])
+        role.groups.set([group.id])
+
+        # Delete the user and group
+        user.delete()
+        group.delete()
 
         resp = self.client.get("/role/api/v2/export")
         data = yaml.safe_load(resp.content.decode("utf-8"))


### PR DESCRIPTION
This PR fixes the issue where inactive users and groups were included in the RoleExportAPI response. Filters have been applied to ensure only active data is exported.