### PR TITLE
Use pydantic models in entity job tasks to ensure job params type safety

### DIFF
--- a/entity/tasks.py
+++ b/entity/tasks.py
@@ -1,13 +1,249 @@
-import json
+from typing import Optional
+
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
 from airone.celery import app
 from airone.lib import custom_view
 from airone.lib.job import may_schedule_until_job_is_ready, register_job_task
+from airone.lib.log import Logger
 from airone.lib.types import AttrType
 from entity.api_v2.serializers import EntityCreateSerializer, EntityUpdateSerializer
 from entity.models import Entity, EntityAttr
 from job.models import Job, JobOperation, JobStatus
 from user.models import History, User
+
+# ============================================================================
+# Pydantic Models for Job Parameters
+# ============================================================================
+
+
+class CreateEntityAttr(BaseModel):
+    """Attribute definition for CREATE_ENTITY (V1) task."""
+
+    name: str = Field(..., max_length=200)
+    type: int
+    is_mandatory: bool
+    is_delete_in_chain: bool
+    row_index: str
+    ref_ids: list[int] = Field(default_factory=list)
+
+    @field_validator("type", mode="before")
+    @classmethod
+    def validate_type(cls, v):
+        """Convert string type to int if needed."""
+        if isinstance(v, str):
+            try:
+                return int(v)
+            except ValueError:
+                raise ValueError(f"Invalid type value: {v}")
+        return v
+
+
+class CreateEntityParams(BaseModel):
+    """Parameters for CREATE_ENTITY (V1) task."""
+
+    attrs: list[CreateEntityAttr]
+
+
+class EditEntityAttr(BaseModel):
+    """Attribute definition for EDIT_ENTITY (V1) task."""
+
+    id: Optional[int] = None
+    name: str = Field(..., max_length=200)
+    type: int
+    is_mandatory: bool
+    is_delete_in_chain: bool
+    row_index: str
+    ref_ids: list[int] = Field(default_factory=list)
+    deleted: Optional[bool] = None
+
+    @field_validator("type", mode="before")
+    @classmethod
+    def validate_type(cls, v):
+        """Convert string type to int if needed."""
+        if isinstance(v, str):
+            try:
+                return int(v)
+            except ValueError:
+                raise ValueError(f"Invalid type value: {v}")
+        return v
+
+
+class EditEntityParams(BaseModel):
+    """Parameters for EDIT_ENTITY (V1) task."""
+
+    name: str = Field(..., max_length=200)
+    note: str
+    attrs: list[EditEntityAttr]
+
+
+class WebhookHeader(BaseModel):
+    """Webhook HTTP header definition."""
+
+    header_key: str
+    header_value: str
+
+
+class CreateEntityV2Webhook(BaseModel):
+    """Webhook definition for CREATE_ENTITY_V2 task."""
+
+    url: str = Field(default="", max_length=200)
+    label: str = ""
+    is_enabled: bool = False
+    headers: list[WebhookHeader] = Field(default_factory=list)
+
+
+class CreateEntityV2Attr(BaseModel):
+    """Attribute definition for CREATE_ENTITY_V2 task."""
+
+    name: str = Field(..., max_length=200)
+    type: int
+    index: Optional[int] = None
+    is_mandatory: bool = False
+    is_delete_in_chain: bool = False
+    is_summarized: bool = False
+    referral: list[int] = Field(default_factory=list)
+    note: str = ""
+    default_value: Optional[str | bool | int | float] = None
+
+    @model_validator(mode="after")
+    def validate_default_value_for_type(self):
+        """Validate that default_value is compatible with the attribute type."""
+        if self.default_value is None:
+            return self
+
+        supported_types = [AttrType.STRING, AttrType.TEXT, AttrType.BOOLEAN, AttrType.NUMBER]
+
+        # Clear default_value for unsupported types (don't raise error)
+        if self.type not in supported_types:
+            Logger.warning(
+                f"default_value is not supported for type {self.type}. "
+                f"Clearing default_value. Supported types: {supported_types}"
+            )
+            self.default_value = None
+            return self
+
+        # Type-specific validation - clear if invalid type
+        is_valid = True
+        if self.type in [AttrType.STRING, AttrType.TEXT]:
+            if not isinstance(self.default_value, str):
+                is_valid = False
+        elif self.type == AttrType.BOOLEAN:
+            if not isinstance(self.default_value, bool):
+                is_valid = False
+        elif self.type == AttrType.NUMBER:
+            if not isinstance(self.default_value, (int, float)):
+                is_valid = False
+
+        if not is_valid:
+            Logger.warning(
+                f"default_value type mismatch for attribute type {self.type}. "
+                f"Clearing default_value. Got: {type(self.default_value)}"
+            )
+            self.default_value = None
+
+        return self
+
+
+class CreateEntityV2Params(BaseModel):
+    """Parameters for CREATE_ENTITY_V2 task."""
+
+    name: str = Field(..., max_length=200)
+    note: str = ""
+    item_name_pattern: str = ""
+    is_toplevel: bool = False
+    attrs: list[CreateEntityV2Attr] = Field(default_factory=list)
+    webhooks: list[CreateEntityV2Webhook] = Field(default_factory=list)
+
+
+class EditEntityV2Webhook(BaseModel):
+    """Webhook definition for EDIT_ENTITY_V2 task."""
+
+    id: Optional[int] = None
+    url: Optional[str] = Field(None, max_length=200)
+    label: str = ""
+    is_enabled: bool = False
+    headers: list[WebhookHeader] = Field(default_factory=list)
+    is_deleted: bool = False
+
+
+class EditEntityV2Attr(BaseModel):
+    """Attribute definition for EDIT_ENTITY_V2 task."""
+
+    id: Optional[int] = None
+    name: Optional[str] = Field(None, max_length=200)
+    type: Optional[int] = None
+    index: Optional[int] = None
+    is_mandatory: Optional[bool] = None
+    is_delete_in_chain: Optional[bool] = None
+    is_summarized: Optional[bool] = None
+    referral: Optional[list[int]] = None
+    note: Optional[str] = None
+    default_value: Optional[str | bool | int | float] = None
+    is_deleted: bool = False
+
+    @model_validator(mode="after")
+    def validate_attr_fields(self):
+        """Validate that required fields are present based on operation type."""
+        if self.id is None:
+            if self.name is None or self.type is None:
+                raise ValueError("name and type are required for new attribute creation")
+        return self
+
+    @model_validator(mode="after")
+    def validate_default_value_for_type(self):
+        """Validate default_value compatibility with attribute type."""
+        if self.default_value is None or self.type is None:
+            return self
+
+        supported_types = [AttrType.STRING, AttrType.TEXT, AttrType.BOOLEAN, AttrType.NUMBER]
+
+        # Clear default_value for unsupported types (don't raise error)
+        if self.type not in supported_types:
+            Logger.warning(
+                f"default_value is not supported for type {self.type}. "
+                f"Clearing default_value. Supported types: {supported_types}"
+            )
+            self.default_value = None
+            return self
+
+        # Type-specific validation - clear if invalid type
+        is_valid = True
+        if self.type in [AttrType.STRING, AttrType.TEXT]:
+            if not isinstance(self.default_value, str):
+                is_valid = False
+        elif self.type == AttrType.BOOLEAN:
+            if not isinstance(self.default_value, bool):
+                is_valid = False
+        elif self.type == AttrType.NUMBER:
+            if not isinstance(self.default_value, (int, float)):
+                is_valid = False
+
+        if not is_valid:
+            Logger.warning(
+                f"default_value type mismatch for attribute type {self.type}. "
+                f"Clearing default_value. Got: {type(self.default_value)}"
+            )
+            self.default_value = None
+
+        return self
+
+
+class EditEntityV2Params(BaseModel):
+    """Parameters for EDIT_ENTITY_V2 task."""
+
+    id: Optional[int] = None
+    name: Optional[str] = Field(None, max_length=200)
+    note: Optional[str] = None
+    item_name_pattern: Optional[str] = None
+    is_toplevel: Optional[bool] = None
+    attrs: list[EditEntityV2Attr] = Field(default_factory=list)
+    webhooks: list[EditEntityV2Webhook] = Field(default_factory=list)
+
+
+# ============================================================================
+# Task Functions
+# ============================================================================
 
 
 @register_job_task(JobOperation.CREATE_ENTITY)
