### PR TITLE
Make useTypedParams safer

### DIFF
--- a/frontend/src/ErrorHandler.tsx
+++ b/frontend/src/ErrorHandler.tsx
@@ -125,6 +125,7 @@ const ErrorBridge: FC<{ children: ReactNode }> = ({ children }) => {
         const httpError = toError(event.reason);
         if (httpError != null) {
           dispatchError(httpError);
+          return;
         }
       }
       dispatchError(event.reason);

--- a/frontend/src/hooks/useTypedParams.tsx
+++ b/frontend/src/hooks/useTypedParams.tsx
@@ -1,17 +1,27 @@
 import { useParams } from "react-router";
 
+interface UseTypedParamsOptions {
+  allowEmpty?: boolean;
+}
+
 export const useTypedParams = <
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Params extends { [K in keyof Params]: any },
->() => {
-  const params = useParams() as unknown as Partial<Params>;
+>(
+  options: UseTypedParamsOptions = {},
+): Required<Params> => {
+  const { allowEmpty = false } = options;
+  const params = useParams();
 
-  const allFieldsDefined = Object.keys(params).every(
-    (key) => params[key as keyof Params] !== undefined,
-  );
+  const keys = Object.keys(params);
+  if (!allowEmpty && keys.length === 0) {
+    throw new Error("No URL parameters found");
+  }
+
+  const allFieldsDefined = keys.every((key) => params[key] !== undefined);
   if (!allFieldsDefined) {
     throw new Error("Some required URL parameters are missing");
   }
 
-  return params as Required<Params>;
+  return params as unknown as Required<Params>;
 };

--- a/frontend/src/pages/CategoryEditPage.tsx
+++ b/frontend/src/pages/CategoryEditPage.tsx
@@ -26,7 +26,9 @@ import {
 } from "services/AironeAPIErrorUtil";
 
 export const CategoryEditPage: FC = () => {
-  const { categoryId } = useTypedParams<{ categoryId?: number }>();
+  const { categoryId } = useTypedParams<{ categoryId?: number }>({
+    allowEmpty: true,
+  });
   const willCreate = categoryId == null;
 
   const navigate = useNavigate();

--- a/frontend/src/pages/GroupEditPage.tsx
+++ b/frontend/src/pages/GroupEditPage.tsx
@@ -26,7 +26,9 @@ import { ForbiddenError } from "services/Exceptions";
 import { ServerContext } from "services/ServerContext";
 
 export const GroupEditPage: FC = () => {
-  const { groupId } = useTypedParams<{ groupId?: number }>();
+  const { groupId } = useTypedParams<{ groupId?: number }>({
+    allowEmpty: true,
+  });
   const willCreate = groupId == null;
 
   const navigate = useNavigate();

--- a/frontend/src/pages/RoleEditPage.tsx
+++ b/frontend/src/pages/RoleEditPage.tsx
@@ -27,7 +27,7 @@ import {
 import { ForbiddenError } from "services/Exceptions";
 
 export const RoleEditPage: FC = () => {
-  const { roleId } = useTypedParams<{ roleId?: number }>();
+  const { roleId } = useTypedParams<{ roleId?: number }>({ allowEmpty: true });
   const willCreate = roleId == null;
 
   const navigate = useNavigate();

--- a/frontend/src/pages/UserEditPage.tsx
+++ b/frontend/src/pages/UserEditPage.tsx
@@ -29,7 +29,7 @@ import {
 import { ServerContext } from "services/ServerContext";
 
 export const UserEditPage: FC = () => {
-  const { userId } = useTypedParams<{ userId?: number }>();
+  const { userId } = useTypedParams<{ userId?: number }>({ allowEmpty: true });
   const willCreate = userId == null;
 
   const navigate = useNavigate();


### PR DESCRIPTION
Allow it to check if required parameters are served. `useParams` will return undefined values.