### PR TITLE
Fix pagination on Advanced Search results

### DIFF
--- a/frontend/src/components/common/PaginationFooter.tsx
+++ b/frontend/src/components/common/PaginationFooter.tsx
@@ -35,7 +35,7 @@ export const PaginationFooter: FC<Props> = ({
           count={Math.ceil(count / maxRowCount)}
           page={page}
           onChange={(_, newPage) => changePage(newPage)}
-          siblingCount={0}
+          siblingCount={1}
           boundaryCount={1}
           color="primary"
         />

--- a/frontend/src/components/entry/SearchResults.tsx
+++ b/frontend/src/components/entry/SearchResults.tsx
@@ -229,7 +229,7 @@ export const SearchResults: FC<Props> = ({
 
         {!disablePaginationFooter && (
           <PaginationFooter
-            count={results.count}
+            count={results.totalCount ?? results.count}
             maxRowCount={AdvancedSerarchResultListParam.MAX_ROW_COUNT}
             page={page}
             changePage={changePage}


### PR DESCRIPTION
Pass totalCount to PaginationFooter (instead of count) and set siblingCount=1 to show adjacent pages. Prevents missing page 4 and neighbors. Files: SearchResults.tsx, PaginationFooter.tsx.