### PR TITLE
Fixed behavior when there are no duplicate items in advanced search

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -282,10 +282,14 @@ def make_query(
                 keyword_infos = resp["aggregations"]["attr_aggs"]["attr_name_aggs"][
                     "attr_value_aggs"
                 ]["buckets"]
-                keyword_list = [x["key"] for x in keyword_infos]
-                hint_attr.keyword = CONFIG.OR_SEARCH_CHARACTER.join(
-                    ["^" + x + "$" for x in keyword_list]
-                )
+                if keyword_infos == []:
+                    # Since there are 0 duplicates, set a condition that will always be false.
+                    hint_attr.keyword = "a^"
+                else:
+                    keyword_list = [x["key"] for x in keyword_infos]
+                    hint_attr.keyword = CONFIG.OR_SEARCH_CHARACTER.join(
+                        ["^" + x + "$" for x in keyword_list]
+                    )
 
     # Making a query to send ElasticSearch by the specified parameters
     query: dict[str, Any] = {

--- a/entry/tests/test_service.py
+++ b/entry/tests/test_service.py
@@ -459,6 +459,25 @@ class AdvancedSearchServiceTest(AironeTestCase):
             [x.entry["name"] for x in result.ret_values], ["dup-%s" % i for i in range(4)]
         )
 
+    def test_search_entries_with_duplicated_filter_key_without_duplicated_item(self):
+        entity = self.create_entity_with_all_type_attributes(self._user)
+
+        self.add_entry(self._user, "entry1", entity, values={"str": ""})
+        self.add_entry(self._user, "entry2", entity, values={"str": "hoge"})
+        self.add_entry(self._user, "entry3", entity, values={"str": "fuga"})
+
+        result = AdvancedSearchService.search_entries(
+            self._user,
+            [entity.id],
+            [
+                AttrHint(
+                    name="str",
+                    filter_key=FilterKey.DUPLICATED,
+                )
+            ],
+        )
+        self.assertEqual(result.ret_count, 0)
+
     def test_search_entries_with_text_not_contained_filter_key(self):
         entity = self.create_entity_with_all_type_attributes(self._user)
 


### PR DESCRIPTION
There was an issue where filtering was not performed when there were no duplicate items.