### PR TITLE
chore: migrate from codecov to octocov for test coverage reporting

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -119,9 +119,8 @@ jobs:
           poetry run coverage run manage.py test ${{ matrix.target }} --parallel 
           poetry run coverage report
           poetry run coverage xml
-      - name: coverage
-        uses: codecov/codecov-action@v3
+      - name: octocov
+        uses: k1LoW/octocov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: core/${{ matrix.target }}
+          config: .octocov.yml
         continue-on-error: true

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -72,9 +72,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: test
         run: npm run test
-      - name: codecov
-        uses: codecov/codecov-action@v3
+      - name: octocov
+        uses: k1LoW/octocov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
-          flags: ui
+          config: .octocov.yml
         continue-on-error: true

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,13 @@
+coverage:
+  paths:
+    - coverage.xml              # Python coverage from coverage.py
+    - coverage/lcov.info         # Frontend coverage from Jest
+comment:
+  if: true                     # Always comment on PRs
+report:
+  if: is_pull_request          # Generate report for PRs
+badge:
+  path: coverage               # Generate coverage badge
+datastore:
+  github:
+    if: is_default_branch      # Store data only on main branch


### PR DESCRIPTION
Use [octocov](https://github.com/k1LoW/octocov) instead of codecov. Now codecov doesn't work well...