### PR TITLE
Enhance RoleAPI with filter and ordering support

### DIFF
--- a/role/api_v2/views.py
+++ b/role/api_v2/views.py
@@ -1,4 +1,5 @@
-from rest_framework import generics, serializers, status, viewsets
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import filters, generics, serializers, status, viewsets
 from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.response import Response
 
@@ -30,6 +31,9 @@ class RolePermission(BasePermission):
 class RoleAPI(viewsets.ModelViewSet):
     queryset = Role.objects.filter(is_active=True).prefetch_related("admin_users", "admin_groups")
     permission_classes = [IsAuthenticated & RolePermission]
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter, filters.SearchFilter]
+    search_fields = ["name"]
+    ordering = ["name"]
 
     def get_serializer_class(self):
         serializer = {

--- a/role/tests/test_api_v2.py
+++ b/role/tests/test_api_v2.py
@@ -399,3 +399,30 @@ class ViewTest(AironeViewTest):
         # Assert that the users and groups lists are empty
         self.assertEqual(role_data["users"], [])
         self.assertEqual(role_data["groups"], [])
+
+    def test_list_roles_with_ordering(self):
+        self.admin_login()
+        self._create_role("role-c")
+        self._create_role("role-a")
+        self._create_role("role-b")
+
+        resp = self.client.get("/role/api/v2/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            [x["name"] for x in resp.json()],
+            ["role-a", "role-b", "role-c"],
+        )
+
+        resp = self.client.get("/role/api/v2/?ordering=name")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            [x["name"] for x in resp.json()],
+            ["role-a", "role-b", "role-c"],
+        )
+
+        resp = self.client.get("/role/api/v2/?ordering=-name")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            [x["name"] for x in resp.json()],
+            ["role-c", "role-b", "role-a"],
+        )


### PR DESCRIPTION
Improved RoleAPI by enabling ordering and filtering capabilities via DRF's built-in backends.