### PR TITLE
Fix unexpected modal closing on Tab key

### DIFF
--- a/frontend/src/components/user/UserControlMenu.test.tsx
+++ b/frontend/src/components/user/UserControlMenu.test.tsx
@@ -25,9 +25,8 @@ describe("UserControlMenu", () => {
         <UserControlMenu
           user={mockUser}
           anchorElem={null}
-          handleClose={() => {
-            /* do nothing */
-          }}
+          handleClose={() => {}}
+          onClickEditPassword={() => {}}
         />,
         {
           wrapper: TestWrapper,
@@ -43,6 +42,7 @@ describe("UserControlMenu", () => {
         user={mockUser}
         anchorElem={document.createElement("button")}
         handleClose={() => {}}
+        onClickEditPassword={() => {}}
       />,
       { wrapper: TestWrapper },
     );
@@ -58,6 +58,7 @@ describe("UserControlMenu", () => {
         user={mockUser}
         anchorElem={null}
         handleClose={() => {}}
+        onClickEditPassword={() => {}}
       />,
       { wrapper: TestWrapper },
     );
@@ -75,6 +76,7 @@ describe("UserControlMenu", () => {
           user={mockUser}
           anchorElem={document.createElement("button")}
           handleClose={() => {}}
+          onClickEditPassword={() => {}}
           setToggle={() => {}}
         />,
         { wrapper: TestWrapper },

--- a/frontend/src/components/user/UserControlMenu.tsx
+++ b/frontend/src/components/user/UserControlMenu.tsx
@@ -9,10 +9,8 @@ import {
   Typography,
 } from "@mui/material";
 import { useSnackbar } from "notistack";
-import React, { FC, useState } from "react";
+import React, { FC } from "react";
 import { useNavigate } from "react-router";
-
-import { UserPasswordFormModal } from "./UserPasswordFormModal";
 
 import { Confirmable } from "components/common/Confirmable";
 import { aironeApiClient } from "repository/AironeApiClient";
@@ -23,6 +21,7 @@ interface UserControlProps {
   user: UserList;
   anchorElem: HTMLButtonElement | null;
   handleClose: (userId: number) => void;
+  onClickEditPassword: (userId: number) => void;
   setToggle?: () => void;
 }
 
@@ -30,20 +29,11 @@ export const UserControlMenu: FC<UserControlProps> = ({
   user,
   anchorElem,
   handleClose,
+  onClickEditPassword,
   setToggle,
 }) => {
   const { enqueueSnackbar } = useSnackbar();
   const navigate = useNavigate();
-
-  const [openModal, setOpenModal] = useState(false);
-
-  const handleOpenModal = () => {
-    setOpenModal(true);
-  };
-
-  const handleCloseModal = () => {
-    setOpenModal(false);
-  };
 
   const handleDelete = async (user: UserList) => {
     try {
@@ -77,9 +67,15 @@ export const UserControlMenu: FC<UserControlProps> = ({
       }}
     >
       <Box sx={{ width: 150 }}>
-        <MenuItem onClick={handleOpenModal}>
+        <MenuItem
+          onClick={() => {
+            handleClose(user.id);
+            onClickEditPassword(user.id);
+          }}
+        >
           <Typography>パスワード編集</Typography>
         </MenuItem>
+
         <Confirmable
           componentGenerator={(handleOpen) => (
             <MenuItem onClick={handleOpen} sx={{ justifyContent: "end" }}>
@@ -91,18 +87,6 @@ export const UserControlMenu: FC<UserControlProps> = ({
           )}
           dialogTitle={`本当に削除しますか？(${user.username})`}
           onClickYes={() => handleDelete(user)}
-        />
-        <UserPasswordFormModal
-          userId={user.id}
-          openModal={openModal}
-          onClose={handleCloseModal}
-          onSubmitSuccess={() => {
-            enqueueSnackbar("パスワードの変更が完了しました", {
-              variant: "success",
-            });
-            handleCloseModal();
-            setToggle?.();
-          }}
         />
       </Box>
     </Menu>

--- a/frontend/src/components/user/UserList.tsx
+++ b/frontend/src/components/user/UserList.tsx
@@ -12,10 +12,12 @@ import {
 } from "@mui/material";
 import Grid from "@mui/material/Grid2";
 import { styled } from "@mui/material/styles";
+import { useSnackbar } from "notistack";
 import React, { FC, useMemo, useState } from "react";
 import { Link } from "react-router";
 
 import { UserControlMenu } from "./UserControlMenu";
+import { UserPasswordFormModal } from "./UserPasswordFormModal";
 
 import { ClipboardCopyButton } from "components/common/ClipboardCopyButton";
 import { Loading } from "components/common/Loading";
@@ -45,7 +47,7 @@ const UserName = styled(Typography)(({}) => ({
   whiteSpace: "nowrap",
 }));
 
-export const UserList: FC = ({}) => {
+export const UserList: FC = () => {
   const { page, query, changePage, changeQuery } = usePage();
   const [userAnchorEls, setUserAnchorEls] = useState<{
     [key: number]: HTMLButtonElement | null;
@@ -67,6 +69,20 @@ export const UserList: FC = ({}) => {
   );
 
   const handleChangeQuery = changeQuery;
+
+  // 新規追加: パスワードモーダル制御用
+  const [passwordModalUserId, setPasswordModalUserId] = useState<number | null>(
+    null,
+  );
+  const { enqueueSnackbar } = useSnackbar();
+
+  const handleOpenPasswordModal = (userId: number) => {
+    setPasswordModalUserId(userId);
+  };
+
+  const handleClosePasswordModal = () => {
+    setPasswordModalUserId(null);
+  };
 
   return (
     <Box>
@@ -151,6 +167,7 @@ export const UserList: FC = ({}) => {
                                   [userId]: null,
                                 })
                               }
+                              onClickEditPassword={handleOpenPasswordModal}
                               setToggle={() => setToggle(!toggle)}
                             />
                           </>
@@ -164,7 +181,20 @@ export const UserList: FC = ({}) => {
           })}
         </Grid>
       )}
-
+      {passwordModalUserId !== null && (
+        <UserPasswordFormModal
+          userId={passwordModalUserId}
+          openModal={true}
+          onClose={handleClosePasswordModal}
+          onSubmitSuccess={() => {
+            enqueueSnackbar("パスワードの変更が完了しました", {
+              variant: "success",
+            });
+            handleClosePasswordModal();
+            setToggle(!toggle);
+          }}
+        />
+      )}
       <PaginationFooter
         count={users.value?.count ?? 0}
         maxRowCount={UserListParam.MAX_ROW_COUNT}


### PR DESCRIPTION
Resolved an issue where the password edit modal would close when pressing the Tab key. Moved modal outside of UserControlMenu to avoid unmount on menu close.