### PR TITLE
Add ordering support to group tree API

### DIFF
--- a/group/api_v2/views.py
+++ b/group/api_v2/views.py
@@ -50,6 +50,9 @@ class GroupTreeAPI(viewsets.ReadOnlyModelViewSet):
     queryset = Group.objects.filter(parent_group__isnull=True, is_active=True)
     serializer_class = GroupTreeSerializer
     permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter, filters.SearchFilter]
+    ordering = ["name"]
+    search_fields = ["name"]
 
 
 class GroupImportAPI(generics.GenericAPIView):

--- a/group/tests/test_api_v2.py
+++ b/group/tests/test_api_v2.py
@@ -92,3 +92,17 @@ class ViewTest(AironeViewTest):
         obj = yaml.load(resp.content, Loader=yaml.SafeLoader)
         self.assertTrue(isinstance(obj, list))
         self.assertEqual(len(obj), 2)
+
+    def test_group_tree_parent_ordering(self):
+        self.admin_login()
+
+        self._create_group("group-b")
+        self._create_group("group-a")
+        self._create_group("group-c")
+
+        resp = self.client.get("/group/api/v2/groups/tree")
+        self.assertEqual(resp.status_code, 200)
+
+        body = resp.json()
+
+        self.assertEqual([g["name"] for g in body], ["group-a", "group-b", "group-c"])


### PR DESCRIPTION
Enabled alphabetical ordering of parent groups in the /groups/tree API response.