### PR TITLE
Reorder attribute type dropdown and handle missing definitions

### DIFF
--- a/frontend/src/components/entity/entityForm/AttributeField.tsx
+++ b/frontend/src/components/entity/entityForm/AttributeField.tsx
@@ -35,6 +35,24 @@ const StyledBox = styled(Box)(({ theme }) => ({
   gap: "8px",
 }));
 
+// Define the custom display order for attribute types
+const ATTRIBUTE_TYPE_ORDER = [
+  "string",
+  "array_string",
+  "object",
+  "array_object",
+  "named_object",
+  "array_named_object",
+  "group",
+  "array_group",
+  "role",
+  "array_role",
+  "text",
+  "boolean",
+  "date",
+  "datetime",
+];
+
 interface Props {
   control: Control<Schema>;
   setValue: UseFormSetValue<Schema>;
@@ -71,9 +89,9 @@ export const AttributeField: FC<Props> = ({
   const [openModal, setOpenModal] = useState(false);
 
   const attributeTypeMenuItems = useMemo(() => {
-    return Object.keys(AttributeTypes).map((typename, index) => (
-      <MenuItem key={index} value={AttributeTypes[typename].type}>
-        {AttributeTypes[typename].name}
+    return ATTRIBUTE_TYPE_ORDER.map((key) => (
+      <MenuItem key={key} value={AttributeTypes[key].type}>
+        {AttributeTypes[key].name}
       </MenuItem>
     ));
   }, []);
@@ -227,7 +245,6 @@ export const AttributeField: FC<Props> = ({
         </IconButton>
       </TableCell>
 
-      {/* This is a button to add new Attribute */}
       <TableCell>
         <IconButton onClick={() => handleAppendAttribute(index ?? 0)}>
           <AddIcon />
@@ -262,7 +279,6 @@ export const AttributeField: FC<Props> = ({
       <TableCell />
       <TableCell />
       <TableCell />
-      {/* This is a button to add new Attribute */}
       <TableCell>
         <IconButton onClick={() => handleAppendAttribute(index ?? 0)}>
           <AddIcon />

--- a/frontend/src/services/Constants.ts
+++ b/frontend/src/services/Constants.ts
@@ -46,25 +46,25 @@ export const BaseAttributeTypes = {
 };
 
 export const AttributeTypes: Record<string, { name: string; type: number }> = {
-  object: {
-    name: "object",
-    type: BaseAttributeTypes.object,
-  },
   string: {
     name: "string",
     type: BaseAttributeTypes.string,
   },
-  named_object: {
-    name: "named_object",
-    type: BaseAttributeTypes.object | BaseAttributeTypes.named,
+  array_string: {
+    name: "array_string",
+    type: BaseAttributeTypes.string | BaseAttributeTypes.array,
+  },
+  object: {
+    name: "object",
+    type: BaseAttributeTypes.object,
   },
   array_object: {
     name: "array_object",
     type: BaseAttributeTypes.object | BaseAttributeTypes.array,
   },
-  array_string: {
-    name: "array_string",
-    type: BaseAttributeTypes.string | BaseAttributeTypes.array,
+  named_object: {
+    name: "named_object",
+    type: BaseAttributeTypes.object | BaseAttributeTypes.named,
   },
   array_named_object: {
     name: "array_named_object",
@@ -73,9 +73,17 @@ export const AttributeTypes: Record<string, { name: string; type: number }> = {
       BaseAttributeTypes.named |
       BaseAttributeTypes.array,
   },
+  group: {
+    name: "group",
+    type: BaseAttributeTypes.group,
+  },
   array_group: {
     name: "array_group",
     type: BaseAttributeTypes.group | BaseAttributeTypes.array,
+  },
+  role: {
+    name: "role",
+    type: BaseAttributeTypes.role,
   },
   array_role: {
     name: "array_role",
@@ -89,17 +97,9 @@ export const AttributeTypes: Record<string, { name: string; type: number }> = {
     name: "boolean",
     type: BaseAttributeTypes.bool,
   },
-  group: {
-    name: "group",
-    type: BaseAttributeTypes.group,
-  },
   date: {
     name: "date",
     type: BaseAttributeTypes.date,
-  },
-  role: {
-    name: "role",
-    type: BaseAttributeTypes.role,
   },
   datetime: {
     name: "datetime",


### PR DESCRIPTION
Reordered the attribute type dropdown list as per expected UX order. Guarded against undefined keys to ensure safe rendering.
