### PR TITLE
style: adjust table cell widths for better layout

### DIFF
--- a/frontend/src/components/entry/EntryAttributes.tsx
+++ b/frontend/src/components/entry/EntryAttributes.tsx
@@ -35,12 +35,14 @@ const HeaderTableCell = styled(TableCell)(({ theme }) => ({
 }));
 
 const AttrNameTableCell = styled(TableCell)(() => ({
-  width: "200px",
+  width: "30%",
+  minWidth: "180px",
+  maxWidth: "320px",
   wordBreak: "break-word",
 }));
 
 const AttrValueTableCell = styled(TableCell)(() => ({
-  width: "950px",
+  width: "70%",
   wordBreak: "break-word",
 }));
 


### PR DESCRIPTION
It takes sufficient width (17% -> 30%) to show long entry names more readable. 17% is too short.