### PR TITLE
Changed the button has been disabled if it is not available

### DIFF
--- a/frontend/src/components/common/AutocompleteWithAllSelector.tsx
+++ b/frontend/src/components/common/AutocompleteWithAllSelector.tsx
@@ -8,13 +8,7 @@ import {
   FilterOptionsState,
 } from "@mui/material";
 import { AutocompleteProps } from "@mui/material/Autocomplete/Autocomplete";
-import {
-  HTMLAttributes,
-  SyntheticEvent,
-  useEffect,
-  useMemo,
-  useRef,
-} from "react";
+import { SyntheticEvent, useEffect, useMemo, useRef } from "react";
 
 type SelectorOption = "select-all" | "remove-all";
 
@@ -109,20 +103,25 @@ export const AutocompleteWithAllSelector = <
   };
 
   const optionRenderer = (
-    props: HTMLAttributes<HTMLLIElement>,
+    props: React.HTMLAttributes<HTMLLIElement> & { key: React.Key },
     option: T | SelectorOption,
   ) => {
+    const { key, ...optionProps } = props;
     switch (option) {
       case "select-all":
       case "remove-all":
         return (
-          <li {...props}>
+          <li key={key} {...optionProps}>
             <Checkbox checked={allSelected} />
             <Box>{selectAllLabel}</Box>
           </li>
         );
       default:
-        return <li {...props}>{option as string}</li>;
+        return (
+          <li key={key} {...optionProps}>
+            {option as string}
+          </li>
+        );
     }
   };
 

--- a/frontend/src/components/entry/SearchResultControlMenu.test.tsx
+++ b/frontend/src/components/entry/SearchResultControlMenu.test.tsx
@@ -21,6 +21,7 @@ describe("SearchResultControlMenu", () => {
     handleSelectFilterConditions: jest.fn(),
     handleClose: jest.fn(),
     setOpenEditModal: jest.fn(),
+    isDisabledEditModal: false,
     entityAttrs: [],
   };
 

--- a/frontend/src/components/entry/SearchResultControlMenu.tsx
+++ b/frontend/src/components/entry/SearchResultControlMenu.tsx
@@ -54,6 +54,7 @@ interface Props {
   handleClose: () => void;
   attrType?: number;
   setOpenEditModal: (willOpen: boolean) => void;
+  isDisabledEditModal: boolean;
   entityAttrs: EntityAttrIDandName[];
   setEditTargetAttrID?: (attrID: number) => void;
   setEditTargetAttrname?: (attrname: string) => void;
@@ -69,6 +70,7 @@ export const SearchResultControlMenu: FC<Props> = ({
   handleClose,
   attrType,
   setOpenEditModal,
+  isDisabledEditModal,
   entityAttrs,
   setEditTargetAttrID,
   setEditTargetAttrname,
@@ -589,6 +591,7 @@ export const SearchResultControlMenu: FC<Props> = ({
           variant="outlined"
           fullWidth
           startIcon={<EditNoteIcon />}
+          disabled={isDisabledEditModal}
           onClick={() => {
             setEditTargetAttrID &&
               setEditTargetAttrID(

--- a/frontend/src/components/entry/SearchResultsTableHead.tsx
+++ b/frontend/src/components/entry/SearchResultsTableHead.tsx
@@ -362,6 +362,9 @@ export const SearchResultsTableHead: FC<Props> = ({
                     handleUpdateAttrFilter={handleUpdateAttrFilter(attrName)}
                     attrType={attrTypes[attrName]}
                     setOpenEditModal={setOpenEditModal}
+                    isDisabledEditModal={
+                      searchAllEntities || joinAttrs.length > 0
+                    }
                     entityAttrs={entityAttrs}
                     setEditTargetAttrID={setEditTargetAttrID}
                     setEditTargetAttrname={setEditTargetAttrname}


### PR DESCRIPTION
The advanced search's bulk update function requires target model IDs,
so it cannot be used if the search scope is not narrowed or if JOIN_ATTR is used.
Therefore, Changed the button has been disabled.

Fixed a bug in bulk updates when multiple models were selected.