### PR TITLE
feat(frontend): Add tooltips to improve UI usability

### DIFF
--- a/frontend/src/components/common/ClipboardCopyButton.tsx
+++ b/frontend/src/components/common/ClipboardCopyButton.tsx
@@ -16,14 +16,16 @@ export const ClipboardCopyButton: FC<Props> = ({ name }) => {
         disableHoverListener
         disableFocusListener
       >
-        <IconButton
-          onClick={() => {
-            global.navigator.clipboard.writeText(name);
-            setOpen(true);
-          }}
-        >
-          <ContentCopyIcon fontSize="small" />
-        </IconButton>
+        <Tooltip title="名前をコピーする">
+          <IconButton
+            onClick={() => {
+              global.navigator.clipboard.writeText(name);
+              setOpen(true);
+            }}
+          >
+            <ContentCopyIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
       </Tooltip>
     </ClickAwayListener>
   );

--- a/frontend/src/components/entity/EntityListCard.tsx
+++ b/frontend/src/components/entity/EntityListCard.tsx
@@ -78,13 +78,15 @@ export const EntityListCard: FC<Props> = ({ entity, setToggle }) => {
           <>
             <ClipboardCopyButton name={entity.name} />
 
-            <IconButton
-              onClick={(e) => {
-                setAnchorElem(e.currentTarget);
-              }}
-            >
-              <MoreVertIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="モデルの操作">
+              <IconButton
+                onClick={(e) => {
+                  setAnchorElem(e.currentTarget);
+                }}
+              >
+                <MoreVertIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
             <EntityControlMenu
               entityId={entity.id}
               anchorElem={anchorElem}

--- a/frontend/src/components/entry/EntryListCard.tsx
+++ b/frontend/src/components/entry/EntryListCard.tsx
@@ -62,9 +62,11 @@ export const EntryListCard: FC<Props> = ({ entityId, entry, setToggle }) => {
           <>
             <ClipboardCopyButton name={entry.name} />
 
-            <IconButton onClick={(e) => setAnchorElem(e.currentTarget)}>
-              <MoreVertIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="アイテムの操作">
+              <IconButton onClick={(e) => setAnchorElem(e.currentTarget)}>
+                <MoreVertIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
             <EntryControlMenu
               entityId={entityId}
               entryId={entry.id}

--- a/frontend/src/components/entry/SearchResultsTableHead.tsx
+++ b/frontend/src/components/entry/SearchResultsTableHead.tsx
@@ -11,6 +11,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
@@ -198,13 +199,19 @@ export const SearchResultsTableHead: FC<Props> = ({
             {/* SearchControlMenu would be invisible when Readonly Mode is True */}
             {!isReadonly && (
               <>
-                <StyledIconButton
-                  onClick={(e) => {
-                    setEntryMenuEls(e.currentTarget);
-                  }}
-                >
-                  {defaultEntryFilter ? <FilterAltIcon /> : <FilterListIcon />}
-                </StyledIconButton>
+                <Tooltip title="アイテム名でフィルタ">
+                  <StyledIconButton
+                    onClick={(e) => {
+                      setEntryMenuEls(e.currentTarget);
+                    }}
+                  >
+                    {defaultEntryFilter ? (
+                      <FilterAltIcon />
+                    ) : (
+                      <FilterListIcon />
+                    )}
+                  </StyledIconButton>
+                </Tooltip>
                 <SearchResultControlMenuForEntry
                   entryFilter={entryFilter}
                   anchorElem={entryMenuEls}
@@ -228,9 +235,11 @@ export const SearchResultsTableHead: FC<Props> = ({
               {(attrTypes[attrName] & EntryAttributeTypeTypeEnum.OBJECT) > 0 &&
                 !isReadonly &&
                 attrsFilter[attrName]?.joinedAttrname === undefined && (
-                  <StyledIconButton onClick={() => setJoinAttrname(attrName)}>
-                    <AddIcon />
-                  </StyledIconButton>
+                  <Tooltip title="アイテムの属性を結合する">
+                    <StyledIconButton onClick={() => setJoinAttrname(attrName)}>
+                      <AddIcon />
+                    </StyledIconButton>
+                  </Tooltip>
                 )}
               {attrName === joinAttrName && (
                 <AdvancedSearchJoinModal
@@ -244,21 +253,23 @@ export const SearchResultsTableHead: FC<Props> = ({
               )}
               {!isReadonly && (
                 <>
-                  <StyledIconButton
-                    onClick={(e) => {
-                      setAttributeMenuEls({
-                        ...attributeMenuEls,
-                        [attrName]: e.currentTarget,
-                      });
-                    }}
-                    sx={{ marginLeft: "auto" }}
-                  >
-                    {(isFiltered[attrName] ?? false) ? (
-                      <FilterAltIcon />
-                    ) : (
-                      <FilterListIcon />
-                    )}
-                  </StyledIconButton>
+                  <Tooltip title="属性値でフィルタ">
+                    <StyledIconButton
+                      onClick={(e) => {
+                        setAttributeMenuEls({
+                          ...attributeMenuEls,
+                          [attrName]: e.currentTarget,
+                        });
+                      }}
+                      sx={{ marginLeft: "auto" }}
+                    >
+                      {(isFiltered[attrName] ?? false) ? (
+                        <FilterAltIcon />
+                      ) : (
+                        <FilterListIcon />
+                      )}
+                    </StyledIconButton>
+                  </Tooltip>
                   <SearchResultControlMenu
                     attrFilter={attrsFilter[attrName]}
                     anchorElem={attributeMenuEls[attrName]}
@@ -283,13 +294,19 @@ export const SearchResultsTableHead: FC<Props> = ({
           <StyledTableCell sx={{ outline: "1px solid #FFFFFF" }}>
             <HeaderBox>
               <Typography>参照アイテム</Typography>
-              <StyledIconButton
-                onClick={(e) => {
-                  setReferralMenuEls(e.currentTarget);
-                }}
-              >
-                {defaultReferralFilter ? <FilterAltIcon /> : <FilterListIcon />}
-              </StyledIconButton>
+              <Tooltip title="参照アイテムでフィルタ">
+                <StyledIconButton
+                  onClick={(e) => {
+                    setReferralMenuEls(e.currentTarget);
+                  }}
+                >
+                  {defaultReferralFilter ? (
+                    <FilterAltIcon />
+                  ) : (
+                    <FilterListIcon />
+                  )}
+                </StyledIconButton>
+              </Tooltip>
               <SearchResultControlMenuForReferral
                 referralFilter={referralFilter}
                 anchorElem={referralMenuEls}

--- a/frontend/src/pages/__snapshots__/AdvancedSearchResultsPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/AdvancedSearchResultsPage.test.tsx.snap
@@ -218,7 +218,9 @@ exports[`should match snapshot 1`] = `
                             アイテム名
                           </p>
                           <button
+                            aria-label="アイテム名でフィルタ"
                             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-5ws45t-MuiButtonBase-root-MuiIconButton-root"
+                            data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
@@ -579,7 +581,9 @@ exports[`should match snapshot 1`] = `
                           アイテム名
                         </p>
                         <button
+                          aria-label="アイテム名でフィルタ"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-5ws45t-MuiButtonBase-root-MuiIconButton-root"
+                          data-mui-internal-clone-element="true"
                           tabindex="0"
                           type="button"
                         >

--- a/frontend/src/pages/__snapshots__/EntityListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntityListPage.test.tsx.snap
@@ -249,7 +249,9 @@ exports[`EntityListPage should match snapshot 1`] = `
                         </svg>
                       </button>
                       <button
+                        aria-label="モデルの操作"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
@@ -334,7 +336,9 @@ exports[`EntityListPage should match snapshot 1`] = `
                         </svg>
                       </button>
                       <button
+                        aria-label="モデルの操作"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
@@ -419,7 +423,9 @@ exports[`EntityListPage should match snapshot 1`] = `
                         </svg>
                       </button>
                       <button
+                        aria-label="モデルの操作"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
@@ -773,7 +779,9 @@ exports[`EntityListPage should match snapshot 1`] = `
                       </svg>
                     </button>
                     <button
+                      aria-label="モデルの操作"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"
                     >
@@ -858,7 +866,9 @@ exports[`EntityListPage should match snapshot 1`] = `
                       </svg>
                     </button>
                     <button
+                      aria-label="モデルの操作"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"
                     >
@@ -943,7 +953,9 @@ exports[`EntityListPage should match snapshot 1`] = `
                       </svg>
                     </button>
                     <button
+                      aria-label="モデルの操作"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"
                     >

--- a/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
@@ -289,7 +289,9 @@ exports[`EntryListPage should match snapshot 1`] = `
                         </svg>
                       </button>
                       <button
+                        aria-label="アイテムの操作"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
@@ -367,7 +369,9 @@ exports[`EntryListPage should match snapshot 1`] = `
                         </svg>
                       </button>
                       <button
+                        aria-label="アイテムの操作"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
@@ -445,7 +449,9 @@ exports[`EntryListPage should match snapshot 1`] = `
                         </svg>
                       </button>
                       <button
+                        aria-label="アイテムの操作"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
@@ -832,7 +838,9 @@ exports[`EntryListPage should match snapshot 1`] = `
                       </svg>
                     </button>
                     <button
+                      aria-label="アイテムの操作"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"
                     >
@@ -910,7 +918,9 @@ exports[`EntryListPage should match snapshot 1`] = `
                       </svg>
                     </button>
                     <button
+                      aria-label="アイテムの操作"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"
                     >
@@ -988,7 +998,9 @@ exports[`EntryListPage should match snapshot 1`] = `
                       </svg>
                     </button>
                     <button
+                      aria-label="アイテムの操作"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"
                     >


### PR DESCRIPTION
Add descriptive tooltips to various icon buttons across components:
- ClipboardCopyButton
- EntityListCard
- EntryListCard
- SearchResultsTableHead

These tooltips provide context for button actions, enhancing user experience and accessibility

for e.g.)
<img width="505" alt="image" src="https://github.com/user-attachments/assets/cbc573d4-e39c-48a4-96ea-d1a98cb0b2d4" />
