### PR TITLE
Fix nested tooptip

### DIFF
--- a/frontend/src/components/common/ClipboardCopyButton.test.tsx
+++ b/frontend/src/components/common/ClipboardCopyButton.test.tsx
@@ -9,52 +9,14 @@ import { ClipboardCopyButton } from "./ClipboardCopyButton";
 
 import { TestWrapper } from "TestWrapper";
 
-// Mock MUI Tooltip component
-jest.mock("@mui/material", () => {
-  const actual = jest.requireActual("@mui/material");
-  return {
-    ...actual,
-    Tooltip: ({
-      children,
-      title,
-    }: {
-      children: React.ReactNode;
-      title: string;
-    }) => (
-      <div data-testid="tooltip" data-title={title}>
-        {children}
-      </div>
-    ),
-    ClickAwayListener: ({
-      children,
-      onClickAway,
-    }: {
-      children: React.ReactNode;
-      onClickAway: () => void;
-    }) => (
-      <div data-testid="click-away-listener" onClick={onClickAway}>
-        {children}
-      </div>
-    ),
-  };
-});
-
 describe("ClipboardCopyButton", () => {
   test("renders button correctly", () => {
     render(<ClipboardCopyButton name="テスト名" />, { wrapper: TestWrapper });
-
-    // Verify button exists
-    const button = screen.getByRole("button");
+    const button = screen.getByRole("button", { name: "名前をコピーする" });
     expect(button).toBeInTheDocument();
-
-    // Verify tooltip is correctly configured
-    const tooltips = screen.getAllByTestId("tooltip");
-    expect(
-      tooltips.some((t) => t.dataset.title === "名前をコピーする"),
-    ).toBeTruthy();
   });
 
-  test("copies text to clipboard when clicked", () => {
+  test("copies text to clipboard when clicked", async () => {
     // Mock clipboard API
     const writeTextMock = jest.fn();
     Object.defineProperty(navigator, "clipboard", {
@@ -63,31 +25,18 @@ describe("ClipboardCopyButton", () => {
     });
 
     render(<ClipboardCopyButton name="テスト名" />, { wrapper: TestWrapper });
+    const button = screen.getByRole("button", { name: "名前をコピーする" });
 
-    // Click the button
-    const button = screen.getByRole("button");
+    // ホバー時のTooltip
+    fireEvent.mouseOver(button);
+    expect(await screen.findByText("名前をコピーする")).toBeInTheDocument();
+
+    // クリック
     fireEvent.click(button);
-
-    // Verify clipboard API was called
     expect(writeTextMock).toHaveBeenCalledWith("テスト名");
 
-    // Verify copy completion tooltip is set
-    const tooltips = screen.getAllByTestId("tooltip");
-    expect(
-      tooltips.some((t) => t.dataset.title === "名前をコピーしました"),
-    ).toBeTruthy();
-  });
-
-  test("renders ClickAwayListener correctly", () => {
-    render(<ClipboardCopyButton name="テスト名" />, { wrapper: TestWrapper });
-
-    // Verify ClickAwayListener exists
-    const clickAwayListener = screen.getByTestId("click-away-listener");
-    expect(clickAwayListener).toBeInTheDocument();
-
-    // Simulate click event
-    fireEvent.click(clickAwayListener);
-
-    // Verify it executes without crashing (implicit assertion)
+    // クリック後のTooltip
+    fireEvent.mouseOver(button);
+    expect(await screen.findByText("名前をコピーしました")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/common/ClipboardCopyButton.tsx
+++ b/frontend/src/components/common/ClipboardCopyButton.tsx
@@ -1,5 +1,5 @@
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
-import { ClickAwayListener, IconButton, Tooltip } from "@mui/material";
+import { IconButton, Tooltip } from "@mui/material";
 import React, { FC, useState } from "react";
 
 interface Props {
@@ -7,26 +7,22 @@ interface Props {
 }
 
 export const ClipboardCopyButton: FC<Props> = ({ name }) => {
-  const [open, setOpen] = useState<boolean>(false);
+  const [copied, setCopied] = useState(false);
   return (
-    <ClickAwayListener onClickAway={() => setOpen(false)}>
-      <Tooltip
-        title="名前をコピーしました"
-        open={open}
-        disableHoverListener
-        disableFocusListener
+    <Tooltip
+      title={copied ? "名前をコピーしました" : "名前をコピーする"}
+      onClose={() => setCopied(false)}
+    >
+      <IconButton
+        aria-label="名前をコピーする"
+        onClick={() => {
+          global.navigator.clipboard.writeText(name);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1000);
+        }}
       >
-        <Tooltip title="名前をコピーする">
-          <IconButton
-            onClick={() => {
-              global.navigator.clipboard.writeText(name);
-              setOpen(true);
-            }}
-          >
-            <ContentCopyIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
-      </Tooltip>
-    </ClickAwayListener>
+        <ContentCopyIcon fontSize="small" />
+      </IconButton>
+    </Tooltip>
   );
 };

--- a/frontend/src/components/entity/EntityListCard.test.tsx
+++ b/frontend/src/components/entity/EntityListCard.test.tsx
@@ -76,7 +76,7 @@ describe("EntityListCard", () => {
     expect(moreButton).toBeInTheDocument();
   });
 
-  test("should copy entity name to clipboard when copy button is clicked", () => {
+  test("should copy entity name to clipboard when copy button is clicked", async () => {
     // Mock clipboard API
     Object.assign(navigator, {
       clipboard: {
@@ -88,11 +88,21 @@ describe("EntityListCard", () => {
       wrapper: TestWrapper,
     });
 
-    // Verify the correct button name
+    // ボタンはaria-labelで取得
     const copyButton = screen.getByRole("button", {
-      name: "名前をコピーしました",
+      name: "名前をコピーする",
     });
+
+    // ホバー時のTooltip
+    fireEvent.mouseOver(copyButton);
+    expect(await screen.findByText("名前をコピーする")).toBeInTheDocument();
+
+    // クリック
     fireEvent.click(copyButton);
+
+    // クリック後のTooltip
+    fireEvent.mouseOver(copyButton);
+    expect(await screen.findByText("名前をコピーしました")).toBeInTheDocument();
 
     // Verify the correct value was written to clipboard
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(entity.name);

--- a/frontend/src/pages/__snapshots__/EntityListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntityListPage.test.tsx.snap
@@ -230,7 +230,7 @@ exports[`EntityListPage should match snapshot 1`] = `
                       class="MuiCardHeader-action css-116l9hl-MuiCardHeader-action"
                     >
                       <button
-                        aria-label="名前をコピーしました"
+                        aria-label="名前をコピーする"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
@@ -317,7 +317,7 @@ exports[`EntityListPage should match snapshot 1`] = `
                       class="MuiCardHeader-action css-116l9hl-MuiCardHeader-action"
                     >
                       <button
-                        aria-label="名前をコピーしました"
+                        aria-label="名前をコピーする"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
@@ -404,7 +404,7 @@ exports[`EntityListPage should match snapshot 1`] = `
                       class="MuiCardHeader-action css-116l9hl-MuiCardHeader-action"
                     >
                       <button
-                        aria-label="名前をコピーしました"
+                        aria-label="名前をコピーする"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
@@ -760,7 +760,7 @@ exports[`EntityListPage should match snapshot 1`] = `
                     class="MuiCardHeader-action css-116l9hl-MuiCardHeader-action"
                   >
                     <button
-                      aria-label="名前をコピーしました"
+                      aria-label="名前をコピーする"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"
@@ -847,7 +847,7 @@ exports[`EntityListPage should match snapshot 1`] = `
                     class="MuiCardHeader-action css-116l9hl-MuiCardHeader-action"
                   >
                     <button
-                      aria-label="名前をコピーしました"
+                      aria-label="名前をコピーする"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"
@@ -934,7 +934,7 @@ exports[`EntityListPage should match snapshot 1`] = `
                     class="MuiCardHeader-action css-116l9hl-MuiCardHeader-action"
                   >
                     <button
-                      aria-label="名前をコピーしました"
+                      aria-label="名前をコピーする"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"

--- a/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntryListPage.test.tsx.snap
@@ -270,7 +270,7 @@ exports[`EntryListPage should match snapshot 1`] = `
                       class="MuiCardHeader-action css-116l9hl-MuiCardHeader-action"
                     >
                       <button
-                        aria-label="名前をコピーしました"
+                        aria-label="名前をコピーする"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
@@ -350,7 +350,7 @@ exports[`EntryListPage should match snapshot 1`] = `
                       class="MuiCardHeader-action css-116l9hl-MuiCardHeader-action"
                     >
                       <button
-                        aria-label="名前をコピーしました"
+                        aria-label="名前をコピーする"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
@@ -430,7 +430,7 @@ exports[`EntryListPage should match snapshot 1`] = `
                       class="MuiCardHeader-action css-116l9hl-MuiCardHeader-action"
                     >
                       <button
-                        aria-label="名前をコピーしました"
+                        aria-label="名前をコピーする"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
@@ -819,7 +819,7 @@ exports[`EntryListPage should match snapshot 1`] = `
                     class="MuiCardHeader-action css-116l9hl-MuiCardHeader-action"
                   >
                     <button
-                      aria-label="名前をコピーしました"
+                      aria-label="名前をコピーする"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"
@@ -899,7 +899,7 @@ exports[`EntryListPage should match snapshot 1`] = `
                     class="MuiCardHeader-action css-116l9hl-MuiCardHeader-action"
                   >
                     <button
-                      aria-label="名前をコピーしました"
+                      aria-label="名前をコピーする"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"
@@ -979,7 +979,7 @@ exports[`EntryListPage should match snapshot 1`] = `
                     class="MuiCardHeader-action css-116l9hl-MuiCardHeader-action"
                   >
                     <button
-                      aria-label="名前をコピーしました"
+                      aria-label="名前をコピーする"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"

--- a/frontend/src/pages/__snapshots__/UserListPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/UserListPage.test.tsx.snap
@@ -221,7 +221,7 @@ exports[`UserListPage should match snapshot 1`] = `
                       class="MuiCardHeader-action css-116l9hl-MuiCardHeader-action"
                     >
                       <button
-                        aria-label="名前をコピーしました"
+                        aria-label="名前をコピーする"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
@@ -542,7 +542,7 @@ exports[`UserListPage should match snapshot 1`] = `
                     class="MuiCardHeader-action css-116l9hl-MuiCardHeader-action"
                   >
                     <button
-                      aria-label="名前をコピーしました"
+                      aria-label="名前をコピーする"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"


### PR DESCRIPTION
It causes warning logs:

```
hook.js:608 MUI: You have provided a `title` prop to the child of <Tooltip />.
Remove this title prop `名前をコピーする` or the Tooltip component. Error Component Stack
    at Tooltip (Tooltip.js:345:97)
    at ClickAwayListener (ClickAwayListener.js:44:5)
    at ClipboardCopyButton (ClipboardCopyButton.tsx:44:19)
    at div (<anonymous>)
    at eval (emotion-element-489459f2.browser.development.esm.js:55:66)
    at div (<anonymous>)
    at eval (emotion-element-489459f2.browser.development.esm.js:55:66)
    at CardHeader (CardHeader.js:91:96)
    at eval (emotion-element-489459f2.browser.development.esm.js:55:66)
    at div (<anonymous>)
    at eval (emotion-element-489459f2.browser.development.esm.js:55:66)
    at Paper (Paper.js:88:96)
    at eval (emotion-element-489459f2.browser.development.esm.js:55:66)
    at Card (Card.js:46:96)
    at eval (emotion-element-489459f2.browser.development.esm.js:55:66)
    at EntityListCard (EntityListCard.tsx:84:21)
    at div (<anonymous>)
    at eval (emotion-element-489459f2.browser.development.esm.js:55:66)
    at Grid (createGrid.js:96:19)
    at div (<anonymous>)
    at eval (emotion-element-489459f2.browser.development.esm.js:55:66)
    at Grid (createGrid.js:96:19)
    at div (<anonymous>)
    at eval (emotion-element-489459f2.browser.development.esm.js:55:66)
    at Box (createBox.js:32:81)
    at EntityList (EntityList.tsx:20:23)
    at div (<anonymous>)
    at eval (emotion-element-489459f2.browser.development.esm.js:55:66)
    at Container (createContainer.js:118:19)
    at div (<anonymous>)
    at eval (emotion-element-489459f2.browser.development.esm.js:55:66)
    at Box (createBox.js:32:81)
    at EntityListPage (EntityListPage.tsx:88:51)
    at RenderedRoute (index.js:5227:26)
    at Outlet (index.js:5854:26)
    at RenderedRoute (index.js:5227:26)
    at RenderedRoute (index.js:5227:26)
    at RenderErrorBoundary (index.js:5186:5)
    at DataRoutes (index.js:5778:3)
    at Router (index.js:5863:13)
    at RouterProvider (index.js:5608:3)
    at AppRouter (AppRouter.tsx:44:27)
    at CheckTerms (CheckTerms.tsx:14:23)
    at ErrorBridge (ErrorHandler.tsx:117:23)
    at ErrorBoundary (react-error-boundary.development.esm.js:21:5)
    at ErrorHandler (ErrorHandler.tsx:137:23)
    at AppBase (AppBase.tsx:13:27)
    at SnackbarProvider (notistack.esm.js:1491:24)
    at eval (emotion-element-489459f2.browser.development.esm.js:55:66)
    at AironeSnackbarProvider (AironeSnackbarProvider.tsx:24:23)
```