### PR TITLE
Add dev rules and update test assertions with waitFor

### DIFF
--- a/frontend/src/TestWrapper.tsx
+++ b/frontend/src/TestWrapper.tsx
@@ -9,7 +9,7 @@ export const TestWrapper: FC<{ children: React.ReactNode }> = ({
   const theme = createTheme();
   return (
     <ThemeProvider theme={theme}>
-      <SnackbarProvider>
+      <SnackbarProvider maxSnack={1} autoHideDuration={100}>
         <MemoryRouter>{children}</MemoryRouter>
       </SnackbarProvider>
     </ThemeProvider>
@@ -22,7 +22,9 @@ export const TestWrapperWithoutRoutes: FC<{ children: React.ReactNode }> = ({
   const theme = createTheme();
   return (
     <ThemeProvider theme={theme}>
-      <SnackbarProvider>{children}</SnackbarProvider>
+      <SnackbarProvider maxSnack={1} autoHideDuration={100}>
+        {children}
+      </SnackbarProvider>
     </ThemeProvider>
   );
 };

--- a/frontend/src/components/user/ChangeUserAuthModal.test.tsx
+++ b/frontend/src/components/user/ChangeUserAuthModal.test.tsx
@@ -79,9 +79,11 @@ describe("ChangeUserAuthModal", () => {
       screen.getByRole("button", { name: "送信" }).click();
     });
 
-    expect(
-      screen.queryByText("認証方法の変更に成功しました"),
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByText("認証方法の変更に成功しました"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   test("should handle a failure on updating auth method", async () => {
@@ -109,8 +111,10 @@ describe("ChangeUserAuthModal", () => {
       screen.getByRole("button", { name: "送信" }).click();
     });
 
-    expect(
-      screen.queryByText("認証方法の変更に失敗しました"),
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByText("認証方法の変更に失敗しました"),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@mui/x-date-pickers": "^7.27.1",
         "@react-oauth/google": "^0.12.1",
         "@testing-library/jest-dom": "^5.17.0",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@types/encoding-japanese": "^2.2.1",
         "@types/jest": "^29.5.14",
         "@types/react-beautiful-dnd": "^13.1.8",
@@ -4216,10 +4216,11 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
-      "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4231,7 +4232,7 @@
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@testing-library/dom/node_modules/ansi-styles": {
@@ -4239,6 +4240,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4254,6 +4256,7 @@
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
       "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "deep-equal": "^2.0.5"
       }
@@ -4263,6 +4266,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4279,6 +4283,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4349,17 +4354,18 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
-      "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
+      "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.5.0",
+        "@testing-library/dom": "^9.0.0",
         "@types/react-dom": "^18.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "peerDependencies": {
         "react": "^18.0.0",
@@ -4383,10 +4389,11 @@
       "license": "MIT"
     },
     "node_modules/@types/aria-query": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.2.tgz",
-      "integrity": "sha512-PHKZuMN+K5qgKIWhBodXzQslTo5P+K/6LqeKXS6O/4liIDdZqaX5RXrCK++LAw+y/nptN48YmUMFiQHRSWYwtQ==",
-      "dev": true
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.2",
@@ -7357,15 +7364,16 @@
       }
     },
     "node_modules/deep-equal": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
-      "integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.5",
         "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.1",
+        "get-intrinsic": "^1.2.2",
         "is-arguments": "^1.1.1",
         "is-array-buffer": "^3.0.2",
         "is-date-object": "^1.0.5",
@@ -7375,11 +7383,14 @@
         "object-is": "^1.1.5",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.0",
+        "regexp.prototype.flags": "^1.5.1",
         "side-channel": "^1.0.4",
         "which-boxed-primitive": "^1.0.2",
         "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.9"
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7753,6 +7764,7 @@
       "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
       "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -9687,13 +9699,14 @@
       "dev": true
     },
     "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13413,6 +13426,7 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -13877,13 +13891,14 @@
       }
     },
     "node_modules/object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -15633,12 +15648,14 @@
       }
     },
     "node_modules/stop-iteration-iterator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "internal-slot": "^1.0.4"
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -20232,9 +20249,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
-      "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -20334,13 +20351,13 @@
       }
     },
     "@testing-library/react": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
-      "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
+      "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.5.0",
+        "@testing-library/dom": "^9.0.0",
         "@types/react-dom": "^18.0.0"
       }
     },
@@ -20357,9 +20374,9 @@
       "dev": true
     },
     "@types/aria-query": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.2.tgz",
-      "integrity": "sha512-PHKZuMN+K5qgKIWhBodXzQslTo5P+K/6LqeKXS6O/4liIDdZqaX5RXrCK++LAw+y/nptN48YmUMFiQHRSWYwtQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true
     },
     "@types/babel__core": {
@@ -22612,15 +22629,15 @@
       "requires": {}
     },
     "deep-equal": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
-      "integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
       "dev": true,
       "requires": {
         "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.5",
         "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.1",
+        "get-intrinsic": "^1.2.2",
         "is-arguments": "^1.1.1",
         "is-array-buffer": "^3.0.2",
         "is-date-object": "^1.0.5",
@@ -22630,11 +22647,11 @@
         "object-is": "^1.1.5",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.0",
+        "regexp.prototype.flags": "^1.5.1",
         "side-channel": "^1.0.4",
         "which-boxed-primitive": "^1.0.2",
         "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.9"
+        "which-typed-array": "^1.1.13"
       }
     },
     "deep-is": {
@@ -24309,13 +24326,13 @@
       "dev": true
     },
     "is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       }
     },
     "is-array-buffer": {
@@ -27405,13 +27422,13 @@
       "dev": true
     },
     "object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
       }
     },
     "object-keys": {
@@ -28626,12 +28643,13 @@
       "dev": true
     },
     "stop-iteration-iterator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
       "dev": true,
       "requires": {
-        "internal-slot": "^1.0.4"
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
       }
     },
     "strict-event-emitter": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@mui/x-date-pickers": "^7.27.1",
     "@react-oauth/google": "^0.12.1",
     "@testing-library/jest-dom": "^5.17.0",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@types/encoding-japanese": "^2.2.1",
     "@types/jest": "^29.5.14",
     "@types/react-beautiful-dnd": "^13.1.8",


### PR DESCRIPTION
Fix lots of warning logs on RTL
>       Warning: `ReactDOMTestUtils.act` is deprecated in favor of `React.act`. Import `act` from `react` instead of `react-dom/test-utils`. See https://react.dev/warnings/react-dom-test-utils for more info.