@@ -24,24 +260,29 @@ def create_entity(self, job: Job) -> JobStatus:
     # for history record
     entity._history_user = user
 
-    recv_data = json.loads(job.params)
+    # Validate and parse job parameters using Pydantic
+    try:
+        params = CreateEntityParams.model_validate_json(job.params)
+    except ValidationError as e:
+        Logger.error(f"Invalid parameters for CREATE_ENTITY job {job.id}: {e}")
+        return JobStatus.ERROR
 
     # register history to modify Entity
     history = user.seth_entity_add(entity)
 
-    for attr in recv_data["attrs"]:
+    for attr in params.attrs:
         attr_base = EntityAttr.objects.create(
-            name=attr["name"],
-            type=int(attr["type"]),
-            is_mandatory=attr["is_mandatory"],
-            is_delete_in_chain=attr["is_delete_in_chain"],
+            name=attr.name,
+            type=attr.type,
+            is_mandatory=attr.is_mandatory,
+            is_delete_in_chain=attr.is_delete_in_chain,
             created_user=user,
             parent_entity=entity,
-            index=int(attr["row_index"]),
+            index=int(attr.row_index),
         )
 
-        if int(attr["type"]) & AttrType.OBJECT:
-            [attr_base.referral.add(Entity.objects.get(id=x)) for x in attr["ref_ids"]]
+        if attr.type & AttrType.OBJECT:
+            [attr_base.referral.add(Entity.objects.get(id=x)) for x in attr.ref_ids]
 
         # register history to modify Entity
         history.add_attr(attr_base)
