### PR TITLE
Allows the APIv2 advanced search to match entries without specified attributes if it has no attribute filter condition

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -348,10 +348,8 @@ def make_query(
             _make_referral_entity_query(hint_referral_entity_id)
         )
 
-    # Set the attribute name so that all the attributes specified in the attribute,
-    # to be searched can be used
-    if hint_attrs:
-        query["query"]["bool"]["filter"].append(
+    if any(hint.keyword for hint in hint_attrs):
+        query["query"]["bool"]["should"].append(
             {
                 "nested": {
                     "path": "attr",

--- a/airone/tests/test_elasticsearch.py
+++ b/airone/tests/test_elasticsearch.py
@@ -1,4 +1,3 @@
-
 from django.test import TestCase
 
 from airone.lib import elasticsearch

--- a/airone/tests/test_elasticsearch.py
+++ b/airone/tests/test_elasticsearch.py
@@ -1,3 +1,4 @@
+
 from django.test import TestCase
 
 from airone.lib import elasticsearch
@@ -200,6 +201,137 @@ class ElasticSearchTest(TestCase):
                 }
             },
         )
+
+    def test_make_query_allow_missing_attributes(self):
+        """Test make_query with allow_missing_attributes=True (APIv2 case)."""
+        query = elasticsearch.make_query(
+            hint_entity=self._entity,
+            hint_attrs=[
+                AttrHint(name="attr_with_keyword", keyword="has_keyword"),
+                AttrHint(name="attr_without_keyword", keyword=""),
+                AttrHint(name="another_attr_with_keyword", keyword="another_keyword"),
+            ],
+            entry_name="test_entry_apiv2",
+            allow_missing_attributes=True,
+        )
+
+        expected_query = {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "nested": {
+                                "path": "entity",
+                                "query": {"term": {"entity.id": self._entity.id}},
+                            }
+                        },
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "bool": {
+                                            "must": [
+                                                {
+                                                    "regexp": {
+                                                        "name": ".*[tT][eE][sS][tT]_[eE][nN][tT][rR][yY]_[aA][pP][iI][vV]2.*"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "nested": {
+                                "path": "attr",
+                                "query": {
+                                    "bool": {
+                                        "should": [
+                                            {"term": {"attr.name": "attr_with_keyword"}},
+                                            {"term": {"attr.name": "another_attr_with_keyword"}},
+                                        ],
+                                        "minimum_should_match": 1,
+                                    }
+                                },
+                            }
+                        },
+                        {
+                            "bool": {
+                                "filter": [
+                                    {
+                                        "nested": {
+                                            "path": "attr",
+                                            "query": {
+                                                "bool": {
+                                                    "filter": [
+                                                        {
+                                                            "term": {
+                                                                "attr.name": "attr_with_keyword"
+                                                            }
+                                                        },
+                                                        {
+                                                            "bool": {
+                                                                "should": [
+                                                                    {
+                                                                        "match": {
+                                                                            "attr.value": "has_keyword"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "regexp": {
+                                                                            "attr.value": ".*[hH][aA][sS]_[kK][eE][yY][wW][oO][rR][dD].*"
+                                                                        }
+                                                                    },
+                                                                ]
+                                                            }
+                                                        },
+                                                    ]
+                                                }
+                                            },
+                                        }
+                                    },
+                                    {
+                                        "nested": {
+                                            "path": "attr",
+                                            "query": {
+                                                "bool": {
+                                                    "filter": [
+                                                        {
+                                                            "term": {
+                                                                "attr.name": "another_attr_with_keyword"
+                                                            }
+                                                        },
+                                                        {
+                                                            "bool": {
+                                                                "should": [
+                                                                    {
+                                                                        "match": {
+                                                                            "attr.value": "another_keyword"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "regexp": {
+                                                                            "attr.value": ".*[aA][nN][oO][tT][hH][eE][rR]_[kK][eE][yY][wW][oO][rR][dD].*"
+                                                                        }
+                                                                    },
+                                                                ]
+                                                            }
+                                                        },
+                                                    ]
+                                                }
+                                            },
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ],
+                    "should": [],
+                }
+            }
+        }
+        self.assertEqual(query, expected_query)
 
     def test_make_query_for_simple(self):
         query = elasticsearch.make_query_for_simple("hoge|fuga&1", None, [], 0)

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -469,6 +469,7 @@ class AdvancedSearchAPI(generics.GenericAPIView):
                 is_output_all,
                 offset=entry_offset,
                 hint_entry=hint_entry,
+                allow_missing_attributes=True,  # For APIv2, allow entries missing attributes
             )
 
         # save total population number

--- a/entry/services.py
+++ b/entry/services.py
@@ -41,6 +41,7 @@ class AdvancedSearchService:
         hint_referral_entity_id: int | None = None,
         offset: int = 0,
         hint_entry: EntryHint | None = None,
+        allow_missing_attributes: bool = False,
     ) -> AdvancedSearchResults:
         """Main method called from advanced search.
 
@@ -70,6 +71,11 @@ class AdvancedSearchService:
                 The number of offset to get a part of a large amount of search results
             hint_entry (AttrHint | None): Defaults to None.
                 Input value used to refine the entry.
+            allow_missing_attributes (bool, optional): Defaults to False.
+                If True, entries that do not have attributes specified in hint_attrs
+                (without a keyword) will be included in the search results.
+                If False, attributes specified in hint_attrs (without a keyword)
+                must exist in the entry.
 
         Returns:
             AdvancedSearchResults: As a result of the search,
@@ -116,7 +122,13 @@ class AdvancedSearchService:
 
             # make query for elasticsearch to retrieve data user wants
             query = make_query(
-                entity, hint_attrs, entry_name, hint_referral, hint_referral_entity_id, hint_entry
+                entity,
+                hint_attrs,
+                entry_name,
+                hint_referral,
+                hint_referral_entity_id,
+                hint_entry,
+                allow_missing_attributes=allow_missing_attributes,
             )
 
             # sending request to elasticsearch with making query


### PR DESCRIPTION
SSIA, search entries in multiple entities more flexibly:

![image](https://github.com/user-attachments/assets/386bc2bc-e91c-4e11-9fb5-69bde1a55373)
