### PR TITLE
Fix TypeScript type safety issues and improve error handling

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
     ],
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "error",
-    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-explicit-any": "error",
   },
   parser: '@typescript-eslint/parser',
   parserOptions: {

--- a/frontend/src/components/category/CategoryForm.tsx
+++ b/frontend/src/components/category/CategoryForm.tsx
@@ -116,7 +116,7 @@ export const CategoryForm: FC<Props> = ({ control, setValue }) => {
                       isOptionEqualToValue={(option, value) =>
                         option.id === value.id
                       }
-                      onChange={(_e, value: any) => {
+                      onChange={(_e, value: { id: number; name: string }[]) => {
                         setValue("models", value, {
                           shouldDirty: true,
                           shouldValidate: true,

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -315,8 +315,8 @@ export const Header: FC = () => {
                 <SearchBox
                   placeholder="Search"
                   defaultValue={query}
-                  onKeyPress={(e) => {
-                    e.key === "Enter" && submitQuery(e.target.value);
+                  onKeyPress={(e, value) => {
+                    e.key === "Enter" && submitQuery(value);
                   }}
                   inputSx={{ height: "42px", "& input": { py: "9px" } }}
                 />

--- a/frontend/src/components/common/SearchBox.tsx
+++ b/frontend/src/components/common/SearchBox.tsx
@@ -1,7 +1,7 @@
 import SearchIcon from "@mui/icons-material/Search";
 import { InputAdornment, SxProps, TextField, Theme } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import React, { FC } from "react";
+import React, { FC, useRef } from "react";
 
 const StyledTextField = styled(TextField)({
   background: "#F4F4F4",
@@ -13,7 +13,7 @@ const StyledTextField = styled(TextField)({
 interface Props {
   placeholder: string;
   onChange?: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
-  onKeyPress?: (e: any) => void;
+  onKeyPress?: (e: React.KeyboardEvent<HTMLDivElement>, value: string) => void;
   value?: string;
   defaultValue?: string;
   inputSx?: SxProps<Theme>;
@@ -29,6 +29,8 @@ export const SearchBox: FC<Props> = ({
   inputSx,
   autoFocus,
 }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
   return (
     <StyledTextField
       key={defaultValue}
@@ -48,8 +50,13 @@ export const SearchBox: FC<Props> = ({
       defaultValue={defaultValue}
       value={value}
       onChange={onChange}
-      onKeyPress={onKeyPress}
+      onKeyDown={(e) => {
+        if (onKeyPress && inputRef.current && e.key === "Enter") {
+          onKeyPress(e, inputRef.current.value);
+        }
+      }}
       autoFocus={autoFocus}
+      inputRef={inputRef}
     />
   );
 };

--- a/frontend/src/components/entity/EntityList.test.tsx
+++ b/frontend/src/components/entity/EntityList.test.tsx
@@ -58,9 +58,9 @@ describe("EntityList", () => {
       fireEvent.change(screen.getByPlaceholderText("モデルを絞り込む"), {
         target: { value: "entity" },
       });
-      fireEvent.keyPress(screen.getByPlaceholderText("モデルを絞り込む"), {
+      fireEvent.keyDown(screen.getByPlaceholderText("モデルを絞り込む"), {
         key: "Enter",
-        code: 13,
+        code: "Enter",
         charCode: 13,
       });
     });

--- a/frontend/src/hooks/useTypedParams.tsx
+++ b/frontend/src/hooks/useTypedParams.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "react-router";
 
 export const useTypedParams = <
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Params extends { [K in keyof Params]: any },
 >() => {
   const params = useParams() as unknown as Partial<Params>;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -61,8 +61,8 @@ export const DashboardPage: FC = () => {
           <SearchBox
             placeholder="Search"
             defaultValue={query}
-            onKeyPress={(e) => {
-              e.key === "Enter" && submitQuery(e.target.value);
+            onKeyPress={(e, value) => {
+              e.key === "Enter" && submitQuery(value);
             }}
             autoFocus
           />

--- a/frontend/src/repository/AironeApiClient.ts
+++ b/frontend/src/repository/AironeApiClient.ts
@@ -532,21 +532,26 @@ class AironeApiClient {
   }
 
   async getGroupTrees(): Promise<GroupTree[]> {
+    interface APIGroupTreeData {
+      id: number;
+      name: string;
+      children: APIGroupTreeData[];
+    }
+
     const groupTrees = await this.group.groupApiV2GroupsTreeList();
 
-    // typing children here because API side type definition will break API client generation.
-    const toTyped = (groupTree: { [key: string]: any }): GroupTree => ({
-      id: groupTree["id"],
-      name: groupTree["name"],
-      children: groupTree["children"].map((child: { [key: string]: any }) =>
-        toTyped(child),
+    const toTyped = (groupTree: Partial<APIGroupTreeData>): GroupTree => ({
+      id: groupTree.id as number,
+      name: groupTree.name as string,
+      children: (groupTree.children || []).map(
+        (child: Partial<APIGroupTreeData>) => toTyped(child),
       ),
     });
 
     return groupTrees.map((groupTree) => ({
       id: groupTree.id,
       name: groupTree.name,
-      children: groupTree.children.map((child: { [key: string]: any }) =>
+      children: groupTree.children.map((child: Partial<APIGroupTreeData>) =>
         toTyped(child),
       ),
     }));

--- a/frontend/src/services/ServerContext.ts
+++ b/frontend/src/services/ServerContext.ts
@@ -3,7 +3,7 @@ class User {
   username: string;
   isSuperuser: boolean;
 
-  constructor(user: any) {
+  constructor(user: { id: number; username: string; isSuperuser: boolean }) {
     this.id = user.id;
     this.username = user.username;
     this.isSuperuser = user.isSuperuser;
@@ -14,6 +14,13 @@ const FlagKey = {
   0: "webhook",
 } as const;
 type FlagKey = (typeof FlagKey)[keyof typeof FlagKey];
+
+// windowオブジェクトの型拡張
+declare global {
+  interface Window {
+    django_context?: Record<string, unknown>;
+  }
+}
 
 /**
  * Context continued from server side to succeed information only server side can know.
@@ -33,7 +40,7 @@ export class ServerContext {
   passwordResetDisabled?: boolean;
   checkTermService?: boolean;
   termsOfServiceUrl?: string;
-  extendedGeneralParameters: { [key: string]: any };
+  extendedGeneralParameters: Record<string, unknown>;
   extendedHeaderMenus: {
     name: string;
     children: { name: string; url: string }[];
@@ -43,28 +50,46 @@ export class ServerContext {
 
   private static _instance: ServerContext | undefined;
 
-  constructor(context: any) {
-    this.loginNext = context.next;
-    this.title = context.title;
-    this.subTitle = context.subtitle;
-    this.noteDesc = context.note_desc;
-    this.noteLink = context.note_link;
-    this.version = context.version;
-    this.user = context.user ? new User(context.user) : undefined;
-    this.singleSignOnLoginUrl = context.singleSignOnLoginUrl;
-    this.legacyUiDisabled = context.legacyUiDisabled;
-    this.passwordResetDisabled = context.password_reset_disabled;
-    this.checkTermService = context.checkTermService;
-    this.termsOfServiceUrl = context.termsOfServiceUrl;
-    this.extendedGeneralParameters = context.extendedGeneralParameters;
-    this.extendedHeaderMenus = context.extendedHeaderMenus;
-    this.headerColor = context.headerColor;
-    this.flags = context.flags ?? { webhook: true };
+  constructor(context: Record<string, unknown>) {
+    this.loginNext = context.next as string;
+    this.title = context.title as string;
+    this.subTitle = context.subtitle as string;
+    this.noteDesc = context.note_desc as string;
+    this.noteLink = context.note_link as string;
+    this.version = context.version as string;
+    this.user = context.user
+      ? new User(
+          context.user as {
+            id: number;
+            username: string;
+            isSuperuser: boolean;
+          },
+        )
+      : undefined;
+    this.singleSignOnLoginUrl = context.singleSignOnLoginUrl as
+      | string
+      | undefined;
+    this.legacyUiDisabled = context.legacyUiDisabled as boolean | undefined;
+    this.passwordResetDisabled = context.password_reset_disabled as
+      | boolean
+      | undefined;
+    this.checkTermService = context.checkTermService as boolean | undefined;
+    this.termsOfServiceUrl = context.termsOfServiceUrl as string | undefined;
+    this.extendedGeneralParameters =
+      context.extendedGeneralParameters as Record<string, unknown>;
+    this.extendedHeaderMenus = context.extendedHeaderMenus as {
+      name: string;
+      children: { name: string; url: string }[];
+    }[];
+    this.headerColor = context.headerColor as string | undefined;
+    this.flags = (context.flags as Record<FlagKey, boolean>) ?? {
+      webhook: true,
+    };
   }
 
   static getInstance() {
-    if ((window as any).django_context) {
-      this._instance = new ServerContext((window as any).django_context);
+    if (typeof window !== "undefined" && window.django_context) {
+      this._instance = new ServerContext(window.django_context);
     }
     return this._instance;
   }

--- a/frontend/src/services/ZodSchemaUtil.ts
+++ b/frontend/src/services/ZodSchemaUtil.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 // see https://github.com/colinhacks/zod/issues/372#issuecomment-826380330
 export const schemaForType =
   <T>() =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   <S extends z.ZodType<T, any, any>>(arg: S) => {
     return arg;
   };

--- a/frontend/src/services/entry/Edit.test.ts
+++ b/frontend/src/services/entry/Edit.test.ts
@@ -4,11 +4,15 @@
 
 import { EntryAttributeTypeTypeEnum } from "@dmm-com/airone-apiclient-typescript-fetch";
 
-import { formalizeEntryInfo, convertAttrsFormatCtoS } from "./Edit";
+import {
+  EntryAttributeValueType,
+  convertAttrsFormatCtoS,
+  formalizeEntryInfo,
+} from "./Edit";
 
 import {
-  EditableEntryAttrs,
   EditableEntryAttrValue,
+  EditableEntryAttrs,
 } from "components/entry/entryForm/EditableEntry";
 
 Object.defineProperty(window, "django_context", {
@@ -89,10 +93,10 @@ test("formalizeEntryInfo should return expect value", () => {
           asArrayRole: [],
           asArrayString: [],
           asBoolean: false,
-          asGroup: undefined,
+          asGroup: null,
           asNamedObject: { name: "", object: null },
-          asObject: undefined,
-          asRole: undefined,
+          asObject: null,
+          asRole: null,
           asString: "",
         },
       },
@@ -111,10 +115,10 @@ test("formalizeEntryInfo should return expect value", () => {
           asArrayRole: [],
           asArrayString: [],
           asBoolean: false,
-          asGroup: undefined,
+          asGroup: null,
           asNamedObject: { name: "", object: null },
-          asObject: undefined,
-          asRole: undefined,
+          asObject: null,
+          asRole: null,
           asString: "",
         },
       },
@@ -133,10 +137,10 @@ test("formalizeEntryInfo should return expect value", () => {
           asArrayRole: [],
           asArrayString: [],
           asBoolean: false,
-          asGroup: undefined,
+          asGroup: null,
           asNamedObject: { name: "", object: null },
-          asObject: undefined,
-          asRole: undefined,
+          asObject: null,
+          asRole: null,
           asString: "",
         },
       },
@@ -254,7 +258,7 @@ test("convertAttrsFormatCtoS() returns expected value", () => {
       type: EntryAttributeTypeTypeEnum;
       value: EditableEntryAttrValue;
     };
-    expected_data: any;
+    expected_data: EntryAttributeValueType;
   }> = [
     // boolean
     {
@@ -439,13 +443,39 @@ test("convertAttrsFormatCtoS() returns expected value", () => {
   });
 });
 
+test("convertAttrsFormatCtoS() should return expected value", () => {
+  const client_data: Record<string, EditableEntryAttrs> = {
+    key: {
+      index: 0,
+      type: EntryAttributeTypeTypeEnum.BOOLEAN,
+      isMandatory: true,
+      schema: {
+        id: 1,
+        name: "test",
+      },
+      value: {
+        asBoolean: true,
+      },
+    },
+  };
+
+  const sending_data = convertAttrsFormatCtoS(client_data);
+
+  expect(sending_data).toStrictEqual([
+    {
+      id: 1,
+      value: true,
+    },
+  ]);
+});
+
 test("convertAttrsFormatCtoS() returns expected value when nothing value", () => {
   const cases: Array<{
     client_data: {
       type: EntryAttributeTypeTypeEnum;
       value: EditableEntryAttrValue;
     };
-    expected_data: any;
+    expected_data: EntryAttributeValueType;
   }> = [
     // boolean
     {

--- a/frontend/src/services/entry/Edit.ts
+++ b/frontend/src/services/entry/Edit.ts
@@ -13,6 +13,22 @@ import {
 } from "components/entry/entryForm/EditableEntry";
 import { Schema } from "components/entry/entryForm/EntryFormSchema";
 
+// zodの型推論を使ってEditableEntryAttrsの型を定義
+type SchemaAttrs = Schema["attrs"] extends Record<string, infer U> ? U : never;
+
+// 属性値の型定義（テストでも使用するためにエクスポート）
+export type EntryAttributeValueType =
+  | string
+  | boolean
+  | number
+  | null
+  | undefined
+  | Array<string>
+  | Array<number>
+  | { id: number | null; name: string }
+  | Array<{ id: number | null; name: string }>
+  | Array<{ id: number | null; name: string; _boolean: boolean }>;
+
 // Convert Entry information from server-side value to presentation format.
 // (NOTE) It might be needed to be refactored because if server returns proper format with frontend, this is not necessary.
 export function formalizeEntryInfo(
@@ -29,24 +45,24 @@ export function formalizeEntryInfo(
     attrs: entity.attrs
       .filter((attr) => !excludeAttrs.includes(attr.name))
       .filter((attr) => attr.id != 0)
-      .reduce((acc: Record<string, any>, attr) => {
+      .reduce((acc: Record<string, SchemaAttrs>, attr) => {
         function getAttrValue(
-          attrType: number,
+          attrType: EntryAttributeTypeTypeEnum,
           value: EntryAttributeValue | undefined,
-        ) {
+        ): EditableEntryAttrValue {
           if (!value) {
             return {
               asString: "",
               asBoolean: false,
-              asObject: undefined,
-              asGroup: undefined,
-              asRole: undefined,
-              asNamedObject: { name: "", object: null },
               asArrayString: [],
               asArrayObject: [],
               asArrayGroup: [],
               asArrayRole: [],
               asArrayNamedObject: [],
+              asObject: null,
+              asGroup: null,
+              asRole: null,
+              asNamedObject: { name: "", object: null },
             };
           }
 
@@ -62,14 +78,61 @@ export function formalizeEntryInfo(
             case EntryAttributeTypeTypeEnum.ARRAY_NAMED_OBJECT:
             case EntryAttributeTypeTypeEnum.ARRAY_NAMED_OBJECT_BOOLEAN:
               return (value?.asArrayNamedObject?.length ?? 0 > 0)
-                ? value
+                ? {
+                    asArrayNamedObject: value.asArrayNamedObject?.map(
+                      (item) => ({
+                        name: item.name,
+                        object: item.object,
+                        _boolean: false,
+                      }),
+                    ),
+                  }
                 : {
                     asArrayNamedObject: [
                       { name: "", object: null, _boolean: false },
                     ],
                   };
             default:
-              return value;
+              // u4ed6u306eu578bu306eu5834u5408u306fu9069u5207u306bu5909u63db
+              const result: EditableEntryAttrValue = {};
+
+              if (value.asBoolean !== undefined) {
+                result.asBoolean = value.asBoolean;
+              }
+
+              if (value.asString !== undefined) {
+                result.asString = value.asString;
+              }
+
+              if (value.asObject !== undefined) {
+                result.asObject = value.asObject;
+              }
+
+              if (value.asGroup !== undefined) {
+                result.asGroup = value.asGroup;
+              }
+
+              if (value.asRole !== undefined) {
+                result.asRole = value.asRole;
+              }
+
+              if (value.asNamedObject !== undefined) {
+                result.asNamedObject = value.asNamedObject;
+              }
+
+              if (value.asArrayObject !== undefined) {
+                result.asArrayObject = value.asArrayObject;
+              }
+
+              if (value.asArrayGroup !== undefined) {
+                result.asArrayGroup = value.asArrayGroup;
+              }
+
+              if (value.asArrayRole !== undefined) {
+                result.asArrayRole = value.asArrayRole;
+              }
+
+              return result;
           }
         }
 
@@ -77,13 +140,13 @@ export function formalizeEntryInfo(
 
         acc[String(attr.id)] = {
           index: attr.index,
-          type: attr.type,
+          type: attr.type as EntryAttributeTypeTypeEnum,
           isMandatory: attr.isMandatory,
           schema: {
             id: attr.id,
             name: attr.name,
           },
-          value: getAttrValue(attr.type, value),
+          value: getAttrValue(attr.type as EntryAttributeTypeTypeEnum, value),
         };
         return acc;
       }, {}),
@@ -94,7 +157,10 @@ export function convertAttrsFormatCtoS(
   attrs: Record<string, EditableEntryAttrs>,
 ): AttributeData[] {
   return Object.entries(attrs).map(([{}, attr]) => {
-    function getAttrValue(attrType: number, attrValue: EditableEntryAttrValue) {
+    function getAttrValue(
+      attrType: EntryAttributeTypeTypeEnum,
+      attrValue: EditableEntryAttrValue,
+    ): EntryAttributeValueType {
       switch (attrType) {
         case EntryAttributeTypeTypeEnum.STRING:
         case EntryAttributeTypeTypeEnum.TEXT:


### PR DESCRIPTION
Restrict not to use `any` in most cases.
Today, our development style is dramatically changing with gAI, and strict typing helps AI works. So I would like to improve typing for AI, not humans :)