### PR TITLE
Fix: Hide group links and menu for unauthorized users

### DIFF
--- a/frontend/src/components/group/GroupTreeItem.tsx
+++ b/frontend/src/components/group/GroupTreeItem.tsx
@@ -45,13 +45,14 @@ export const GroupTreeItem: FC<Props> = ({
                 handleSelectGroupId(e.target.checked ? groupTree.id : null)
               }
             />
-            <Typography
-              component={AironeLink}
-              to={isSuperuser ? groupPath(groupTree.id) : "#"}
-            >
-              {groupTree.name}
-            </Typography>
-            {setGroupAnchorEls != null && (
+            {isSuperuser ? (
+              <Typography component={AironeLink} to={groupPath(groupTree.id)}>
+                {groupTree.name}
+              </Typography>
+            ) : (
+              <Typography>{groupTree.name}</Typography>
+            )}
+            {isSuperuser && setGroupAnchorEls != null && (
               <IconButton
                 sx={{ margin: "0 0 0 auto" }}
                 onClick={(e) => {

--- a/frontend/src/components/group/GroupTreeRoot.test.tsx
+++ b/frontend/src/components/group/GroupTreeRoot.test.tsx
@@ -7,8 +7,21 @@ import React from "react";
 
 import { TestWrapper } from "../../TestWrapper";
 import { GroupTree } from "../../repository/AironeApiClient";
+import { ServerContext } from "../../services/ServerContext";
 
 import { GroupTreeRoot } from "./GroupTreeRoot";
+
+// ServerContext のモック
+jest.mock("../../services/ServerContext", () => {
+  const mockInstance = {
+    user: { isSuperuser: false },
+  };
+  return {
+    ServerContext: {
+      getInstance: jest.fn(() => mockInstance),
+    },
+  };
+});
 
 describe("GroupTreeRoot", () => {
   const groups: GroupTree[] = [
@@ -35,23 +48,44 @@ describe("GroupTreeRoot", () => {
     },
   ];
 
-  test("should show groups", async function () {
-    render(
-      <GroupTreeRoot
-        groupTrees={groups}
-        selectedGroupId={1}
-        handleSelectGroupId={() => {
-          /* noop */
-        }}
-        setGroupAnchorEls={() => {
-          /* noop */
-        }}
-      />,
-      { wrapper: TestWrapper },
-    );
+  const baseProps = {
+    groupTrees: groups,
+    selectedGroupId: 1,
+    handleSelectGroupId: () => {},
+    setGroupAnchorEls: () => {},
+  };
+
+  afterEach(() => {
+    // ステートをテストごとに初期化
+    (ServerContext.getInstance as jest.Mock).mockReset();
+  });
+
+  test("renders correctly for general user (no menu buttons)", () => {
+    // 一般ユーザとしてモックを上書き
+    (ServerContext.getInstance as jest.Mock).mockReturnValue({
+      user: { isSuperuser: false },
+    });
+
+    render(<GroupTreeRoot {...baseProps} />, { wrapper: TestWrapper });
 
     expect(screen.getAllByRole("checkbox")).toHaveLength(4);
     expect(screen.getAllByRole("checkbox")[0]).toBeChecked();
+
+    // 一般ユーザは操作ボタンが表示されない想定
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+
+  test("renders correctly for superuser (menu buttons shown)", () => {
+    (ServerContext.getInstance as jest.Mock).mockReturnValue({
+      user: { isSuperuser: true },
+    });
+
+    render(<GroupTreeRoot {...baseProps} />, { wrapper: TestWrapper });
+
+    expect(screen.getAllByRole("checkbox")).toHaveLength(4);
+    expect(screen.getAllByRole("checkbox")[0]).toBeChecked();
+
+    // スーパーユーザの場合は、4つのグループそれぞれにボタンがある想定
     expect(screen.getAllByRole("button")).toHaveLength(4);
   });
 });

--- a/frontend/src/components/group/GroupTreeRoot.test.tsx
+++ b/frontend/src/components/group/GroupTreeRoot.test.tsx
@@ -11,7 +11,7 @@ import { ServerContext } from "../../services/ServerContext";
 
 import { GroupTreeRoot } from "./GroupTreeRoot";
 
-// ServerContext のモック
+// Mock for ServerContext
 jest.mock("../../services/ServerContext", () => {
   const mockInstance = {
     user: { isSuperuser: false },
@@ -56,12 +56,12 @@ describe("GroupTreeRoot", () => {
   };
 
   afterEach(() => {
-    // ステートをテストごとに初期化
+    // Reset mock state after each test
     (ServerContext.getInstance as jest.Mock).mockReset();
   });
 
   test("renders correctly for general user (no menu buttons)", () => {
-    // 一般ユーザとしてモックを上書き
+    // Mock as a general user
     (ServerContext.getInstance as jest.Mock).mockReturnValue({
       user: { isSuperuser: false },
     });
@@ -71,7 +71,7 @@ describe("GroupTreeRoot", () => {
     expect(screen.getAllByRole("checkbox")).toHaveLength(4);
     expect(screen.getAllByRole("checkbox")[0]).toBeChecked();
 
-    // 一般ユーザは操作ボタンが表示されない想定
+    // General users should not see any action buttons
     expect(screen.queryAllByRole("button")).toHaveLength(0);
   });
 
@@ -85,7 +85,7 @@ describe("GroupTreeRoot", () => {
     expect(screen.getAllByRole("checkbox")).toHaveLength(4);
     expect(screen.getAllByRole("checkbox")[0]).toBeChecked();
 
-    // スーパーユーザの場合は、4つのグループそれぞれにボタンがある想定
+    // Superusers should see menu buttons for each group
     expect(screen.getAllByRole("button")).toHaveLength(4);
   });
 });

--- a/frontend/src/components/group/GroupTreeRoot.tsx
+++ b/frontend/src/components/group/GroupTreeRoot.tsx
@@ -56,13 +56,14 @@ export const GroupTreeRoot: FC<Props> = ({
                   handleSelectGroupId(e.target.checked ? groupTree.id : null)
                 }
               />
-              <Typography
-                component={AironeLink}
-                to={isSuperuser ? groupPath(groupTree.id) : "#"}
-              >
-                {groupTree.name}
-              </Typography>
-              {setGroupAnchorEls != null && (
+              {isSuperuser ? (
+                <Typography component={AironeLink} to={groupPath(groupTree.id)}>
+                  {groupTree.name}
+                </Typography>
+              ) : (
+                <Typography>{groupTree.name}</Typography>
+              )}
+              {isSuperuser && setGroupAnchorEls != null && (
                 <IconButton
                   sx={{ margin: "0 0 0 auto" }}
                   onClick={(e) => {


### PR DESCRIPTION
Restricted access to group detail pages and actions from users without sufficient permissions.