@@ -67,27 +308,32 @@ def edit_entity(self, job: Job) -> JobStatus:
     # for history record
     entity._history_user = user
 
-    recv_data = json.loads(job.params)
+    # Validate and parse job parameters using Pydantic
+    try:
+        params = EditEntityParams.model_validate_json(job.params)
+    except ValidationError as e:
+        Logger.error(f"Invalid parameters for EDIT_ENTITY job {job.id}: {e}")
+        return JobStatus.ERROR
 
     # register history to modify Entity
     history = user.seth_entity_mod(entity)
-    if entity.name != recv_data["name"]:
+    if entity.name != params.name:
         history.mod_entity(entity, 'old name: "%s"' % (entity.name))
 
-    if entity.name != recv_data["name"]:
-        entity.name = recv_data["name"]
+    if entity.name != params.name:
+        entity.name = params.name
         entity.save(update_fields=["name"])
 
-    if entity.note != recv_data["note"]:
-        entity.note = recv_data["note"]
+    if entity.note != params.note:
+        entity.note = params.note
         entity.save(update_fields=["note"])
 
     # update processing for each attrs
     deleted_attr_ids = []
-    for attr in recv_data["attrs"]:
-        if "deleted" in attr:
+    for attr in params.attrs:
+        if attr.deleted:
             # In case of deleting attribute which has been already existed
-            attr_obj = EntityAttr.objects.get(id=attr["id"])
+            attr_obj = EntityAttr.objects.get(id=attr.id)
             attr_obj.delete()
 
             # Save deleted EntityAttr id to update es_document of Entries
@@ -97,58 +343,56 @@ def edit_entity(self, job: Job) -> JobStatus:
             # register History to register deleting EntityAttr
             history.del_attr(attr_obj)
 
-        elif "id" in attr and EntityAttr.objects.filter(id=attr["id"]).exists():
+        elif attr.id is not None and EntityAttr.objects.filter(id=attr.id).exists():
             # In case of updating attribute which has been already existed
-            attr_obj = EntityAttr.objects.get(id=attr["id"])
+            attr_obj = EntityAttr.objects.get(id=attr.id)
 
             # register operaion history if the parameters are changed
-            if attr_obj.name != attr["name"]:
+            if attr_obj.name != attr.name:
                 history.mod_attr(attr_obj, 'old name: "%s"' % (attr_obj.name))
 
-            if attr_obj.is_mandatory != attr["is_mandatory"]:
-                if attr["is_mandatory"]:
+            if attr_obj.is_mandatory != attr.is_mandatory:
+                if attr.is_mandatory:
                     history.mod_attr(attr_obj, "set mandatory flag")
                 else:
                     history.mod_attr(attr_obj, "unset mandatory flag")
 
             # EntityAttr.is_referral_updated() is separated from EntityAttr.is_updated()
             # to reduce unnecessary creation of HistoricalRecord.
