### PR TITLE
Add dynamic document titles to main pages using usePageTitle

### DIFF
--- a/frontend/src/hooks/usePageTitle.ts
+++ b/frontend/src/hooks/usePageTitle.ts
@@ -4,10 +4,7 @@ interface PageTitleOptions {
   prefix?: string;
 }
 
-export const usePageTitle = (
-  title?: string,
-  options?: PageTitleOptions
-) => {
+export const usePageTitle = (title?: string, options?: PageTitleOptions) => {
   useEffect(() => {
     const originalTitle = document.title;
     const prefix = options?.prefix;

--- a/frontend/src/hooks/usePageTitle.ts
+++ b/frontend/src/hooks/usePageTitle.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+
+interface PageTitleOptions {
+  prefix?: string;
+}
+
+export const usePageTitle = (
+  title?: string,
+  options?: PageTitleOptions
+) => {
+  useEffect(() => {
+    const originalTitle = document.title;
+    const prefix = options?.prefix;
+
+    if (title) {
+      document.title = prefix ? `${prefix} - ${title}` : title;
+    } else {
+      document.title = originalTitle;
+    }
+
+    return () => {
+      document.title = originalTitle;
+    };
+  }, [title, options?.prefix]);
+};

--- a/frontend/src/pages/EntityEditPage.tsx
+++ b/frontend/src/pages/EntityEditPage.tsx
@@ -13,10 +13,12 @@ import { EntityForm } from "components/entity/EntityForm";
 import { Schema, schema } from "components/entity/entityForm/EntityFormSchema";
 import { useAsyncWithThrow } from "hooks/useAsyncWithThrow";
 import { useFormNotification } from "hooks/useFormNotification";
+import { usePageTitle } from "hooks/usePageTitle";
 import { usePrompt } from "hooks/usePrompt";
 import { useTypedParams } from "hooks/useTypedParams";
 import { aironeApiClient } from "repository/AironeApiClient";
 import { entitiesPath, entityEntriesPath } from "routes/Routes";
+import { TITLE_TEMPLATES } from "services";
 import {
   extractAPIException,
   isResponseError,
@@ -160,6 +162,15 @@ export const EntityEditPage: FC = () => {
       }
     }
   };
+
+  usePageTitle(
+    entity.loading || (entityId && entity.loading)
+      ? "読み込み中..."
+      : TITLE_TEMPLATES.entityEdit,
+    {
+      prefix: entity.value?.name ?? (entityId == null ? "新規作成" : undefined),
+    },
+  );
 
   useEffect(() => {
     !entity.loading && entity.value != null && reset(entity.value);

--- a/frontend/src/pages/EntityListPage.tsx
+++ b/frontend/src/pages/EntityListPage.tsx
@@ -1,17 +1,18 @@
 import { Box, Button, Container, Typography } from "@mui/material";
 import React, { FC, useCallback, useState } from "react";
 
-import { useAsyncWithThrow } from "../hooks/useAsyncWithThrow";
-
 import { AironeLink } from "components";
 import { AironeBreadcrumbs } from "components/common/AironeBreadcrumbs";
 import { Loading } from "components/common/Loading";
 import { PageHeader } from "components/common/PageHeader";
 import { EntityImportModal } from "components/entity/EntityImportModal";
 import { EntityList } from "components/entity/EntityList";
+import { useAsyncWithThrow } from "hooks/useAsyncWithThrow";
 import { usePage } from "hooks/usePage";
+import { usePageTitle } from "hooks/usePageTitle";
 import { aironeApiClient } from "repository/AironeApiClient";
 import { topPath } from "routes/Routes";
+import { TITLE_TEMPLATES } from "services";
 
 export const EntityListPage: FC = () => {
   const { page, query, changePage, changeQuery } = usePage();
@@ -26,6 +27,8 @@ export const EntityListPage: FC = () => {
   const handleExport = useCallback(async () => {
     await aironeApiClient.exportEntities("entity.yaml");
   }, []);
+
+  usePageTitle(TITLE_TEMPLATES.entityList);
 
   return (
     <Box className="container-fluid">

--- a/frontend/src/pages/EntryDetailsPage.tsx
+++ b/frontend/src/pages/EntryDetailsPage.tsx
@@ -6,17 +6,18 @@ import { styled } from "@mui/material/styles";
 import React, { FC, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 
-import { useAsyncWithThrow } from "../hooks/useAsyncWithThrow";
-import { useTypedParams } from "../hooks/useTypedParams";
-
 import { Loading } from "components/common/Loading";
 import { PageHeader } from "components/common/PageHeader";
 import { EntryAttributes } from "components/entry/EntryAttributes";
 import { EntryBreadcrumbs } from "components/entry/EntryBreadcrumbs";
 import { EntryControlMenu } from "components/entry/EntryControlMenu";
 import { EntryReferral } from "components/entry/EntryReferral";
+import { useAsyncWithThrow } from "hooks/useAsyncWithThrow";
+import { usePageTitle } from "hooks/usePageTitle";
+import { useTypedParams } from "hooks/useTypedParams";
 import { aironeApiClient } from "repository/AironeApiClient";
 import { entryDetailsPath, restoreEntryPath } from "routes/Routes";
+import { TITLE_TEMPLATES } from "services";
 
 const FlexBox = styled(Box)(({}) => ({
   display: "flex",
@@ -104,6 +105,10 @@ export const EntryDetailsPage: FC<Props> = ({
       );
     }
   }, [entry.loading]);
+
+  usePageTitle(entry.loading ? "読み込み中..." : TITLE_TEMPLATES.entryDetail, {
+    prefix: entry.value?.name,
+  });
 
   return (
     <FlexBox>

--- a/frontend/src/pages/EntryEditPage.tsx
+++ b/frontend/src/pages/EntryEditPage.tsx
@@ -5,8 +5,6 @@ import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
 import { v4 as uuidv4 } from "uuid";
 
-import { useAsyncWithThrow } from "../hooks/useAsyncWithThrow";
-
 import { Loading } from "components/common/Loading";
 import { PageHeader } from "components/common/PageHeader";
 import { SubmitButton } from "components/common/SubmitButton";
@@ -17,11 +15,14 @@ import {
   EntryFormProps,
 } from "components/entry/EntryForm";
 import { Schema, schema } from "components/entry/entryForm/EntryFormSchema";
+import { useAsyncWithThrow } from "hooks/useAsyncWithThrow";
 import { useFormNotification } from "hooks/useFormNotification";
+import { usePageTitle } from "hooks/usePageTitle";
 import { usePrompt } from "hooks/usePrompt";
 import { useTypedParams } from "hooks/useTypedParams";
 import { aironeApiClient } from "repository/AironeApiClient";
 import { entityEntriesPath, entryDetailsPath } from "routes/Routes";
+import { TITLE_TEMPLATES } from "services";
 import {
   extractAPIException,
   isResponseError,
@@ -120,6 +121,15 @@ export const EntryEditPage: FC<Props> = ({
       }
     }
   }, [isSubmitSuccessful]);
+
+  usePageTitle(
+    entity.loading || (entryId && entry.loading)
+      ? "読み込み中..."
+      : TITLE_TEMPLATES.entryEdit,
+    {
+      prefix: entry.value?.name ?? (entryId == null ? "新規作成" : undefined),
+    },
+  );
 
   const handleSubmitOnValid = async (entry: Schema) => {
     const updatedAttr = convertAttrsFormatCtoS(entry.attrs);

--- a/frontend/src/pages/EntryListPage.tsx
+++ b/frontend/src/pages/EntryListPage.tsx
@@ -2,15 +2,16 @@ import AppsIcon from "@mui/icons-material/Apps";
 import { Box, Container, IconButton } from "@mui/material";
 import React, { FC, useState } from "react";
 
-import { EntityControlMenu } from "../components/entity/EntityControlMenu";
-import { useAsyncWithThrow } from "../hooks/useAsyncWithThrow";
-import { useTypedParams } from "../hooks/useTypedParams";
-
 import { PageHeader } from "components/common/PageHeader";
 import { EntityBreadcrumbs } from "components/entity/EntityBreadcrumbs";
+import { EntityControlMenu } from "components/entity/EntityControlMenu";
 import { EntryImportModal } from "components/entry/EntryImportModal";
 import { EntryList } from "components/entry/EntryList";
+import { useAsyncWithThrow } from "hooks/useAsyncWithThrow";
+import { usePageTitle } from "hooks/usePageTitle";
+import { useTypedParams } from "hooks/useTypedParams";
 import { aironeApiClient } from "repository/AironeApiClient";
+import { TITLE_TEMPLATES } from "services";
 
 interface Props {
   canCreateEntry?: boolean;
@@ -25,6 +26,10 @@ export const EntryListPage: FC<Props> = ({ canCreateEntry = true }) => {
 
   const entity = useAsyncWithThrow(async () => {
     return await aironeApiClient.getEntity(entityId);
+  });
+
+  usePageTitle(entity.loading ? "読み込み中..." : TITLE_TEMPLATES.entryList, {
+    prefix: entity.value?.name,
   });
 
   return (

--- a/frontend/src/pages/GroupEditPage.tsx
+++ b/frontend/src/pages/GroupEditPage.tsx
@@ -4,19 +4,20 @@ import React, { FC, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
 
-import { useAsyncWithThrow } from "../hooks/useAsyncWithThrow";
-
 import { AironeLink } from "components";
 import { AironeBreadcrumbs } from "components/common/AironeBreadcrumbs";
 import { PageHeader } from "components/common/PageHeader";
 import { SubmitButton } from "components/common/SubmitButton";
 import { GroupForm } from "components/group/GroupForm";
 import { schema, Schema } from "components/group/groupForm/GroupFormSchema";
+import { useAsyncWithThrow } from "hooks/useAsyncWithThrow";
 import { useFormNotification } from "hooks/useFormNotification";
+import { usePageTitle } from "hooks/usePageTitle";
 import { usePrompt } from "hooks/usePrompt";
 import { useTypedParams } from "hooks/useTypedParams";
 import { aironeApiClient } from "repository/AironeApiClient";
 import { groupsPath, topPath } from "routes/Routes";
+import { TITLE_TEMPLATES } from "services";
 import {
   extractAPIException,
   isResponseError,
@@ -91,6 +92,10 @@ export const GroupEditPage: FC = () => {
   useEffect(() => {
     isSubmitSuccessful && navigate(groupsPath(), { replace: true });
   }, [isSubmitSuccessful]);
+
+  usePageTitle(group.loading ? "読み込み中..." : TITLE_TEMPLATES.groupEdit, {
+    prefix: group.value?.name ?? (willCreate ? "新規作成" : undefined),
+  });
 
   const handleCancel = async () => {
     navigate(-1);

--- a/frontend/src/pages/GroupListPage.tsx
+++ b/frontend/src/pages/GroupListPage.tsx
@@ -12,18 +12,20 @@ import { styled } from "@mui/material/styles";
 import React, { FC, useCallback, useMemo, useState } from "react";
 import { Link } from "react-router";
 
-import { SearchBox } from "../components/common/SearchBox";
 import { GroupControlMenu } from "../components/group/GroupControlMenu";
 import { GroupImportModal } from "../components/group/GroupImportModal";
 import { GroupTreeRoot } from "../components/group/GroupTreeRoot";
-import { useAsyncWithThrow } from "../hooks/useAsyncWithThrow";
 
 import { AironeLink } from "components";
 import { AironeBreadcrumbs } from "components/common/AironeBreadcrumbs";
 import { Loading } from "components/common/Loading";
 import { PageHeader } from "components/common/PageHeader";
+import { SearchBox } from "components/common/SearchBox";
+import { useAsyncWithThrow } from "hooks/useAsyncWithThrow";
+import { usePageTitle } from "hooks/usePageTitle";
 import { aironeApiClient } from "repository/AironeApiClient";
 import { newGroupPath, topPath } from "routes/Routes";
+import { TITLE_TEMPLATES } from "services";
 import { ServerContext } from "services/ServerContext";
 
 const StyledContainer = styled(Container)({
@@ -88,6 +90,8 @@ export const GroupListPage: FC = () => {
   }, []);
 
   const isSuperuser = ServerContext.getInstance()?.user?.isSuperuser ?? false;
+
+  usePageTitle(TITLE_TEMPLATES.groupList);
 
   return (
     <Box display="flex" flexDirection="column" flexGrow="1">

--- a/frontend/src/pages/RoleEditPage.tsx
+++ b/frontend/src/pages/RoleEditPage.tsx
@@ -5,8 +5,6 @@ import React, { FC, useCallback, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
 
-import { useAsyncWithThrow } from "../hooks/useAsyncWithThrow";
-
 import { AironeLink } from "components";
 import { AironeBreadcrumbs } from "components/common/AironeBreadcrumbs";
 import { Loading } from "components/common/Loading";
@@ -14,11 +12,14 @@ import { PageHeader } from "components/common/PageHeader";
 import { SubmitButton } from "components/common/SubmitButton";
 import { RoleForm } from "components/role/RoleForm";
 import { Schema, schema } from "components/role/roleForm/RoleFormSchema";
+import { useAsyncWithThrow } from "hooks/useAsyncWithThrow";
 import { useFormNotification } from "hooks/useFormNotification";
+import { usePageTitle } from "hooks/usePageTitle";
 import { usePrompt } from "hooks/usePrompt";
 import { useTypedParams } from "hooks/useTypedParams";
 import { aironeApiClient } from "repository/AironeApiClient";
 import { rolesPath, topPath } from "routes/Routes";
+import { TITLE_TEMPLATES } from "services";
 import {
   extractAPIException,
   isResponseError,
@@ -66,6 +67,10 @@ export const RoleEditPage: FC = () => {
   useEffect(() => {
     isSubmitSuccessful && navigate(rolesPath());
   }, [isSubmitSuccessful]);
+
+  usePageTitle(role.loading ? "読み込み中..." : TITLE_TEMPLATES.roleEdit, {
+    prefix: role.value?.name ?? (willCreate ? "新規作成" : undefined),
+  });
 
   const handleSubmitOnValid = useCallback(
     async (role: Schema) => {

--- a/frontend/src/pages/RoleListPage.tsx
+++ b/frontend/src/pages/RoleListPage.tsx
@@ -5,12 +5,14 @@ import { Link } from "react-router";
 
 import { RoleImportModal } from "../components/role/RoleImportModal";
 import { RoleList } from "../components/role/RoleList";
-import { aironeApiClient } from "../repository/AironeApiClient";
 
 import { AironeLink } from "components";
 import { AironeBreadcrumbs } from "components/common/AironeBreadcrumbs";
 import { PageHeader } from "components/common/PageHeader";
+import { usePageTitle } from "hooks/usePageTitle";
+import { aironeApiClient } from "repository/AironeApiClient";
 import { newRolePath, topPath } from "routes/Routes";
+import { TITLE_TEMPLATES } from "services";
 
 export const RoleListPage: FC = () => {
   const [openImportModal, setOpenImportModal] = useState(false);
@@ -18,6 +20,8 @@ export const RoleListPage: FC = () => {
   const handleExport = useCallback(async () => {
     await aironeApiClient.exportRoles("role.yaml");
   }, []);
+
+  usePageTitle(TITLE_TEMPLATES.roleList);
 
   return (
     <Box className="container-fluid">

--- a/frontend/src/pages/UserEditPage.tsx
+++ b/frontend/src/pages/UserEditPage.tsx
@@ -16,10 +16,12 @@ import { UserPasswordFormModal } from "components/user/UserPasswordFormModal";
 import { schema, Schema } from "components/user/userForm/UserFormSchema";
 import { useAsyncWithThrow } from "hooks/useAsyncWithThrow";
 import { useFormNotification } from "hooks/useFormNotification";
+import { usePageTitle } from "hooks/usePageTitle";
 import { usePrompt } from "hooks/usePrompt";
 import { useTypedParams } from "hooks/useTypedParams";
 import { aironeApiClient } from "repository/AironeApiClient";
 import { topPath, usersPath, loginPath } from "routes/Routes";
+import { TITLE_TEMPLATES } from "services";
 import {
   extractAPIException,
   isResponseError,
@@ -71,6 +73,10 @@ export const UserEditPage: FC = () => {
   useEffect(() => {
     isSubmitSuccessful && navigate(usersPath());
   }, [isSubmitSuccessful]);
+
+  usePageTitle(user.loading ? "読み込み中..." : TITLE_TEMPLATES.userEdit, {
+    prefix: user.value?.username ?? (willCreate ? "新規作成" : undefined),
+  });
 
   // These state variables and handlers are used for password reset feature
   const [openModal, setOpenModal] = useState(false);

--- a/frontend/src/pages/UserListPage.tsx
+++ b/frontend/src/pages/UserListPage.tsx
@@ -6,8 +6,10 @@ import { AironeBreadcrumbs } from "components/common/AironeBreadcrumbs";
 import { PageHeader } from "components/common/PageHeader";
 import { UserImportModal } from "components/user/UserImportModal";
 import { UserList } from "components/user/UserList";
+import { usePageTitle } from "hooks/usePageTitle";
 import { aironeApiClient } from "repository/AironeApiClient";
 import { topPath } from "routes/Routes";
+import { TITLE_TEMPLATES } from "services";
 
 export const UserListPage: FC = () => {
   const [openImportModal, setOpenImportModal] = useState(false);
@@ -15,6 +17,8 @@ export const UserListPage: FC = () => {
   const handleExport = useCallback(async () => {
     await aironeApiClient.exportUsers("user.yaml");
   }, []);
+
+  usePageTitle(TITLE_TEMPLATES.userList);
 
   return (
     <Box className="container-fluid">

--- a/frontend/src/services/Constants.ts
+++ b/frontend/src/services/Constants.ts
@@ -178,3 +178,17 @@ export const ACLTypeLabels: Record<ACLType, string> = {
   [ACLType.Writable]: "閲覧・編集",
   [ACLType.Full]: "閲覧・編集・削除",
 };
+
+export const TITLE_TEMPLATES = {
+  userList: "User List",
+  userEdit: "EditUser",
+  groupList: "Group List",
+  groupEdit: "EditGroup",
+  roleList: "Role List",
+  roleEdit: "EditRole",
+  entryList: "Item List",
+  entryDetail: "Item Detail",
+  entryEdit: "EditItem",
+  entityList: "Model List",
+  entityEdit: "EditModel",
+};


### PR DESCRIPTION
This PR introduces the usePageTitle hook to several main pages (Entry, Entity, Role, User, etc.) to provide dynamic and consistent document titles.