### PR TITLE
Added isNarrowDown parameters to the advanced search results page

### DIFF
--- a/frontend/src/components/entry/SearchResults.tsx
+++ b/frontend/src/components/entry/SearchResults.tsx
@@ -74,6 +74,7 @@ interface Props {
   joinAttrs: AdvancedSearchJoinAttrInfo[];
   disablePaginationFooter: boolean;
   isReadonly?: boolean;
+  isNarrowDown?: boolean;
   omitHeadline?: boolean;
 }
 
@@ -92,6 +93,7 @@ export const SearchResults: FC<Props> = ({
   joinAttrs,
   disablePaginationFooter,
   isReadonly = false,
+  isNarrowDown = true,
   omitHeadline = false,
 }) => {
   // NOTE attrTypes are guessed by the first element on the results. So if it has no appropriate attr,
@@ -141,6 +143,7 @@ export const SearchResults: FC<Props> = ({
                 handleChangeAllBulkOperationEntryIds
               }
               isReadonly={isReadonly}
+              isNarrowDown={isNarrowDown}
               omitHeadline={omitHeadline}
             />
             <TableBody>

--- a/frontend/src/components/entry/SearchResultsTableHead.test.tsx
+++ b/frontend/src/components/entry/SearchResultsTableHead.test.tsx
@@ -131,6 +131,7 @@ describe("SearchResultsTableHead", () => {
     renderSearchResultsTableHead({
       hasReferral: true,
       isReadonly: true,
+      isNarrowDown: false,
     });
 
     // Should not show filter button for item name in readonly mode

--- a/frontend/src/components/entry/SearchResultsTableHead.tsx
+++ b/frontend/src/components/entry/SearchResultsTableHead.tsx
@@ -68,6 +68,7 @@ interface Props {
   joinAttrs: AdvancedSearchJoinAttrInfo[];
   handleChangeAllBulkOperationEntryIds: (checked: boolean) => void;
   isReadonly?: boolean;
+  isNarrowDown?: boolean;
   omitHeadline?: boolean;
 }
 
@@ -82,6 +83,7 @@ export const SearchResultsTableHead: FC<Props> = ({
   joinAttrs,
   handleChangeAllBulkOperationEntryIds,
   isReadonly = false,
+  isNarrowDown = true,
   omitHeadline = false,
 }) => {
   const location = useLocation();
@@ -233,8 +235,8 @@ export const SearchResultsTableHead: FC<Props> = ({
           <HeaderBox>
             <Typography>{!omitHeadline ? "アイテム名" : ""}</Typography>
 
-            {/* SearchControlMenu would be invisible when Readonly Mode is True */}
-            {!isReadonly && (
+            {/* SearchControlMenu would be invisible when NarrowDown Mode is True */}
+            {isNarrowDown && !omitHeadline && (
               <>
                 <Tooltip title="アイテム名でフィルタ">
                   <StyledIconButton
@@ -266,9 +268,9 @@ export const SearchResultsTableHead: FC<Props> = ({
                   : attrName}
               </Typography>
 
-              {/* Bulk operation checkbox would be invisible when Readonly mode is true */}
+              {/* Bulk operation checkbox would be invisible when NarrowDown mode is true */}
               {(attrTypes[attrName] & EntryAttributeTypeTypeEnum.OBJECT) > 0 &&
-                !isReadonly &&
+                isNarrowDown &&
                 attrsFilter[attrName]?.joinedAttrname === undefined && (
                   <Tooltip title="アイテムの属性を結合する">
                     <StyledIconButton onClick={() => setJoinAttrname(attrName)}>
@@ -285,7 +287,7 @@ export const SearchResultsTableHead: FC<Props> = ({
                   handleClose={() => setJoinAttrname("")}
                 />
               )}
-              {!isReadonly && (
+              {isNarrowDown && (
                 <>
                   <Tooltip title="属性値でフィルタ">
                     <StyledIconButton


### PR DESCRIPTION
Added parameters to the advanced search results page.

The following parameters are available:
- isReadonly: Whether or not there is a delete function.
- isNarrowDown: Whether or not there is a narrow down function.
- omitHeadline: Whether or not there is a display item name