### PR TITLE
Replace predefined method_table with register decorator to avoid cycle imports

### DIFF
--- a/airone/celery.py
+++ b/airone/celery.py
@@ -29,3 +29,6 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks()
+
+# Recognize tasks explicitly
+import trigger.tasks  # noqa: F401, E402

--- a/airone/celery.py
+++ b/airone/celery.py
@@ -31,4 +31,9 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()
 
 # Recognize tasks explicitly
+import dashboard.tasks  # noqa: F401, E402
+import entity.tasks  # noqa: F401, E402
+import entry.tasks  # noqa: F401, E402
+import group.tasks  # noqa: F401, E402
+import role.tasks  # noqa: F401, E402
 import trigger.tasks  # noqa: F401, E402

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -9,10 +9,10 @@ from natsort import natsorted
 
 from airone.celery import app
 from airone.lib.elasticsearch import AdvancedSearchResultRecord, AttrHint
-from airone.lib.job import may_schedule_until_job_is_ready
+from airone.lib.job import may_schedule_until_job_is_ready, register_job_task
 from airone.lib.types import AttrType
 from entry.services import AdvancedSearchService
-from job.models import Job
+from job.models import Job, JobOperation
 
 
 def _csv_export(
@@ -164,6 +164,7 @@ def _yaml_export(
     return output
 
 
+@register_job_task(JobOperation.EXPORT_SEARCH_RESULT)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def export_search_result(self, job: Job):

--- a/entity/tasks.py
+++ b/entity/tasks.py
@@ -2,14 +2,15 @@ import json
 
 from airone.celery import app
 from airone.lib import custom_view
-from airone.lib.job import may_schedule_until_job_is_ready
+from airone.lib.job import may_schedule_until_job_is_ready, register_job_task
 from airone.lib.types import AttrType
 from entity.api_v2.serializers import EntityCreateSerializer, EntityUpdateSerializer
 from entity.models import Entity, EntityAttr
-from job.models import Job, JobStatus
+from job.models import Job, JobOperation, JobStatus
 from user.models import History, User
 
 
+@register_job_task(JobOperation.CREATE_ENTITY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def create_entity(self, job: Job) -> JobStatus:
@@ -52,6 +53,7 @@ def create_entity(self, job: Job) -> JobStatus:
     return JobStatus.DONE
 
 
+@register_job_task(JobOperation.EDIT_ENTITY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def edit_entity(self, job: Job) -> JobStatus:
@@ -158,6 +160,7 @@ def edit_entity(self, job: Job) -> JobStatus:
     return JobStatus.DONE
 
 
+@register_job_task(JobOperation.DELETE_ENTITY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def delete_entity(self, job: Job) -> JobStatus:
@@ -183,6 +186,7 @@ def delete_entity(self, job: Job) -> JobStatus:
     return JobStatus.DONE
 
 
+@register_job_task(JobOperation.CREATE_ENTITY_V2)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def create_entity_v2(self, job: Job) -> JobStatus:
@@ -198,6 +202,7 @@ def create_entity_v2(self, job: Job) -> JobStatus:
     return JobStatus.DONE
 
 
+@register_job_task(JobOperation.EDIT_ENTITY_V2)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def edit_entity_v2(self, job: Job) -> JobStatus:
@@ -216,6 +221,7 @@ def edit_entity_v2(self, job: Job) -> JobStatus:
     return JobStatus.DONE
 
 
+@register_job_task(JobOperation.DELETE_ENTITY_V2)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def delete_entity_v2(self, job: Job) -> JobStatus:

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -21,6 +21,7 @@ from airone.lib.http import DRFRequest
 from airone.lib.job import (
     may_schedule_until_job_is_ready,
     may_schedule_until_job_is_ready_with_handlers,
+    register_job_task,
 )
 from airone.lib.log import Logger
 from airone.lib.types import AttrType
@@ -43,7 +44,7 @@ from entry.api_v2.serializers import (
 from entry.models import Attribute, Entry
 from entry.services import AdvancedSearchService
 from group.models import Group
-from job.models import Job, JobStatus
+from job.models import Job, JobOperation, JobStatus
 from role.models import Role
 from user.models import User
 
@@ -355,6 +356,7 @@ def _yaml_export_v2(
     return output
 
 
+@register_job_task(JobOperation.CREATE_ENTRY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready_with_handlers(
     on_cancelled=lambda job: Entry.objects.filter(id=job.target.id, is_active=True).first().delete()
@@ -426,6 +428,7 @@ def create_entry_attrs(self, job: Job) -> JobStatus | None:
     return JobStatus.DONE
 
 
+@register_job_task(JobOperation.EDIT_ENTRY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def edit_entry_attrs(self, job: Job) -> JobStatus:
@@ -479,6 +482,7 @@ def edit_entry_attrs(self, job: Job) -> JobStatus:
     return JobStatus.DONE
 
 
+@register_job_task(JobOperation.DELETE_ENTRY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def delete_entry(self, job: Job) -> JobStatus:
@@ -495,6 +499,7 @@ def delete_entry(self, job: Job) -> JobStatus:
     return JobStatus.DONE
 
 
+@register_job_task(JobOperation.RESTORE_ENTRY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def restore_entry(self, job: Job):
@@ -519,6 +524,7 @@ def restore_entry(self, job: Job):
     return JobStatus.DONE
 
 
+@register_job_task(JobOperation.COPY_ENTRY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def copy_entry(self, job: Job) -> tuple[JobStatus, str, None] | None:
@@ -544,6 +550,7 @@ def copy_entry(self, job: Job) -> tuple[JobStatus, str, None] | None:
     return JobStatus.DONE, "Copy completed [%5d/%5d]" % (total_count, total_count), None
 
 
+@register_job_task(JobOperation.DO_COPY_ENTRY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def do_copy_entry(self, job: Job) -> tuple[JobStatus, str, None]:
@@ -580,6 +587,7 @@ def do_copy_entry(self, job: Job) -> tuple[JobStatus, str, None]:
     return JobStatus.DONE, "original entry: %s" % src_entry.name, dest_entry
 
 
+@register_job_task(JobOperation.IMPORT_ENTRY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def import_entries(self, job: Job) -> tuple[JobStatus, str, None] | None:
@@ -591,6 +599,7 @@ def import_entries(self, job: Job) -> tuple[JobStatus, str, None] | None:
     return None
 
 
+@register_job_task(JobOperation.IMPORT_ENTRY_V2)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def import_entries_v2(self, job: Job) -> tuple[JobStatus, str, None] | None:
@@ -640,6 +649,7 @@ def import_entries_v2(self, job: Job) -> tuple[JobStatus, str, None] | None:
         return JobStatus.DONE, "Imported Entry count: %d" % total_count, None
 
 
+@register_job_task(JobOperation.EXPORT_ENTRY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def export_entries(self, job: Job):
@@ -702,6 +712,7 @@ def export_entries(self, job: Job):
         job.set_cache(output.getvalue())
 
 
+@register_job_task(JobOperation.EXPORT_ENTRY_V2)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def export_entries_v2(self, job: Job):
@@ -768,6 +779,7 @@ def export_entries_v2(self, job: Job):
         job.set_cache(output.getvalue())
 
 
+@register_job_task(JobOperation.EXPORT_SEARCH_RESULT_V2)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def export_search_result_v2(self, job: Job):
@@ -825,6 +837,7 @@ def export_search_result_v2(self, job: Job):
         job.set_cache(output.getvalue())
 
 
+@register_job_task(JobOperation.REGISTER_REFERRALS)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def register_referrals(self, job: Job):
@@ -848,6 +861,7 @@ def _notify_event(
         return JobStatus.ERROR, str(e), None
 
 
+@register_job_task(JobOperation.UPDATE_DOCUMENT)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def update_es_documents(self, job: Job) -> JobStatus:
@@ -859,24 +873,28 @@ def update_es_documents(self, job: Job) -> JobStatus:
     return JobStatus.DONE
 
 
+@register_job_task(JobOperation.NOTIFY_CREATE_ENTRY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def notify_create_entry(self, job: Job) -> tuple[JobStatus, str, None] | None:
     return _notify_event(notify_entry_create, job.target.id, job.user)
 
 
+@register_job_task(JobOperation.NOTIFY_UPDATE_ENTRY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def notify_update_entry(self, job: Job) -> tuple[JobStatus, str, None] | None:
     return _notify_event(notify_entry_update, job.target.id, job.user)
 
 
+@register_job_task(JobOperation.NOTIFY_DELETE_ENTRY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def notify_delete_entry(self, job: Job) -> tuple[JobStatus, str, None] | None:
     return _notify_event(notify_entry_delete, job.target.id, job.user)
 
 
+@register_job_task(JobOperation.CREATE_ENTRY_V2)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def create_entry_v2(self, job: Job) -> JobStatus:
@@ -889,6 +907,7 @@ def create_entry_v2(self, job: Job) -> JobStatus:
     return JobStatus.DONE
 
 
+@register_job_task(JobOperation.EDIT_ENTRY_V2)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def edit_entry_v2(self, job: Job) -> JobStatus:
@@ -907,6 +926,7 @@ def edit_entry_v2(self, job: Job) -> JobStatus:
     return JobStatus.DONE
 
 
+@register_job_task(JobOperation.DELETE_ENTRY_V2)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def delete_entry_v2(self, job: Job) -> JobStatus:

--- a/group/tasks.py
+++ b/group/tasks.py
@@ -1,11 +1,12 @@
 import json
 
 from airone.celery import app
-from airone.lib.job import may_schedule_until_job_is_ready
+from airone.lib.job import may_schedule_until_job_is_ready, register_job_task
 from group.models import Group
-from job.models import Job, JobStatus
+from job.models import Job, JobOperation, JobStatus
 
 
+@register_job_task(JobOperation.GROUP_REGISTER_REFERRAL)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def edit_group_referrals(self, job: Job) -> JobStatus:

--- a/job/models.py
+++ b/job/models.py
@@ -356,43 +356,6 @@ class Job(models.Model):
 
     @classmethod
     def method_table(kls):
-        entry_task = kls.get_task_module("entry.tasks")
-        dashboard_task = kls.get_task_module("dashboard.tasks")
-        entity_task = kls.get_task_module("entity.tasks")
-        group_task = kls.get_task_module("group.tasks")
-        role_task = kls.get_task_module("role.tasks")
-
-        kls._METHOD_TABLE |= {
-            JobOperation.CREATE_ENTRY: entry_task.create_entry_attrs,
-            JobOperation.EDIT_ENTRY: entry_task.edit_entry_attrs,
-            JobOperation.DELETE_ENTRY: entry_task.delete_entry,
-            JobOperation.COPY_ENTRY: entry_task.copy_entry,
-            JobOperation.DO_COPY_ENTRY: entry_task.do_copy_entry,
-            JobOperation.IMPORT_ENTRY: entry_task.import_entries,
-            JobOperation.IMPORT_ENTRY_V2: entry_task.import_entries_v2,
-            JobOperation.EXPORT_ENTRY: entry_task.export_entries,
-            JobOperation.EXPORT_ENTRY_V2: entry_task.export_entries_v2,
-            JobOperation.RESTORE_ENTRY: entry_task.restore_entry,
-            JobOperation.EXPORT_SEARCH_RESULT: dashboard_task.export_search_result,
-            JobOperation.REGISTER_REFERRALS: entry_task.register_referrals,
-            JobOperation.CREATE_ENTITY: entity_task.create_entity,
-            JobOperation.EDIT_ENTITY: entity_task.edit_entity,
-            JobOperation.DELETE_ENTITY: entity_task.delete_entity,
-            JobOperation.NOTIFY_CREATE_ENTRY: entry_task.notify_create_entry,
-            JobOperation.NOTIFY_UPDATE_ENTRY: entry_task.notify_update_entry,
-            JobOperation.NOTIFY_DELETE_ENTRY: entry_task.notify_delete_entry,
-            JobOperation.GROUP_REGISTER_REFERRAL: group_task.edit_group_referrals,
-            JobOperation.ROLE_REGISTER_REFERRAL: role_task.edit_role_referrals,
-            JobOperation.UPDATE_DOCUMENT: entry_task.update_es_documents,
-            JobOperation.EXPORT_SEARCH_RESULT_V2: entry_task.export_search_result_v2,
-            JobOperation.CREATE_ENTITY_V2: entity_task.create_entity_v2,
-            JobOperation.EDIT_ENTITY_V2: entity_task.edit_entity_v2,
-            JobOperation.DELETE_ENTITY_V2: entity_task.delete_entity_v2,
-            JobOperation.CREATE_ENTRY_V2: entry_task.create_entry_v2,
-            JobOperation.EDIT_ENTRY_V2: entry_task.edit_entry_v2,
-            JobOperation.DELETE_ENTRY_V2: entry_task.delete_entry_v2,
-            JobOperation.IMPORT_ROLE_V2: role_task.import_role_v2,
-        }
         for operation_num, task in CUSTOM_TASKS.items():
             custom_task = kls.get_task_module("custom_view.tasks")
             kls._METHOD_TABLE |= {operation_num: getattr(custom_task, task)}

--- a/job/models.py
+++ b/job/models.py
@@ -356,47 +356,46 @@ class Job(models.Model):
 
     @classmethod
     def method_table(kls):
-        if not kls._METHOD_TABLE:
-            entry_task = kls.get_task_module("entry.tasks")
-            dashboard_task = kls.get_task_module("dashboard.tasks")
-            entity_task = kls.get_task_module("entity.tasks")
-            group_task = kls.get_task_module("group.tasks")
-            role_task = kls.get_task_module("role.tasks")
+        entry_task = kls.get_task_module("entry.tasks")
+        dashboard_task = kls.get_task_module("dashboard.tasks")
+        entity_task = kls.get_task_module("entity.tasks")
+        group_task = kls.get_task_module("group.tasks")
+        role_task = kls.get_task_module("role.tasks")
 
-            kls._METHOD_TABLE = {
-                JobOperation.CREATE_ENTRY: entry_task.create_entry_attrs,
-                JobOperation.EDIT_ENTRY: entry_task.edit_entry_attrs,
-                JobOperation.DELETE_ENTRY: entry_task.delete_entry,
-                JobOperation.COPY_ENTRY: entry_task.copy_entry,
-                JobOperation.DO_COPY_ENTRY: entry_task.do_copy_entry,
-                JobOperation.IMPORT_ENTRY: entry_task.import_entries,
-                JobOperation.IMPORT_ENTRY_V2: entry_task.import_entries_v2,
-                JobOperation.EXPORT_ENTRY: entry_task.export_entries,
-                JobOperation.EXPORT_ENTRY_V2: entry_task.export_entries_v2,
-                JobOperation.RESTORE_ENTRY: entry_task.restore_entry,
-                JobOperation.EXPORT_SEARCH_RESULT: dashboard_task.export_search_result,
-                JobOperation.REGISTER_REFERRALS: entry_task.register_referrals,
-                JobOperation.CREATE_ENTITY: entity_task.create_entity,
-                JobOperation.EDIT_ENTITY: entity_task.edit_entity,
-                JobOperation.DELETE_ENTITY: entity_task.delete_entity,
-                JobOperation.NOTIFY_CREATE_ENTRY: entry_task.notify_create_entry,
-                JobOperation.NOTIFY_UPDATE_ENTRY: entry_task.notify_update_entry,
-                JobOperation.NOTIFY_DELETE_ENTRY: entry_task.notify_delete_entry,
-                JobOperation.GROUP_REGISTER_REFERRAL: group_task.edit_group_referrals,
-                JobOperation.ROLE_REGISTER_REFERRAL: role_task.edit_role_referrals,
-                JobOperation.UPDATE_DOCUMENT: entry_task.update_es_documents,
-                JobOperation.EXPORT_SEARCH_RESULT_V2: entry_task.export_search_result_v2,
-                JobOperation.CREATE_ENTITY_V2: entity_task.create_entity_v2,
-                JobOperation.EDIT_ENTITY_V2: entity_task.edit_entity_v2,
-                JobOperation.DELETE_ENTITY_V2: entity_task.delete_entity_v2,
-                JobOperation.CREATE_ENTRY_V2: entry_task.create_entry_v2,
-                JobOperation.EDIT_ENTRY_V2: entry_task.edit_entry_v2,
-                JobOperation.DELETE_ENTRY_V2: entry_task.delete_entry_v2,
-                JobOperation.IMPORT_ROLE_V2: role_task.import_role_v2,
-            }
-            for operation_num, task in CUSTOM_TASKS.items():
-                custom_task = kls.get_task_module("custom_view.tasks")
-                kls._METHOD_TABLE |= {operation_num: getattr(custom_task, task)}
+        kls._METHOD_TABLE |= {
+            JobOperation.CREATE_ENTRY: entry_task.create_entry_attrs,
+            JobOperation.EDIT_ENTRY: entry_task.edit_entry_attrs,
+            JobOperation.DELETE_ENTRY: entry_task.delete_entry,
+            JobOperation.COPY_ENTRY: entry_task.copy_entry,
+            JobOperation.DO_COPY_ENTRY: entry_task.do_copy_entry,
+            JobOperation.IMPORT_ENTRY: entry_task.import_entries,
+            JobOperation.IMPORT_ENTRY_V2: entry_task.import_entries_v2,
+            JobOperation.EXPORT_ENTRY: entry_task.export_entries,
+            JobOperation.EXPORT_ENTRY_V2: entry_task.export_entries_v2,
+            JobOperation.RESTORE_ENTRY: entry_task.restore_entry,
+            JobOperation.EXPORT_SEARCH_RESULT: dashboard_task.export_search_result,
+            JobOperation.REGISTER_REFERRALS: entry_task.register_referrals,
+            JobOperation.CREATE_ENTITY: entity_task.create_entity,
+            JobOperation.EDIT_ENTITY: entity_task.edit_entity,
+            JobOperation.DELETE_ENTITY: entity_task.delete_entity,
+            JobOperation.NOTIFY_CREATE_ENTRY: entry_task.notify_create_entry,
+            JobOperation.NOTIFY_UPDATE_ENTRY: entry_task.notify_update_entry,
+            JobOperation.NOTIFY_DELETE_ENTRY: entry_task.notify_delete_entry,
+            JobOperation.GROUP_REGISTER_REFERRAL: group_task.edit_group_referrals,
+            JobOperation.ROLE_REGISTER_REFERRAL: role_task.edit_role_referrals,
+            JobOperation.UPDATE_DOCUMENT: entry_task.update_es_documents,
+            JobOperation.EXPORT_SEARCH_RESULT_V2: entry_task.export_search_result_v2,
+            JobOperation.CREATE_ENTITY_V2: entity_task.create_entity_v2,
+            JobOperation.EDIT_ENTITY_V2: entity_task.edit_entity_v2,
+            JobOperation.DELETE_ENTITY_V2: entity_task.delete_entity_v2,
+            JobOperation.CREATE_ENTRY_V2: entry_task.create_entry_v2,
+            JobOperation.EDIT_ENTRY_V2: entry_task.edit_entry_v2,
+            JobOperation.DELETE_ENTRY_V2: entry_task.delete_entry_v2,
+            JobOperation.IMPORT_ROLE_V2: role_task.import_role_v2,
+        }
+        for operation_num, task in CUSTOM_TASKS.items():
+            custom_task = kls.get_task_module("custom_view.tasks")
+            kls._METHOD_TABLE |= {operation_num: getattr(custom_task, task)}
 
         return kls._METHOD_TABLE
 

--- a/job/tests/test_model.py
+++ b/job/tests/test_model.py
@@ -257,11 +257,13 @@ class ModelTest(AironeTestCase):
 
     def test_method_table(self):
         method_table = Job.method_table()
+        expected_operations = sorted([x for x in JobOperation] + [x for x in JobOperationCustom])
 
         # This confirms all operations of JobOperation are registered
-        self.assertListEqual(
-            sorted([x for x in method_table]),
-            sorted([x for x in JobOperation] + [x for x in JobOperationCustom]),
+        self.maxDiff = None
+        self.assertCountEqual(
+            list(method_table.keys()),
+            expected_operations,
         )
 
         # This confirms the number of JobOperation and method_table count is same
@@ -286,5 +288,8 @@ class ModelTest(AironeTestCase):
         self.assertEqual(job.run(will_delay=False), "result of custom_method")
 
         # check unable to overwrite method when specified operation has already registered.
-        Job.register_method_table("custom_operation", another_custom_method)
+        # It should raise ValueError
+        with self.assertRaises(ValueError):
+            Job.register_method_table("custom_operation", another_custom_method)
+        # Ensure the original method is still registered
         self.assertEqual(job.run(will_delay=False), "result of custom_method")

--- a/job/tests/test_model.py
+++ b/job/tests/test_model.py
@@ -258,16 +258,14 @@ class ModelTest(AironeTestCase):
     def test_method_table(self):
         method_table = Job.method_table()
 
+        # This confirms all operations of JobOperation are registered
+        self.assertListEqual(
+            sorted([x for x in method_table]),
+            sorted([x for x in JobOperation] + [x for x in JobOperationCustom]),
+        )
+
         # This confirms the number of JobOperation and method_table count is same
         self.assertEqual(len(method_table), len(JobOperation) + len(JobOperationCustom))
-
-        # This confirms all operations of JobOperation are registered
-        self.assertTrue(
-            all(
-                [x.value in method_table for x in JobOperation]
-                + [x.value in method_table for x in JobOperationCustom]
-            )
-        )
 
     def test_register_method_table(self):
         @app.task(bind=True)

--- a/role/tasks.py
+++ b/role/tasks.py
@@ -2,14 +2,15 @@ import json
 
 from acl.models import ACLBase
 from airone.celery import app
-from airone.lib.job import may_schedule_until_job_is_ready
+from airone.lib.job import may_schedule_until_job_is_ready, register_job_task
 from airone.lib.log import Logger
 from group.models import Group
-from job.models import Job, JobStatus
+from job.models import Job, JobOperation, JobStatus
 from role.models import Role
 from user.models import User
 
 
+@register_job_task(JobOperation.ROLE_REGISTER_REFERRAL)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def edit_role_referrals(self, job: Job) -> JobStatus:
@@ -22,6 +23,7 @@ def edit_role_referrals(self, job: Job) -> JobStatus:
     return JobStatus.DONE
 
 
+@register_job_task(JobOperation.IMPORT_ROLE_V2)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def import_role_v2(self, job: Job) -> tuple[JobStatus, str, None] | None:

--- a/trigger/tasks.py
+++ b/trigger/tasks.py
@@ -1,15 +1,16 @@
 import json
 
 from airone.celery import app
-from airone.lib.job import may_schedule_until_job_is_ready
+from airone.lib.job import may_schedule_until_job_is_ready, register_job_task
 from entry.models import Entry
-from job.models import Job, JobStatus
+from job.models import Job, JobOperation, JobStatus
 from trigger.models import (
     TriggerCondition,
 )
 from user.models import User
 
 
+@register_job_task(JobOperation.MAY_INVOKE_TRIGGER)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def may_invoke_trigger(self, job: Job) -> JobStatus:


### PR DESCRIPTION
Simplify module dependencies, previously job <-> tasks requires each others, now just tasks require the job.