### PR TITLE
AdvancedSearchResultsPage: add hintEntry to export job registration

### DIFF
--- a/frontend/src/pages/AdvancedSearchResultsPage.tsx
+++ b/frontend/src/pages/AdvancedSearchResultsPage.tsx
@@ -232,6 +232,7 @@ export const AdvancedSearchResultsPage: FC = () => {
         hasReferral,
         searchAllEntities,
         exportStyle,
+        hintEntry,
       );
       enqueueSnackbar("エクスポートジョブの登録に成功しました", {
         variant: "success",

--- a/frontend/src/repository/AironeApiClient.ts
+++ b/frontend/src/repository/AironeApiClient.ts
@@ -880,6 +880,7 @@ class AironeApiClient {
     hasReferral: boolean,
     isAllEntities: boolean,
     format: "yaml" | "csv",
+    hintEntry?: EntryHint,
   ): Promise<void> {
     await this.entry.entryApiV2AdvancedSearchResultExportCreate(
       {
@@ -889,6 +890,7 @@ class AironeApiClient {
           hasReferral: hasReferral,
           isAllEntities: isAllEntities,
           exportStyle: format,
+          hintEntry: hintEntry,
         },
       },
       {


### PR DESCRIPTION
Currently the exported data contains filtered entries; the entry name filter is just ignored. Its unexpected behavior. I'd like to fix it.