### PR TITLE
Restrict access to RoleEditPage for unauthorized users

### DIFF
--- a/frontend/src/components/group/GroupTreeItem.test.tsx
+++ b/frontend/src/components/group/GroupTreeItem.test.tsx
@@ -80,11 +80,9 @@ describe("GroupTreeItem", () => {
   });
 
   test("should render group name as a link to detail page when user is superuser", () => {
-    // Override the mock to set user as superuser
-    const mockServerContext = ServerContext.getInstance() as {
-      user: { isSuperuser: boolean };
-    };
-    mockServerContext.user.isSuperuser = true;
+    (ServerContext.getInstance as jest.Mock).mockReturnValue({
+      user: { isSuperuser: true },
+    });
 
     const { container } = render(
       <GroupTreeItem
@@ -96,35 +94,30 @@ describe("GroupTreeItem", () => {
       { wrapper: TestWrapper },
     );
 
-    // Check that link exists and has a proper href attribute
-    // Note: The actual href value may vary depending on TestWrapper configuration
     const link = container.querySelector("a");
     expect(link).toBeInTheDocument();
     expect(link?.getAttribute("href")).not.toBe("#");
   });
 
-  test("should not render group name as a clickable link when user is not superuser", () => {
-    // Override the mock to set user as non-superuser
-    const mockServerContext = ServerContext.getInstance() as {
-      user: { isSuperuser: boolean };
-    };
-    mockServerContext.user.isSuperuser = false;
-
-    const { container } = render(
-      <GroupTreeItem
-        depth={0}
-        groupTrees={[mockGroupTrees[0]]}
-        selectedGroupId={null}
-        handleSelectGroupId={() => {}}
-      />,
-      { wrapper: TestWrapper },
-    );
-
-    // Check that link has "/" href due to TestWrapper configuration
-    // In a real scenario without TestWrapper, it might be "#"
-    const link = container.querySelector("a");
-    expect(link?.getAttribute("href")).toBe("/");
+test("should not render group name as a clickable link when user is not superuser", () => {
+  (ServerContext.getInstance as jest.Mock).mockReturnValue({
+    user: { isSuperuser: false },
   });
+
+  const { container } = render(
+    <GroupTreeItem
+      depth={0}
+      groupTrees={[mockGroupTrees[0]]}
+      selectedGroupId={null}
+      handleSelectGroupId={() => {}}
+    />,
+    { wrapper: TestWrapper },
+  );
+
+  const link = container.querySelector("a");
+  expect(link).toBeNull();
+});
+
 
   test("should check the checkbox when group ID matches selectedGroupId", () => {
     render(
@@ -197,6 +190,10 @@ describe("GroupTreeItem", () => {
   test("should display menu button when setGroupAnchorEls is provided", () => {
     const setGroupAnchorEls = jest.fn();
 
+    (ServerContext.getInstance as jest.Mock).mockReturnValue({
+      user: { isSuperuser: true },
+    });
+
     render(
       <GroupTreeItem
         depth={0}
@@ -224,12 +221,15 @@ describe("GroupTreeItem", () => {
     );
 
     const menuButtons = container.querySelectorAll("button");
-    // Checkboxes are not counted as buttons, so there should be 0 buttons when menu button is not shown
     expect(menuButtons.length).toBe(0);
   });
 
   test("should call setGroupAnchorEls with correct arguments when menu button is clicked", () => {
     const setGroupAnchorEls = jest.fn();
+
+    (ServerContext.getInstance as jest.Mock).mockReturnValue({
+      user: { isSuperuser: true },
+    });
 
     render(
       <GroupTreeItem
@@ -246,32 +246,29 @@ describe("GroupTreeItem", () => {
     fireEvent.click(menuButton);
 
     expect(setGroupAnchorEls).toHaveBeenCalled();
-    // Verify the argument - groupId should be correct
-    expect(setGroupAnchorEls.mock.calls[0][0].groupId).toBe(1);
-    // Verify that HTMLButtonElement is passed
-    expect(
-      setGroupAnchorEls.mock.calls[0][0].el instanceof HTMLButtonElement,
-    ).toBe(true);
+
+    const callArgs = setGroupAnchorEls.mock.calls[0][0];
+    expect(callArgs.groupId).toBe(1);
+    expect(callArgs.el instanceof HTMLButtonElement).toBe(true);
   });
 
   test("should recursively render child groups when they exist", () => {
     render(
       <GroupTreeItem
         depth={0}
-        groupTrees={[mockGroupTrees[1]]} // Use group2 which has a child
+        groupTrees={[mockGroupTrees[1]]}
         selectedGroupId={null}
         handleSelectGroupId={() => {}}
       />,
       { wrapper: TestWrapper },
     );
 
-    // Both parent and child group names should be displayed
     expect(screen.getByText("u30b0u30ebu30fcu30d72")).toBeInTheDocument();
     expect(screen.getByText("u5b50u30b0u30ebu30fcu30d71")).toBeInTheDocument();
   });
 
   test("should apply correct indent style based on depth", () => {
-    const CHILDREN_INDENT_WIDTH = 16; // Same constant as in the component
+    const CHILDREN_INDENT_WIDTH = 16;
     const testDepth = 2;
 
     const { container } = render(
@@ -285,8 +282,6 @@ describe("GroupTreeItem", () => {
     );
 
     const listItem = container.querySelector(".MuiListItem-root");
-    // Check that paddingLeft style matches the expected value
-    // Based on the calculation formula: (depth + 1) * CHILDREN_INDENT_WIDTH
     expect(listItem).toHaveStyle(
       `padding-left: ${(testDepth + 1) * CHILDREN_INDENT_WIDTH}px`,
     );

--- a/frontend/src/components/group/GroupTreeItem.test.tsx
+++ b/frontend/src/components/group/GroupTreeItem.test.tsx
@@ -99,25 +99,24 @@ describe("GroupTreeItem", () => {
     expect(link?.getAttribute("href")).not.toBe("#");
   });
 
-test("should not render group name as a clickable link when user is not superuser", () => {
-  (ServerContext.getInstance as jest.Mock).mockReturnValue({
-    user: { isSuperuser: false },
+  test("should not render group name as a clickable link when user is not superuser", () => {
+    (ServerContext.getInstance as jest.Mock).mockReturnValue({
+      user: { isSuperuser: false },
+    });
+
+    const { container } = render(
+      <GroupTreeItem
+        depth={0}
+        groupTrees={[mockGroupTrees[0]]}
+        selectedGroupId={null}
+        handleSelectGroupId={() => {}}
+      />,
+      { wrapper: TestWrapper },
+    );
+
+    const link = container.querySelector("a");
+    expect(link).toBeNull();
   });
-
-  const { container } = render(
-    <GroupTreeItem
-      depth={0}
-      groupTrees={[mockGroupTrees[0]]}
-      selectedGroupId={null}
-      handleSelectGroupId={() => {}}
-    />,
-    { wrapper: TestWrapper },
-  );
-
-  const link = container.querySelector("a");
-  expect(link).toBeNull();
-});
-
 
   test("should check the checkbox when group ID matches selectedGroupId", () => {
     render(

--- a/frontend/src/pages/RoleEditPage.tsx
+++ b/frontend/src/pages/RoleEditPage.tsx
@@ -23,6 +23,7 @@ import {
   extractAPIException,
   isResponseError,
 } from "services/AironeAPIErrorUtil";
+import { ForbiddenError } from "services/Exceptions";
 
 export const RoleEditPage: FC = () => {
   const { roleId } = useTypedParams<{ roleId?: number }>();
@@ -51,6 +52,12 @@ export const RoleEditPage: FC = () => {
   const role = useAsyncWithThrow(async () => {
     return roleId != null ? await aironeApiClient.getRole(roleId) : undefined;
   }, [roleId]);
+
+  useEffect(() => {
+    if (!role.loading && role.value && !role.value.isEditable) {
+      throw new ForbiddenError("Only admin can edit a role");
+    }
+  }, [role]);
 
   useEffect(() => {
     !role.loading && role.value != null && reset(role.value);


### PR DESCRIPTION
Adds frontend check using isEditable to prevent users without permission from viewing the role edit page. Shows a 403 error when accessed via direct URL.