### PR TITLE
refactor: Migrate Grid components to Grid2

### DIFF
--- a/frontend/src/components/category/CategoryList.tsx
+++ b/frontend/src/components/category/CategoryList.tsx
@@ -1,5 +1,6 @@
 import AddIcon from "@mui/icons-material/Add";
-import { Box, Button, Container, Grid, List, Typography } from "@mui/material";
+import { Box, Button, Container, List, Typography } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import React, { FC, useState } from "react";
 import { Link, useNavigate } from "react-router";
 
@@ -77,7 +78,7 @@ export const CategoryList: FC<Props> = ({ isEdit = false }) => {
       ) : (
         <Grid container spacing={3}>
           {categories.value?.results.map((category) => (
-            <Grid item md={4} key={category.id}>
+            <Grid size={4} key={category.id}>
               <List
                 subheader={
                   <CategoryListHeader

--- a/frontend/src/components/entity/EntityList.tsx
+++ b/frontend/src/components/entity/EntityList.tsx
@@ -1,6 +1,7 @@
 import { PaginatedEntityListList } from "@dmm-com/airone-apiclient-typescript-fetch";
 import AddIcon from "@mui/icons-material/Add";
-import { Box, Button, Grid } from "@mui/material";
+import { Box, Button } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import React, { FC } from "react";
 import { Link } from "react-router";
 
@@ -59,7 +60,7 @@ export const EntityList: FC<Props> = ({
       {/* This box shows each entity Cards */}
       <Grid container spacing={2} id="entity_list">
         {entities.results?.map((entity) => (
-          <Grid item xs={4} key={entity.id}>
+          <Grid size={4} key={entity.id}>
             <EntityListCard entity={entity} setToggle={setToggle} />
           </Grid>
         ))}

--- a/frontend/src/components/entry/EntryList.tsx
+++ b/frontend/src/components/entry/EntryList.tsx
@@ -1,5 +1,6 @@
 import AddIcon from "@mui/icons-material/Add";
-import { Box, Button, Grid } from "@mui/material";
+import { Box, Button } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import React, { FC, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router";
 
@@ -81,7 +82,7 @@ export const EntryList: FC<Props> = ({ entityId, canCreateEntry = true }) => {
         <Grid container spacing={2} id="entry_list">
           {entries.value?.results?.map((entry) => {
             return (
-              <Grid item xs={4} key={entry.id}>
+              <Grid size={4} key={entry.id}>
                 <EntryListCard
                   entityId={entityId}
                   entry={entry}

--- a/frontend/src/components/entry/RestorableEntryList.tsx
+++ b/frontend/src/components/entry/RestorableEntryList.tsx
@@ -5,7 +5,6 @@ import {
   Card,
   CardActionArea,
   CardHeader,
-  Grid,
   IconButton,
   Modal,
   Paper,
@@ -17,6 +16,7 @@ import {
   TableRow,
   Typography,
 } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import { styled } from "@mui/material/styles";
 import { useSnackbar } from "notistack";
 import React, { FC, useState } from "react";
@@ -176,7 +176,7 @@ export const RestorableEntryList: FC<Props> = ({ entityId }) => {
         <Grid container spacing={2} id="entry_list">
           {entries.value?.results?.map((entry) => {
             return (
-              <Grid item xs={4} key={entry.id}>
+              <Grid size={4} key={entry.id}>
                 <StyledCard>
                   <StyledCardHeader
                     title={

--- a/frontend/src/components/user/UserList.tsx
+++ b/frontend/src/components/user/UserList.tsx
@@ -6,11 +6,11 @@ import {
   Card,
   CardActionArea,
   CardHeader,
-  Grid,
   IconButton,
   Tooltip,
   Typography,
 } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import { styled } from "@mui/material/styles";
 import React, { FC, useMemo, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router";
@@ -111,7 +111,7 @@ export const UserList: FC = ({}) => {
         <Grid container spacing={2} id="user_list">
           {users.value?.results?.map((user) => {
             return (
-              <Grid item xs={4} key={user.id}>
+              <Grid size={4} key={user.id}>
                 <Card sx={{ height: "100%" }}>
                   <StyledCardHeader
                     title={

--- a/frontend/src/pages/EntryDetailsPage.tsx
+++ b/frontend/src/pages/EntryDetailsPage.tsx
@@ -1,6 +1,7 @@
 import AppsIcon from "@mui/icons-material/Apps";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
-import { Box, Chip, Grid, IconButton, Stack, Typography } from "@mui/material";
+import { Box, Chip, IconButton, Stack, Typography } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import { styled } from "@mui/material/styles";
 import React, { FC, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
@@ -152,10 +153,10 @@ export const EntryDetailsPage: FC<Props> = ({
       </PageHeader>
 
       <Grid container flexGrow="1" columns={6}>
-        <LeftGrid item xs={1}>
+        <LeftGrid size={1}>
           <EntryReferral entryId={entryId} />
         </LeftGrid>
-        <Grid item xs={4}>
+        <Grid size={4}>
           {[
             {
               name: "attr_list",
@@ -184,9 +185,7 @@ export const EntryDetailsPage: FC<Props> = ({
             );
           })}
         </Grid>
-        <RightGrid item xs={1}>
-          {sideContent}
-        </RightGrid>
+        <RightGrid size={1}>{sideContent}</RightGrid>
       </Grid>
     </FlexBox>
   );

--- a/frontend/src/pages/ListAliasEntryPage.tsx
+++ b/frontend/src/pages/ListAliasEntryPage.tsx
@@ -1,6 +1,7 @@
 import { EntryBase } from "@dmm-com/airone-apiclient-typescript-fetch";
 import AppsIcon from "@mui/icons-material/Apps";
-import { Box, Container, Grid, IconButton } from "@mui/material";
+import { Box, Container, IconButton } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import { useSnackbar } from "notistack";
 import React, { FC, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
@@ -168,10 +169,8 @@ export const ListAliasEntryPage: FC = ({}) => {
             display="flex"
             alignItems="center"
           >
-            <Grid item xs={4}>
-              {entry.name}
-            </Grid>
-            <Grid item xs={8}>
+            <Grid size={4}>{entry.name}</Grid>
+            <Grid size={8}>
               <AliasEntryList
                 entry={entry}
                 handleCreate={handleCreate}

--- a/frontend/src/pages/__snapshots__/DashboardPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/DashboardPage.test.tsx.snap
@@ -72,10 +72,10 @@ exports[`should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 css-1qw2a80-MuiGrid-root"
+            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-3 css-ipzchf-MuiGrid2-root"
           >
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-4 css-1ube6tp-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
             >
               <ul
                 class="MuiList-root MuiList-padding MuiList-subheader css-h1es49-MuiList-root"
@@ -118,7 +118,7 @@ exports[`should match snapshot 1`] = `
               </ul>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-4 css-1ube6tp-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
             >
               <ul
                 class="MuiList-root MuiList-padding MuiList-subheader css-h1es49-MuiList-root"
@@ -161,7 +161,7 @@ exports[`should match snapshot 1`] = `
               </ul>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-4 css-1ube6tp-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
             >
               <ul
                 class="MuiList-root MuiList-padding MuiList-subheader css-h1es49-MuiList-root"
@@ -352,10 +352,10 @@ exports[`should match snapshot 1`] = `
           </div>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 css-1qw2a80-MuiGrid-root"
+          class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-3 css-ipzchf-MuiGrid2-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-4 css-1ube6tp-MuiGrid-root"
+            class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
           >
             <ul
               class="MuiList-root MuiList-padding MuiList-subheader css-h1es49-MuiList-root"
@@ -398,7 +398,7 @@ exports[`should match snapshot 1`] = `
             </ul>
           </div>
           <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-4 css-1ube6tp-MuiGrid-root"
+            class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
           >
             <ul
               class="MuiList-root MuiList-padding MuiList-subheader css-h1es49-MuiList-root"
@@ -441,7 +441,7 @@ exports[`should match snapshot 1`] = `
             </ul>
           </div>
           <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-4 css-1ube6tp-MuiGrid-root"
+            class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
           >
             <ul
               class="MuiList-root MuiList-padding MuiList-subheader css-h1es49-MuiList-root"

--- a/frontend/src/pages/__snapshots__/EntityListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntityListPage.test.tsx.snap
@@ -188,11 +188,11 @@ exports[`EntityListPage should match snapshot 1`] = `
               </a>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-11nsb57-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 css-ubb9a5-MuiGrid2-root"
               id="entity_list"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
               >
                 <div
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -277,7 +277,7 @@ exports[`EntityListPage should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
               >
                 <div
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -362,7 +362,7 @@ exports[`EntityListPage should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
               >
                 <div
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -712,11 +712,11 @@ exports[`EntityListPage should match snapshot 1`] = `
             </a>
           </div>
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-11nsb57-MuiGrid-root"
+            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 css-ubb9a5-MuiGrid2-root"
             id="entity_list"
           >
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
             >
               <div
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -801,7 +801,7 @@ exports[`EntityListPage should match snapshot 1`] = `
               </div>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
             >
               <div
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -886,7 +886,7 @@ exports[`EntityListPage should match snapshot 1`] = `
               </div>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
             >
               <div
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"

--- a/frontend/src/pages/__snapshots__/EntryDetailsPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryDetailsPage.test.tsx.snap
@@ -206,10 +206,10 @@ exports[`should match snapshot 1`] = `
           </div>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-container css-rvs8lc-MuiGrid-root"
+          class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row css-1sq6lgs-MuiGrid2-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1 css-1dv2ucr-MuiGrid-root"
+            class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-1 css-1lc06tg-MuiGrid2-root"
           >
             <div
               class="MuiBox-root css-0"
@@ -375,7 +375,7 @@ exports[`should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-vok43g-MuiGrid-root"
+            class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
           >
             <div
               class="MuiBox-root css-1310p9u"
@@ -421,7 +421,7 @@ exports[`should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1 css-1xemioo-MuiGrid-root"
+            class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-1 css-1d4ugon-MuiGrid2-root"
           >
             <div
               class="MuiBox-root css-0"
@@ -633,10 +633,10 @@ exports[`should match snapshot 1`] = `
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-container css-rvs8lc-MuiGrid-root"
+        class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row css-1sq6lgs-MuiGrid2-root"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1 css-1dv2ucr-MuiGrid-root"
+          class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-1 css-1lc06tg-MuiGrid2-root"
         >
           <div
             class="MuiBox-root css-0"
@@ -802,7 +802,7 @@ exports[`should match snapshot 1`] = `
           </div>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-vok43g-MuiGrid-root"
+          class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
         >
           <div
             class="MuiBox-root css-1310p9u"
@@ -848,7 +848,7 @@ exports[`should match snapshot 1`] = `
           </div>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1 css-1xemioo-MuiGrid-root"
+          class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-1 css-1d4ugon-MuiGrid2-root"
         >
           <div
             class="MuiBox-root css-0"

--- a/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
@@ -228,11 +228,11 @@ exports[`EntryListPage should match snapshot 1`] = `
               </a>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-11nsb57-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 css-ubb9a5-MuiGrid2-root"
               id="entry_list"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
               >
                 <div
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -310,7 +310,7 @@ exports[`EntryListPage should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
               >
                 <div
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -388,7 +388,7 @@ exports[`EntryListPage should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
               >
                 <div
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -771,11 +771,11 @@ exports[`EntryListPage should match snapshot 1`] = `
             </a>
           </div>
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-11nsb57-MuiGrid-root"
+            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 css-ubb9a5-MuiGrid2-root"
             id="entry_list"
           >
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
             >
               <div
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -853,7 +853,7 @@ exports[`EntryListPage should match snapshot 1`] = `
               </div>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
             >
               <div
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -931,7 +931,7 @@ exports[`EntryListPage should match snapshot 1`] = `
               </div>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
             >
               <div
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"

--- a/frontend/src/pages/__snapshots__/EntryRestorePage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryRestorePage.test.tsx.snap
@@ -224,11 +224,11 @@ exports[`should match snapshot 1`] = `
               </div>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-11nsb57-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 css-ubb9a5-MuiGrid2-root"
               id="entry_list"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
               >
                 <div
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -288,7 +288,7 @@ exports[`should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
               >
                 <div
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -348,7 +348,7 @@ exports[`should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
               >
                 <div
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -709,11 +709,11 @@ exports[`should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-11nsb57-MuiGrid-root"
+            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 css-ubb9a5-MuiGrid2-root"
             id="entry_list"
           >
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
             >
               <div
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -773,7 +773,7 @@ exports[`should match snapshot 1`] = `
               </div>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
             >
               <div
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"
@@ -833,7 +833,7 @@ exports[`should match snapshot 1`] = `
               </div>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
             >
               <div
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1re93eb-MuiPaper-root-MuiCard-root"

--- a/frontend/src/pages/__snapshots__/UserListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/UserListPage.test.tsx.snap
@@ -189,11 +189,11 @@ exports[`UserListPage should match snapshot 1`] = `
               </a>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-11nsb57-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 css-ubb9a5-MuiGrid2-root"
               id="user_list"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
               >
                 <div
                   class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-uqzz15-MuiPaper-root-MuiCard-root"
@@ -537,11 +537,11 @@ exports[`UserListPage should match snapshot 1`] = `
             </a>
           </div>
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-11nsb57-MuiGrid-root"
+            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 css-ubb9a5-MuiGrid2-root"
             id="user_list"
           >
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 css-17yh78r-MuiGrid2-root"
             >
               <div
                 class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-uqzz15-MuiPaper-root-MuiCard-root"


### PR DESCRIPTION
Use the new Grid, the current Grid will be deprecated
https://mui.com/material-ui/migration/upgrade-to-grid-v2/