### PR TITLE
fix: handle empty string case in Elasticsearch regex pattern generation

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -495,7 +495,7 @@ def _get_regex_pattern(keyword: str) -> str:
 
     # Elasticsearch doesn't support anchor operators,
     begin = ".*"
-    if escaped[0] == "^":
+    if escaped and escaped[0] == "^":
         begin = ""
         escaped = escaped.lstrip("^")
 

--- a/airone/tests/test_elasticsearch.py
+++ b/airone/tests/test_elasticsearch.py
@@ -38,6 +38,10 @@ class ElasticSearchTest(TestCase):
         p2 = elasticsearch._get_regex_pattern("^keyword$")
         self.assertEqual(p2, "[kK][eE][yY][wW][oO][rR][dD]")
 
+        # with empty string
+        p3 = elasticsearch._get_regex_pattern("")
+        self.assertEqual(p3, ".*.*")
+
     def test_make_query(self):
         query = elasticsearch.make_query(
             hint_entity=self._entity,


### PR DESCRIPTION
Ensure not to raise `IndexError` on the pattern builder. Currently its possible that a user filter advanced search results with spaces like ` `, `　`