### PR TITLE
Fix breadcrumb rendering in group edit page

### DIFF
--- a/frontend/src/pages/GroupEditPage.tsx
+++ b/frontend/src/pages/GroupEditPage.tsx
@@ -100,6 +100,9 @@ export const GroupEditPage: FC = () => {
     throw new ForbiddenError("only admin can edit a group");
   }
 
+  const pageTitle = group.value?.name ?? "新規グループの作成";
+  const pageDescription = willCreate ? undefined : "グループ編集";
+
   return (
     <Box>
       <AironeBreadcrumbs>
@@ -109,13 +112,11 @@ export const GroupEditPage: FC = () => {
         <Typography component={AironeLink} to={groupsPath()}>
           グループ管理
         </Typography>
-        <Typography color="textPrimary">グループ編集</Typography>
+        <Typography color="textPrimary">
+          {willCreate ? "新規グループの作成" : "グループの編集"}
+        </Typography>
       </AironeBreadcrumbs>
-
-      <PageHeader
-        title={group.value?.name ?? "新規グループの作成"}
-        description={group.value?.id != 0 ? "グループ編集" : undefined}
-      >
+      <PageHeader title={pageTitle} description={pageDescription}>
         <SubmitButton
           name="保存"
           disabled={!isDirty || !isValid || isSubmitting || isSubmitSuccessful}

--- a/frontend/src/pages/__snapshots__/GroupEditPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/GroupEditPage.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`EditGroupPage should match snapshot 1`] = `
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1bgbmvw-MuiTypography-root"
                     >
-                      グループ編集
+                      新規グループの作成
                     </p>
                   </li>
                 </ol>
@@ -90,9 +90,7 @@ exports[`EditGroupPage should match snapshot 1`] = `
               <h6
                 class="MuiTypography-root MuiTypography-subtitle1 css-1i3tsf3-MuiTypography-root"
                 id="description"
-              >
-                グループ編集
-              </h6>
+              />
               <div
                 class="MuiBox-root css-hoapfw"
               >
@@ -502,7 +500,7 @@ exports[`EditGroupPage should match snapshot 1`] = `
                   <p
                     class="MuiTypography-root MuiTypography-body1 css-1bgbmvw-MuiTypography-root"
                   >
-                    グループ編集
+                    新規グループの作成
                   </p>
                 </li>
               </ol>
@@ -528,9 +526,7 @@ exports[`EditGroupPage should match snapshot 1`] = `
             <h6
               class="MuiTypography-root MuiTypography-subtitle1 css-1i3tsf3-MuiTypography-root"
               id="description"
-            >
-              グループ編集
-            </h6>
+            />
             <div
               class="MuiBox-root css-hoapfw"
             >


### PR DESCRIPTION
Fixes breadcrumb label to show "create" or "edit" depending on groupId. Snapshot updated. Deprecated act usage remains out of scope.