### PR TITLE
Add error handling for non-UTF8 encodings in file download response

### DIFF
--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -210,7 +210,8 @@ def render(request, template, context={}):
 
 def get_download_response(io_stream, fname, encode="utf-8"):
     response = HttpResponse(
-        io_stream.getvalue().encode(encode), content_type="application/force-download"
+        io_stream.getvalue().encode(encode, errors="replace"),
+        content_type="application/force-download",
     )
     response["Content-Disposition"] = 'attachment; filename="{fn}"'.format(
         fn=urllib.parse.quote(smart_str(fname))


### PR DESCRIPTION
Some encodings will fail at unsupported characters. It allows to continue encoding with replacing that to `?`.