### PR TITLE
feat: Prevent 4-byte character input in entry form validation

### DIFF
--- a/frontend/src/components/entry/entryForm/EntryFormSchema.test.ts
+++ b/frontend/src/components/entry/entryForm/EntryFormSchema.test.ts
@@ -248,6 +248,47 @@ describe("schema", () => {
     expect(() => schema.parse(value)).toThrow();
   });
 
+  test("validation fails if name contains 4-byte characters", () => {
+    const value = {
+      ...baseValue,
+      name: "テスト😊", // Contains emoji (4-byte character)
+    };
+
+    expect(() => schema.parse(value)).toThrow();
+  });
+
+  test("validation fails if string attribute value contains 4-byte characters", () => {
+    const value = {
+      ...baseValue,
+      attrs: {
+        string: {
+          ...baseValue.attrs.string,
+          value: {
+            asString: "テスト🚀", // Contains emoji (4-byte character)
+          },
+        },
+      },
+    };
+
+    expect(() => schema.parse(value)).toThrow();
+  });
+
+  test("validation fails if array string attribute value contains 4-byte characters", () => {
+    const value = {
+      ...baseValue,
+      attrs: {
+        arrayString: {
+          ...baseValue.attrs.arrayString,
+          value: {
+            asArrayString: [{ value: "テスト🎮" }], // Contains emoji (4-byte character)
+          },
+        },
+      },
+    };
+
+    expect(() => schema.parse(value)).toThrow();
+  });
+
   test("validation fails if array-string attr value is mandatory and empty", () => {
     const value = {
       ...baseValue,

--- a/frontend/src/components/entry/entryForm/EntryFormSchema.ts
+++ b/frontend/src/components/entry/entryForm/EntryFormSchema.ts
@@ -6,6 +6,25 @@ import { EditableEntry } from "./EditableEntry";
 import { AttributeTypes } from "services/Constants";
 import { schemaForType } from "services/ZodSchemaUtil";
 
+// Function to detect 4-byte characters (characters outside the BMP - Basic Multilingual Plane)
+const hasFourByteChars = (value: string): boolean => {
+  // Check for surrogate pairs (4-byte characters are represented as surrogate pairs in UTF-16)
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      // High surrogate
+      if (i + 1 < value.length) {
+        const nextCode = value.charCodeAt(i + 1);
+        if (nextCode >= 0xdc00 && nextCode <= 0xdfff) {
+          // Low surrogate - this is a 4-byte character (surrogate pair)
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+};
+
 // A schema that's compatible with existing types
 // TODO rethink it, e.g. consider to use union as a type of value
 export const schema = schemaForType<EditableEntry>()(
@@ -15,6 +34,9 @@ export const schema = schemaForType<EditableEntry>()(
       .trim()
       .min(1, "アイテム名は必須です")
       .max(200, "アイテム名が大きすぎます")
+      .refine((value) => !hasFourByteChars(value), {
+        message: "使用できない文字が含まれています",
+      })
       .default(""),
     schema: z.object({
       id: z.number(),
@@ -38,19 +60,29 @@ export const schema = schemaForType<EditableEntry>()(
               asString: z
                 .string()
                 .max(1 << 16, "属性の値が大きすぎます")
+                .refine((value) => !hasFourByteChars(value), {
+                  message: "使用できない文字が含まれています",
+                })
                 .default("")
                 .optional(),
               asArrayString: z
                 .array(
                   z.object({
-                    value: z.string().max(1 << 16, "属性の値が大きすぎます"),
+                    value: z
+                      .string()
+                      .max(1 << 16, "属性の値が大きすぎます")
+                      .refine((value) => !hasFourByteChars(value), {
+                        message: "使用できない文字が含まれています",
+                      }),
                   }),
                 )
                 .optional(),
               asObject: z
                 .object({
                   id: z.number(),
-                  name: z.string(),
+                  name: z.string().refine((value) => !hasFourByteChars(value), {
+                    message: "使用できない文字が含まれています",
+                  }),
                 })
                 .nullable()
                 .optional(),
@@ -58,17 +90,27 @@ export const schema = schemaForType<EditableEntry>()(
                 .array(
                   z.object({
                     id: z.number(),
-                    name: z.string(),
+                    name: z
+                      .string()
+                      .refine((value) => !hasFourByteChars(value), {
+                        message: "使用できない文字が含まれています",
+                      }),
                   }),
                 )
                 .optional(),
               asNamedObject: z
                 .object({
-                  name: z.string(),
+                  name: z.string().refine((value) => !hasFourByteChars(value), {
+                    message: "使用できない文字が含まれています",
+                  }),
                   object: z
                     .object({
                       id: z.number(),
-                      name: z.string(),
+                      name: z
+                        .string()
+                        .refine((value) => !hasFourByteChars(value), {
+                          message: "使用できない文字が含まれています",
+                        }),
                     })
                     .nullable()
                     .default(null),
@@ -77,11 +119,19 @@ export const schema = schemaForType<EditableEntry>()(
               asArrayNamedObject: z
                 .array(
                   z.object({
-                    name: z.string(),
+                    name: z
+                      .string()
+                      .refine((value) => !hasFourByteChars(value), {
+                        message: "使用できない文字が含まれています",
+                      }),
                     object: z
                       .object({
                         id: z.number(),
-                        name: z.string(),
+                        name: z
+                          .string()
+                          .refine((value) => !hasFourByteChars(value), {
+                            message: "使用できない文字が含まれています",
+                          }),
                       })
                       .nullable()
                       .default(null),
@@ -92,7 +142,9 @@ export const schema = schemaForType<EditableEntry>()(
               asGroup: z
                 .object({
                   id: z.number(),
-                  name: z.string(),
+                  name: z.string().refine((value) => !hasFourByteChars(value), {
+                    message: "使用できない文字が含まれています",
+                  }),
                 })
                 .nullable()
                 .optional(),
@@ -100,14 +152,20 @@ export const schema = schemaForType<EditableEntry>()(
                 .array(
                   z.object({
                     id: z.number(),
-                    name: z.string(),
+                    name: z
+                      .string()
+                      .refine((value) => !hasFourByteChars(value), {
+                        message: "使用できない文字が含まれています",
+                      }),
                   }),
                 )
                 .optional(),
               asRole: z
                 .object({
                   id: z.number(),
-                  name: z.string(),
+                  name: z.string().refine((value) => !hasFourByteChars(value), {
+                    message: "使用できない文字が含まれています",
+                  }),
                 })
                 .nullable()
                 .optional(),
@@ -115,7 +173,11 @@ export const schema = schemaForType<EditableEntry>()(
                 .array(
                   z.object({
                     id: z.number(),
-                    name: z.string(),
+                    name: z
+                      .string()
+                      .refine((value) => !hasFourByteChars(value), {
+                        message: "使用できない文字が含まれています",
+                      }),
                   }),
                 )
                 .optional(),


### PR DESCRIPTION
Add validation to reject entries with 4-byte characters (emojis) in:
- Entry name
- String attribute values
- Array string attribute values
- Object name fields

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/8dbccbf9-0cca-451a-81b8-135847f8b358" />
