### PR TITLE
Fixed creating attribute would fail if exists deleted attribute

### DIFF
--- a/entry/models.py
+++ b/entry/models.py
@@ -1475,15 +1475,16 @@ class Entry(ACLBase):
 
         # If multiple requests are invoked to make requests at the same time,
         # some may create the same attribute. So use get_or_create().
-        attr, is_created = Attribute.objects.get_or_create(
+        attr, _ = Attribute.objects.get_or_create(
             schema=base,
             parent_entry=self,
-            is_active=True,
             defaults={
                 "name": base.name,
                 "created_user": request_user,
             },
         )
+        if attr.is_active is False:
+            attr.restore()
         return attr
 
     def get_prev_refers_objects(self) -> QuerySet:

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -240,6 +240,12 @@ class ModelTest(AironeTestCase):
         self.assertTrue(entry.attrs.filter(id=attr.id).exists())
         self.assertEqual(entry.attrs.count(), 1)
 
+        # check that deleted attributes are restored
+        attr.delete()
+        entry.add_attribute_from_base(attrbase, user)
+        self.assertTrue(entry.attrs.filter(id=attr.id, is_active=True).exists())
+        self.assertEqual(entry.attrs.count(), 1)
+
     def test_status_update_methods_of_attribute_value(self):
         value = AttributeValue(value="hoge", created_user=self._user, parent_attr=self._attr)
         value.save()


### PR DESCRIPTION
There are cases where an attribute has been deleted and remains.
In such cases, there was an issue where a new attribute could not be created.