-            params = {
-                "name": attr["name"],
-                "index": attr["row_index"],
-                "is_mandatory": attr["is_mandatory"],
-                "is_delete_in_chain": attr["is_delete_in_chain"],
+            update_params = {
+                "name": attr.name,
+                "index": attr.row_index,
+                "is_mandatory": attr.is_mandatory,
+                "is_delete_in_chain": attr.is_delete_in_chain,
             }
-            if attr_obj.is_updated(**params):
-                attr_obj.name = attr["name"]
-                attr_obj.is_mandatory = attr["is_mandatory"]
-                attr_obj.is_delete_in_chain = attr["is_delete_in_chain"]
-                attr_obj.index = int(attr["row_index"])
+            if attr_obj.is_updated(**update_params):
+                attr_obj.name = attr.name
+                attr_obj.is_mandatory = attr.is_mandatory
+                attr_obj.is_delete_in_chain = attr.is_delete_in_chain
+                attr_obj.index = int(attr.row_index)
 
                 attr_obj.save()
 
-            if (attr_obj.type & AttrType.OBJECT) and (
-                attr_obj.is_referral_updated([int(x) for x in attr["ref_ids"]])
-            ):
+            if (attr_obj.type & AttrType.OBJECT) and (attr_obj.is_referral_updated(attr.ref_ids)):
                 # the case of an attribute that has referral entry
                 attr_obj.referral_clear()
-                attr_obj.referral.add(*[Entity.objects.get(id=x) for x in attr["ref_ids"]])
+                attr_obj.referral.add(*[Entity.objects.get(id=x) for x in attr.ref_ids])
 
         else:
             # In case of creating new attribute
             attr_obj = EntityAttr.objects.create(
-                name=attr["name"],
-                type=int(attr["type"]),
-                is_mandatory=attr["is_mandatory"],
-                is_delete_in_chain=attr["is_delete_in_chain"],
-                index=int(attr["row_index"]),
+                name=attr.name,
+                type=attr.type,
+                is_mandatory=attr.is_mandatory,
+                is_delete_in_chain=attr.is_delete_in_chain,
+                index=int(attr.row_index),
                 created_user=user,
                 parent_entity=entity,
             )
 
             # append referral objects
-            if int(attr["type"]) & AttrType.OBJECT:
-                [attr_obj.referral.add(Entity.objects.get(id=x)) for x in attr["ref_ids"]]
+            if attr.type & AttrType.OBJECT:
+                [attr_obj.referral.add(Entity.objects.get(id=x)) for x in attr.ref_ids]
 
             # register History to register adding EntityAttr
             history.add_attr(attr_obj)
@@ -194,8 +438,20 @@ def create_entity_v2(self, job: Job) -> JobStatus:
     if not entity:
         return JobStatus.ERROR
 
+    # Validate and parse job parameters using Pydantic
+    try:
+        params = CreateEntityV2Params.model_validate_json(job.params)
+    except ValidationError as e:
+        Logger.error(f"Invalid parameters for CREATE_ENTITY_V2 job {job.id}: {e}")
+        return JobStatus.ERROR
+
+    # Convert Pydantic model to dict for serializer
+    # (EntityCreateSerializer expects dict input)
+    # Use exclude_none=True to avoid passing None values that may violate DB constraints
+    params_dict = params.model_dump(exclude_none=True)
+
     # pass to validate the params because the entity should be already created
-    serializer = EntityCreateSerializer(data=json.loads(job.params), context={"_user": job.user})
+    serializer = EntityCreateSerializer(data=params_dict, context={"_user": job.user})
     serializer.create_remaining(entity, serializer.initial_data)
 
     # update job status and save it
@@ -210,8 +466,19 @@ def edit_entity_v2(self, job: Job) -> JobStatus:
     if not entity:
         return JobStatus.ERROR
 
+    # Validate and parse job parameters using Pydantic
+    try:
+        params = EditEntityV2Params.model_validate_json(job.params)
+    except ValidationError as e:
+        Logger.error(f"Invalid parameters for EDIT_ENTITY_V2 job {job.id}: {e}")
+        return JobStatus.ERROR
+
+    # Convert Pydantic model to dict for serializer
+    # (EntityUpdateSerializer expects dict input)
+    params_dict = params.model_dump(exclude_none=True)
+
     serializer = EntityUpdateSerializer(
-        instance=entity, data=json.loads(job.params), context={"_user": job.user}
+        instance=entity, data=params_dict, context={"_user": job.user}
     )
     if not serializer.is_valid():
         return JobStatus.ERROR

--- a/entity/tests/test_tasks.py
+++ b/entity/tests/test_tasks.py
@@ -1,0 +1,403 @@
+from django.test import TestCase
+from pydantic import ValidationError
+
+from airone.lib.types import AttrType
+from entity.tasks import (
+    CreateEntityAttr,
+    CreateEntityParams,
+    CreateEntityV2Attr,
+    CreateEntityV2Params,
+    CreateEntityV2Webhook,
+    EditEntityAttr,
+    EditEntityV2Attr,
+    EditEntityV2Params,
+    EditEntityV2Webhook,
+    WebhookHeader,
+)
+
+
+class CreateEntityAttrTest(TestCase):
+    """Tests for CreateEntityAttr Pydantic model."""
+
+    def test_valid_attr_with_int_type(self):
+        """Test creating a valid attribute with integer type."""
+        attr = CreateEntityAttr(
+            name="test_attr",
+            type=AttrType.STRING,
+            is_mandatory=True,
+            is_delete_in_chain=False,
+            row_index="1",
+            ref_ids=[],
+        )
+        self.assertEqual(attr.name, "test_attr")
+        self.assertEqual(attr.type, AttrType.STRING)
+        self.assertEqual(attr.is_mandatory, True)
+
+    def test_valid_attr_with_string_type(self):
+        """Test creating a valid attribute with string type (converted to int)."""
+        attr = CreateEntityAttr(
+            name="test_attr",
+            type="2",  # STRING as string
+            is_mandatory=True,
+            is_delete_in_chain=False,
+            row_index="1",
+            ref_ids=[],
+        )
+        self.assertEqual(attr.type, 2)
+
+    def test_invalid_string_type(self):
+        """Test that invalid string type raises ValidationError."""
+        with self.assertRaises(ValidationError) as context:
+            CreateEntityAttr(
+                name="test_attr",
+                type="invalid",
+                is_mandatory=True,
+                is_delete_in_chain=False,
+                row_index="1",
+            )
+        self.assertIn("Invalid type value", str(context.exception))
+
+    def test_name_max_length_validation(self):
+        """Test that name exceeding max length raises ValidationError."""
+        with self.assertRaises(ValidationError):
+            CreateEntityAttr(
+                name="x" * 201,  # Exceeds max_length=200
+                type=AttrType.STRING,
+                is_mandatory=True,
+                is_delete_in_chain=False,
+                row_index="1",
+            )
+
+
+class CreateEntityParamsTest(TestCase):
+    """Tests for CreateEntityParams Pydantic model."""
+
+    def test_valid_params(self):
+        """Test creating valid entity params."""
+        params = CreateEntityParams(
+            attrs=[
+                {
+                    "name": "attr1",
+                    "type": AttrType.STRING,
+                    "is_mandatory": True,
+                    "is_delete_in_chain": False,
+                    "row_index": "1",
+                    "ref_ids": [],
+                }
+            ]
+        )
+        self.assertEqual(len(params.attrs), 1)
+        self.assertEqual(params.attrs[0].name, "attr1")
+
+    def test_empty_attrs(self):
+        """Test that empty attrs list is valid."""
+        params = CreateEntityParams(attrs=[])
+        self.assertEqual(len(params.attrs), 0)
+
+
+class EditEntityAttrTest(TestCase):
+    """Tests for EditEntityAttr Pydantic model."""
+
+    def test_valid_attr_with_id(self):
+        """Test creating a valid attribute with id (for editing)."""
+        attr = EditEntityAttr(
+            id=123,
+            name="test_attr",
+            type=AttrType.STRING,
+            is_mandatory=True,
+            is_delete_in_chain=False,
+            row_index="1",
+            ref_ids=[],
+        )
+        self.assertEqual(attr.id, 123)
+        self.assertEqual(attr.name, "test_attr")
+
+    def test_valid_attr_without_id(self):
+        """Test creating a valid attribute without id (for new attr)."""
+        attr = EditEntityAttr(
+            name="test_attr",
+            type=AttrType.STRING,
+            is_mandatory=True,
+            is_delete_in_chain=False,
+            row_index="1",
+        )
+        self.assertIsNone(attr.id)
+
+    def test_deleted_flag(self):
+        """Test that deleted flag works correctly."""
+        attr = EditEntityAttr(
+            id=123,
+            name="test_attr",
+            type=AttrType.STRING,
+            is_mandatory=True,
+            is_delete_in_chain=False,
+            row_index="1",
+            deleted=True,
+        )
+        self.assertEqual(attr.deleted, True)
+
+
+class WebhookHeaderTest(TestCase):
+    """Tests for WebhookHeader Pydantic model."""
+
+    def test_valid_header(self):
+        """Test creating a valid webhook header."""
+        header = WebhookHeader(header_key="Authorization", header_value="Bearer token123")
+        self.assertEqual(header.header_key, "Authorization")
+        self.assertEqual(header.header_value, "Bearer token123")
+
+    def test_missing_fields(self):
+        """Test that missing required fields raise ValidationError."""
+        with self.assertRaises(ValidationError):
+            WebhookHeader(header_key="Authorization")
+
+
+class CreateEntityV2WebhookTest(TestCase):
+    """Tests for CreateEntityV2Webhook Pydantic model."""
+
+    def test_valid_webhook_with_defaults(self):
+        """Test creating a webhook with default values."""
+        webhook = CreateEntityV2Webhook(url="http://example.com")
+        self.assertEqual(webhook.url, "http://example.com")
+        self.assertEqual(webhook.label, "")
+        self.assertEqual(webhook.is_enabled, False)
+        self.assertEqual(len(webhook.headers), 0)
+
+    def test_valid_webhook_with_all_fields(self):
+        """Test creating a webhook with all fields."""
+        webhook = CreateEntityV2Webhook(
+            url="http://example.com",
+            label="test webhook",
+            is_enabled=True,
+            headers=[
+                {"header_key": "Authorization", "header_value": "Bearer token123"},
+            ],
+        )
+        self.assertEqual(webhook.label, "test webhook")
+        self.assertEqual(webhook.is_enabled, True)
+        self.assertEqual(len(webhook.headers), 1)
+
+    def test_url_max_length_validation(self):
+        """Test that URL exceeding max length raises ValidationError."""
+        with self.assertRaises(ValidationError):
+            CreateEntityV2Webhook(url="x" * 201)
+
+    def test_webhook_without_url_uses_default(self):
+        """Test that webhook without URL uses default empty string."""
+        webhook = CreateEntityV2Webhook()
+        self.assertEqual(webhook.url, "")
+
+
+class EditEntityV2WebhookTest(TestCase):
+    """Tests for EditEntityV2Webhook Pydantic model."""
+
+    def test_valid_webhook_with_id(self):
+        """Test creating a webhook with id (for editing)."""
+        webhook = EditEntityV2Webhook(
+            id=123, url="http://example.com", label="test", is_enabled=True
+        )
+        self.assertEqual(webhook.id, 123)
+        self.assertEqual(webhook.url, "http://example.com")
+
+    def test_valid_webhook_without_id(self):
+        """Test creating a webhook without id (for new webhook)."""
+        webhook = EditEntityV2Webhook(url="http://example.com")
+        self.assertIsNone(webhook.id)
+
+    def test_is_deleted_flag(self):
+        """Test that is_deleted flag works correctly."""
+        webhook = EditEntityV2Webhook(id=123, is_deleted=True)
+        self.assertEqual(webhook.is_deleted, True)
+
+    def test_all_fields_optional_except_defaults(self):
+        """Test that all fields are optional (have defaults)."""
+        webhook = EditEntityV2Webhook()
+        self.assertIsNone(webhook.id)
+        self.assertIsNone(webhook.url)
+        self.assertEqual(webhook.label, "")
+        self.assertEqual(webhook.is_enabled, False)
+        self.assertEqual(webhook.is_deleted, False)
+
+
+class CreateEntityV2AttrTest(TestCase):
+    """Tests for CreateEntityV2Attr Pydantic model."""
+
+    def test_valid_attr_with_defaults(self):
+        """Test creating a valid attribute with default values."""
+        attr = CreateEntityV2Attr(name="test_attr", type=AttrType.STRING)
+        self.assertEqual(attr.name, "test_attr")
+        self.assertEqual(attr.type, AttrType.STRING)
+        self.assertEqual(attr.is_mandatory, False)
+        self.assertEqual(attr.is_delete_in_chain, False)
+        self.assertEqual(attr.is_summarized, False)
+        self.assertEqual(len(attr.referral), 0)
+        self.assertEqual(attr.note, "")
+
+    def test_valid_attr_with_all_fields(self):
+        """Test creating a valid attribute with all fields."""
+        attr = CreateEntityV2Attr(
+            name="test_attr",
+            type=AttrType.STRING,
+            index=1,
+            is_mandatory=True,
+            is_delete_in_chain=True,
+            is_summarized=True,
+            referral=[1, 2, 3],
+            note="test note",
+            default_value="test default",
+        )
+        self.assertEqual(attr.is_mandatory, True)
+        self.assertEqual(attr.default_value, "test default")
+
+    def test_default_value_for_string_type(self):
+        """Test that default_value works for STRING type."""
+        attr = CreateEntityV2Attr(name="test_attr", type=AttrType.STRING, default_value="test")
+        self.assertEqual(attr.default_value, "test")
+
+    def test_default_value_for_text_type(self):
+        """Test that default_value works for TEXT type."""
+        attr = CreateEntityV2Attr(name="test_attr", type=AttrType.TEXT, default_value="test")
+        self.assertEqual(attr.default_value, "test")
+
+    def test_default_value_for_boolean_type(self):
+        """Test that default_value works for BOOLEAN type."""
+        attr = CreateEntityV2Attr(name="test_attr", type=AttrType.BOOLEAN, default_value=True)
+        self.assertEqual(attr.default_value, True)
+
+    def test_default_value_for_number_type(self):
+        """Test that default_value works for NUMBER type."""
+        attr = CreateEntityV2Attr(name="test_attr", type=AttrType.NUMBER, default_value=42)
+        self.assertEqual(attr.default_value, 42)
+
+        attr = CreateEntityV2Attr(name="test_attr", type=AttrType.NUMBER, default_value=3.14)
+        self.assertEqual(attr.default_value, 3.14)
+
+    def test_default_value_cleared_for_unsupported_type(self):
+        """Test that default_value is cleared for unsupported types (e.g., OBJECT)."""
+        # This should log a warning but not raise an error
+        attr = CreateEntityV2Attr(name="test_attr", type=AttrType.OBJECT, default_value="test")
+        self.assertIsNone(attr.default_value)
+
+    def test_default_value_type_mismatch_for_string(self):
+        """Test that default_value is cleared when type mismatches (STRING)."""
+        attr = CreateEntityV2Attr(name="test_attr", type=AttrType.STRING, default_value=123)
+        self.assertIsNone(attr.default_value)
+
+    def test_default_value_type_mismatch_for_boolean(self):
+        """Test that default_value is cleared when type mismatches (BOOLEAN)."""
+        attr = CreateEntityV2Attr(name="test_attr", type=AttrType.BOOLEAN, default_value="true")
+        self.assertIsNone(attr.default_value)
+
+    def test_default_value_type_mismatch_for_number(self):
+        """Test that default_value is cleared when type mismatches (NUMBER)."""
+        attr = CreateEntityV2Attr(name="test_attr", type=AttrType.NUMBER, default_value="42")
+        self.assertIsNone(attr.default_value)
+
+    def test_name_max_length_validation(self):
+        """Test that name exceeding max length raises ValidationError."""
+        with self.assertRaises(ValidationError):
+            CreateEntityV2Attr(name="x" * 201, type=AttrType.STRING)
+
+
+class CreateEntityV2ParamsTest(TestCase):
+    """Tests for CreateEntityV2Params Pydantic model."""
+
+    def test_valid_params_with_name_only(self):
+        """Test creating valid params with name only."""
+        params = CreateEntityV2Params(name="test_entity")
+        self.assertEqual(params.name, "test_entity")
+        self.assertEqual(params.note, "")
+        self.assertEqual(len(params.attrs), 0)
+        self.assertEqual(len(params.webhooks), 0)
+
+    def test_valid_params_with_all_fields(self):
+        """Test creating valid params with all fields."""
+        params = CreateEntityV2Params(
+            name="test_entity",
+            note="test note",
+            attrs=[{"name": "attr1", "type": AttrType.STRING}],
+            webhooks=[{"url": "http://example.com"}],
+        )
+        self.assertEqual(params.name, "test_entity")
+        self.assertEqual(params.note, "test note")
+        self.assertEqual(len(params.attrs), 1)
+        self.assertEqual(len(params.webhooks), 1)
+
+    def test_name_max_length_validation(self):
+        """Test that name exceeding max length raises ValidationError."""
+        with self.assertRaises(ValidationError):
+            CreateEntityV2Params(name="x" * 201)
+
+
+class EditEntityV2AttrTest(TestCase):
+    """Tests for EditEntityV2Attr Pydantic model."""
+
+    def test_valid_attr_with_id_has_optional_fields(self):
+        """Test that existing attrs (with id) can have optional fields."""
+        # When id is provided, name and type are not required
+        attr = EditEntityV2Attr(id=123)
+        self.assertEqual(attr.id, 123)
+        self.assertIsNone(attr.name)
+        self.assertIsNone(attr.type)
+        self.assertEqual(attr.is_deleted, False)
+
+    def test_new_attr_requires_name_and_type(self):
+        """Test that new attrs (without id) require name and type."""
+        with self.assertRaises(ValidationError) as context:
+            EditEntityV2Attr()
+        self.assertIn("name and type are required", str(context.exception))
+
+    def test_valid_attr_with_some_fields(self):
+        """Test creating an attr with some fields."""
+        attr = EditEntityV2Attr(id=123, name="updated_attr", type=AttrType.TEXT)
+        self.assertEqual(attr.id, 123)
+        self.assertEqual(attr.name, "updated_attr")
+        self.assertEqual(attr.type, AttrType.TEXT)
+
+    def test_is_deleted_flag(self):
+        """Test that is_deleted flag works correctly."""
+        attr = EditEntityV2Attr(id=123, is_deleted=True)
+        self.assertEqual(attr.is_deleted, True)
+
+    def test_name_max_length_validation(self):
+        """Test that name exceeding max length raises ValidationError."""
+        with self.assertRaises(ValidationError):
+            EditEntityV2Attr(name="x" * 201)
+
+
+class EditEntityV2ParamsTest(TestCase):
+    """Tests for EditEntityV2Params Pydantic model."""
+
+    def test_valid_params_with_name_only(self):
+        """Test creating valid params with name only."""
+        params = EditEntityV2Params(name="updated_entity")
+        self.assertEqual(params.name, "updated_entity")
+
+    def test_valid_params_with_all_fields(self):
+        """Test creating valid params with all fields."""
+        params = EditEntityV2Params(
+            name="updated_entity",
+            note="updated note",
+            is_toplevel=True,
+            attrs=[{"id": 123, "name": "updated_attr"}],
+            webhooks=[{"id": 456, "url": "http://example.com"}],
+        )
+        self.assertEqual(params.name, "updated_entity")
+        self.assertEqual(params.note, "updated note")
+        self.assertEqual(params.is_toplevel, True)
+        self.assertEqual(len(params.attrs), 1)
+        self.assertEqual(len(params.webhooks), 1)
+
+    def test_all_fields_optional(self):
+        """Test that all fields are optional."""
+        params = EditEntityV2Params()
+        self.assertIsNone(params.name)
+        self.assertIsNone(params.note)
+        self.assertIsNone(params.is_toplevel)
+        self.assertEqual(len(params.attrs), 0)
+        self.assertEqual(len(params.webhooks), 0)
+
+    def test_name_max_length_validation(self):
+        """Test that name exceeding max length raises ValidationError."""
+        with self.assertRaises(ValidationError):
+            EditEntityV2Params(name="x" * 201)


### PR DESCRIPTION
Current job params don't have any explicit schemas. Making pydantic models enforces the mechanism to eusure type safety -- like _editing entity params must have id, name, type, ..._