### PR TITLE
Support frontend custom routings for plugins

### DIFF
--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -279,6 +279,18 @@ class Common(Configuration):
         "PLUGINS": {
             "ENABLED": bool(ENABLED_PLUGINS),
         },
+        # Entity-specific plugin view routing configuration
+        # Format: { "entityId": { "plugin": "plugin-id", "pages": ["entry.list"] } }
+        #
+        # TEST CONFIG: Entity ID "9681" uses sample plugin for entry.list page.
+        # Change the ID to match your test entity, or set ENTITY_PLUGIN_VIEWS env var.
+        # To disable: set ENTITY_PLUGIN_VIEWS='{}'
+        "ENTITY_PLUGIN_VIEWS": json.loads(
+            env.str(
+                "ENTITY_PLUGIN_VIEWS",
+                json.dumps({"9681": {"plugin": "sample", "pages": ["entry.list"]}}),
+            )
+        ),
     }
 
     # flags to enable/disable AirOne core features

--- a/docs/content/advanced/plugin_entity_aware_routing.md
+++ b/docs/content/advanced/plugin_entity_aware_routing.md
@@ -1,0 +1,496 @@
+---
+title: Entity-Aware Routing
+weight: 2
+---
+
+## Overview
+
+Entity-Aware Routing enables **entity-specific UI customization** through the frontend plugin system. This feature allows administrators to configure custom plugin views for specific entities, replacing default Pagoda pages with plugin-provided alternatives.
+
+### Key Benefits
+
+- **Entity-Specific UX**: Different entities can have completely different UI experiences
+- **Plugin-Based Customization**: Leverage the plugin ecosystem for UI extensions
+- **Zero-Code Configuration**: Switch views via Django settings, no code changes required
+- **Graceful Fallback**: Missing plugins or pages automatically fall back to defaults
+
+### Current Scope (Phase 1)
+
+Phase 1 supports:
+- **Page Type**: `entry.list` (Entity entries listing page)
+- **URL Pattern**: `/ui/entities/:entityId/entries`
+
+Future phases may extend to additional page types such as `entry.detail`, `entry.edit`, etc.
+
+## Architecture
+
+### System Overview
+
+```mermaid
+graph TB
+    subgraph "Django Backend"
+        SETTINGS[settings_common.py<br/>ENTITY_PLUGIN_VIEWS]
+        TEMPLATE[index.html Template]
+        CONTEXT[django_context<br/>window.django_context]
+    end
+
+    subgraph "React Frontend"
+        SERVERCTX[ServerContext]
+        HOOK[usePluginMappings Hook]
+        ROUTER[EntityAwareRoute]
+        PLUGINMAP[pluginMap<br/>Map&lt;string, Plugin&gt;]
+    end
+
+    subgraph "Plugin Layer"
+        PLUGIN[Entity View Plugin]
+        PAGES[entityPages<br/>entry.list Component]
+    end
+
+    subgraph "UI Output"
+        DEFAULT[Default EntryListPage]
+        CUSTOM[Plugin Custom Page]
+    end
+
+    SETTINGS --> TEMPLATE
+    TEMPLATE --> CONTEXT
+    CONTEXT --> SERVERCTX
+    SERVERCTX --> HOOK
+    HOOK --> ROUTER
+    PLUGINMAP --> ROUTER
+
+    PLUGIN --> PAGES
+    PAGES --> ROUTER
+
+    ROUTER -->|No mapping| DEFAULT
+    ROUTER -->|Has mapping| CUSTOM
+
+    style SETTINGS fill:#e8f5e8
+    style ROUTER fill:#e1f5fe
+    style PLUGIN fill:#f3e5f5
+```
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Admin as Administrator
+    participant Django as Django Settings
+    participant Template as HTML Template
+    participant React as React App
+    participant Router as EntityAwareRoute
+    participant Plugin as Plugin Component
+
+    Note over Admin,Django: Configuration Phase
+    Admin->>Django: Set ENTITY_PLUGIN_VIEWS<br/>{"9681": {"plugin": "sample", "pages": ["entry.list"]}}
+
+    Note over Template,React: Page Load Phase
+    Django->>Template: Render index.html
+    Template->>React: window.django_context.entityPluginViews
+
+    Note over React,Plugin: Routing Phase
+    React->>Router: Navigate to /ui/entities/9681/entries
+    Router->>Router: Extract entityId from URL
+    Router->>Router: Lookup config[entityId] (O(1))
+    Router->>Router: Check if "entry.list" in pages
+    Router->>Router: Lookup pluginMap.get("sample") (O(1))
+    Router->>Plugin: Render plugin.entityPages["entry.list"]
+    Plugin-->>React: Custom Entry List UI
+```
+
+### Component Relationships
+
+```mermaid
+graph LR
+    subgraph "App Initialization"
+        APP[AppBase]
+        PLUGINS[plugins: Plugin[]]
+        MAP[pluginMap: Map]
+    end
+
+    subgraph "Routing Layer"
+        APPROUTER[AppRouter]
+        ROUTE[EntityAwareRoute]
+    end
+
+    subgraph "Data Sources"
+        CTX[ServerContext]
+        HOOK[usePluginMappings]
+        CONFIG[EntityPluginViewsConfig]
+    end
+
+    subgraph "Resolution"
+        LOOKUP_ID[config&lsqb;entityId&rsqb;]
+        LOOKUP_PLUGIN[pluginMap.get&lpar;pluginId&rpar;]
+        COMPONENT[PluginComponent]
+    end
+
+    APP --> PLUGINS
+    PLUGINS -->|useMemo| MAP
+    APP --> APPROUTER
+    APPROUTER --> ROUTE
+    MAP --> ROUTE
+
+    CTX --> HOOK
+    HOOK --> CONFIG
+    CONFIG --> ROUTE
+
+    ROUTE --> LOOKUP_ID
+    LOOKUP_ID --> LOOKUP_PLUGIN
+    LOOKUP_PLUGIN --> COMPONENT
+
+    style APP fill:#e1f5fe
+    style ROUTE fill:#f3e5f5
+    style COMPONENT fill:#e8f5e8
+```
+
+## Configuration
+
+### Django Settings
+
+Configure entity-plugin mappings in `settings_common.py` or via environment variable:
+
+```python
+# airone/settings_common.py
+AIRONE = {
+    # ... other settings ...
+
+    # Entity-specific plugin view routing configuration
+    # Format: { "entityId": { "plugin": "plugin-id", "pages": ["entry.list"] } }
+    "ENTITY_PLUGIN_VIEWS": json.loads(
+        env.str(
+            "ENTITY_PLUGIN_VIEWS",
+            json.dumps({}),  # Default: no overrides
+        )
+    ),
+}
+```
+
+### Configuration Format
+
+```json
+{
+  "entityId": {
+    "plugin": "plugin-id",
+    "pages": ["entry.list"]
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `entityId` | string | The entity ID (as string) to apply custom routing |
+| `plugin` | string | The plugin ID that provides the custom view |
+| `pages` | string[] | List of page types to override (currently only `"entry.list"`) |
+
+### Example Configurations
+
+**Single Entity Override:**
+```bash
+export ENTITY_PLUGIN_VIEWS='{"42": {"plugin": "network-tools", "pages": ["entry.list"]}}'
+```
+
+**Multiple Entity Overrides:**
+```bash
+export ENTITY_PLUGIN_VIEWS='{
+  "42": {"plugin": "network-tools", "pages": ["entry.list"]},
+  "100": {"plugin": "asset-manager", "pages": ["entry.list"]},
+  "255": {"plugin": "custom-dashboard", "pages": ["entry.list"]}
+}'
+```
+
+**Disable All Overrides:**
+```bash
+export ENTITY_PLUGIN_VIEWS='{}'
+```
+
+## Plugin Development
+
+### Creating an Entity View Plugin
+
+To provide custom entity pages, your plugin must implement the `EntityViewPlugin` interface:
+
+```typescript
+import { FC } from "react";
+
+// Plugin interface for entity-specific views
+interface EntityViewPlugin {
+  id: string;
+  name: string;
+
+  // Entity page components by page type
+  entityPages?: {
+    "entry.list"?: FC;
+    // Future: "entry.detail"?, "entry.edit"?, etc.
+  };
+}
+```
+
+### Example Plugin Implementation
+
+```typescript
+// plugin-sample/src/index.ts
+import { FC } from "react";
+import { CustomEntryList } from "./components/CustomEntryList";
+
+interface Plugin {
+  id: string;
+  name: string;
+  entityPages?: {
+    "entry.list"?: FC;
+  };
+}
+
+const plugin: Plugin = {
+  id: "sample",
+  name: "Sample Entity View Plugin",
+
+  entityPages: {
+    "entry.list": CustomEntryList,
+  },
+};
+
+export default plugin;
+```
+
+### Custom Component Example
+
+```tsx
+// plugin-sample/src/components/CustomEntryList.tsx
+import { FC } from "react";
+import { useParams } from "react-router";
+import { Box, Typography } from "@mui/material";
+
+export const CustomEntryList: FC = () => {
+  const { entityId } = useParams<{ entityId: string }>();
+
+  return (
+    <Box p={3}>
+      <Typography variant="h4">
+        Custom Entry List for Entity {entityId}
+      </Typography>
+      {/* Your custom implementation */}
+    </Box>
+  );
+};
+```
+
+### Plugin Registration
+
+Register your plugin in `pagoda-minimal-builder`:
+
+```javascript
+// frontend/plugins/pagoda-minimal-builder/plugins.config.js
+module.exports = {
+  plugins: [
+    "pagoda-plugin-hello-world",
+    "pagoda-plugin-dashboard",
+    "pagoda-plugin-entity-sample",  // Your entity view plugin
+  ],
+};
+```
+
+## Routing Flow
+
+### Decision Logic
+
+```mermaid
+flowchart TD
+    START[User navigates to<br/>/ui/entities/:entityId/entries]
+
+    CHECK_ID{entityId<br/>in URL?}
+
+    LOOKUP_CONFIG[Lookup config&lsqb;entityId&rsqb;<br/>O&lpar;1&rpar;]
+
+    CHECK_MAPPING{Mapping<br/>exists?}
+
+    CHECK_PAGE{pageType in<br/>mapping.pages?}
+
+    LOOKUP_PLUGIN[Lookup pluginMap.get&lpar;pluginId&rpar;<br/>O&lpar;1&rpar;]
+
+    CHECK_PLUGIN{Plugin<br/>found?}
+
+    CHECK_ENTITY_VIEW{Plugin has<br/>entityPages?}
+
+    CHECK_COMPONENT{Page component<br/>exists?}
+
+    RENDER_PLUGIN[Render Plugin Component]
+    RENDER_DEFAULT[Render Default EntryListPage]
+
+    START --> CHECK_ID
+    CHECK_ID -->|No| RENDER_DEFAULT
+    CHECK_ID -->|Yes| LOOKUP_CONFIG
+
+    LOOKUP_CONFIG --> CHECK_MAPPING
+    CHECK_MAPPING -->|No| RENDER_DEFAULT
+    CHECK_MAPPING -->|Yes| CHECK_PAGE
+
+    CHECK_PAGE -->|No| RENDER_DEFAULT
+    CHECK_PAGE -->|Yes| LOOKUP_PLUGIN
+
+    LOOKUP_PLUGIN --> CHECK_PLUGIN
+    CHECK_PLUGIN -->|No| RENDER_DEFAULT
+    CHECK_PLUGIN -->|Yes| CHECK_ENTITY_VIEW
+
+    CHECK_ENTITY_VIEW -->|No| RENDER_DEFAULT
+    CHECK_ENTITY_VIEW -->|Yes| CHECK_COMPONENT
+
+    CHECK_COMPONENT -->|No| RENDER_DEFAULT
+    CHECK_COMPONENT -->|Yes| RENDER_PLUGIN
+
+    style START fill:#e1f5fe
+    style RENDER_PLUGIN fill:#e8f5e8
+    style RENDER_DEFAULT fill:#fff3e0
+```
+
+### Performance Characteristics
+
+All lookups are O(1):
+
+| Operation | Complexity | Implementation |
+|-----------|------------|----------------|
+| Entity mapping lookup | O(1) | `config[entityId]` object property access |
+| Plugin lookup | O(1) | `pluginMap.get(pluginId)` Map lookup |
+| Page check | O(n) | `pages.includes(pageType)` where n is typically 1-3 |
+
+Total routing decision: **O(1)** with respect to number of entities and plugins.
+
+## Implementation Details
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `airone/settings_common.py` | Django configuration for ENTITY_PLUGIN_VIEWS |
+| `templates/frontend/index.html` | Passes config to frontend via django_context |
+| `frontend/src/plugins/index.ts` | Type definitions for EntityViewPlugin |
+| `frontend/src/services/ServerContext.ts` | Reads entityPluginViews from window |
+| `frontend/src/hooks/usePluginMappings.ts` | Hook to access plugin mappings |
+| `frontend/src/routes/EntityAwareRoute.tsx` | Core routing logic component |
+| `frontend/src/routes/AppRouter.tsx` | Integrates EntityAwareRoute |
+| `frontend/src/AppBase.tsx` | Creates pluginMap from plugins array |
+
+### Type Definitions
+
+```typescript
+// frontend/src/plugins/index.ts
+
+// Supported page types for entity views
+export type EntityPageType = "entry.list";
+
+// Configuration for a single entity mapping
+export interface EntityPluginMapping {
+  plugin: string;           // Plugin ID
+  pages: EntityPageType[];  // Page types to override
+}
+
+// Full configuration: entityId -> mapping
+export type EntityPluginViewsConfig = Record<string, EntityPluginMapping>;
+
+// Plugin interface with entity pages
+export interface EntityViewPlugin extends Plugin {
+  entityPages?: Partial<Record<EntityPageType, FC>>;
+}
+
+// Type guard function
+export function isEntityViewPlugin(plugin: Plugin): plugin is EntityViewPlugin {
+  return "entityPages" in plugin && plugin.entityPages !== undefined;
+}
+```
+
+## Verification
+
+### Testing the Configuration
+
+1. **Set up the configuration:**
+   ```bash
+   # In your Django settings or environment
+   export ENTITY_PLUGIN_VIEWS='{"9681": {"plugin": "sample", "pages": ["entry.list"]}}'
+   ```
+
+2. **Build the frontend with plugins:**
+   ```bash
+   # Build the core library
+   npm run build:lib
+
+   # Build with plugins
+   cd frontend/plugins/pagoda-minimal-builder
+   npm run build
+   cp dist/ui.js ../../../static/js/ui.js
+   ```
+
+3. **Start the server:**
+   ```bash
+   python manage.py runserver
+   ```
+
+4. **Verify in browser:**
+   - Navigate to `/ui/entities/9681/entries`
+   - You should see the plugin's custom view instead of the default EntryListPage
+
+5. **Check console for configuration:**
+   ```javascript
+   // In browser console
+   console.log(window.django_context.entityPluginViews);
+   // Output: {"9681": {"plugin": "sample", "pages": ["entry.list"]}}
+   ```
+
+### Debugging
+
+If the custom view is not displayed:
+
+1. **Check configuration is loaded:**
+   ```javascript
+   window.django_context.entityPluginViews
+   ```
+
+2. **Verify plugin is registered:**
+   - Check `pagoda-minimal-builder/plugins.config.js`
+   - Ensure plugin is in the configured plugins list
+
+3. **Check console warnings:**
+   - EntityAwareRoute logs warnings for:
+     - Plugin not found
+     - Plugin doesn't support entity pages
+     - Page type not provided by plugin
+
+## Future Extensions
+
+### Planned Page Types
+
+| Page Type | URL Pattern | Status |
+|-----------|-------------|--------|
+| `entry.list` | `/ui/entities/:entityId/entries` | Implemented |
+| `entry.detail` | `/ui/entities/:entityId/entries/:entryId` | Planned |
+| `entry.edit` | `/ui/entities/:entityId/entries/:entryId/edit` | Planned |
+| `entry.create` | `/ui/entities/:entityId/entries/new` | Planned |
+
+### Adding New Page Types
+
+To extend the system with new page types:
+
+1. Add the page type to `EntityPageType`:
+   ```typescript
+   export type EntityPageType = "entry.list" | "entry.detail" | "entry.edit";
+   ```
+
+2. Add routing in `AppRouter.tsx`:
+   ```typescript
+   <Route
+     path={entryDetailsPath(":entityId", ":entryId")}
+     element={
+       <EntityAwareRoute
+         pageType="entry.detail"
+         defaultComponent={EntryDetailsPage}
+         pluginMap={pluginMap}
+       />
+     }
+   />
+   ```
+
+3. Implement the page in your plugin:
+   ```typescript
+   entityPages: {
+     "entry.list": CustomEntryList,
+     "entry.detail": CustomEntryDetail,
+   },
+   ```

--- a/frontend/plugins/pagoda-minimal-builder/package-lock.json
+++ b/frontend/plugins/pagoda-minimal-builder/package-lock.json
@@ -12,6 +12,7 @@
         "@dmm-com/pagoda-core": "file:../../..",
         "@mui/material": "^6.4.6",
         "pagoda-plugin-dashboard": "file:../plugin-dashboard",
+        "pagoda-plugin-entity-sample": "file:../plugin-entity-sample",
         "pagoda-plugin-hello-world": "file:../plugin-hello-world",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
@@ -31,14 +32,14 @@
       "version": "1.1.0",
       "license": "GPLv2",
       "dependencies": {
-        "react-router": "^7.5.2"
+        "react-router": "^7.12.0"
       },
       "devDependencies": {
         "@babel/core": "^7.26.9",
         "@babel/plugin-transform-runtime": "^7.26.9",
         "@babel/preset-env": "^7.26.9",
         "@babel/preset-react": "^7.26.3",
-        "@dmm-com/airone-apiclient-typescript-fetch": "^0.18.0",
+        "@dmm-com/airone-apiclient-typescript-fetch": "^0.21.0",
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
         "@hookform/resolvers": "^2.9.11",
@@ -165,6 +166,27 @@
         "@mui/material": "^5.11.3",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "../plugin-entity-sample": {
+      "name": "@airone/plugin-entity-sample",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@dmm-com/pagoda-core": "file:../../..",
+        "@mui/material": "^5.11.3",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "react-router": "^7.0.0"
       }
     },
     "../plugin-hello-world": {
@@ -850,7 +872,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1179,7 +1200,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1206,7 +1226,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1388,7 +1407,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -3169,6 +3187,10 @@
       "resolved": "../plugin-dashboard",
       "link": true
     },
+    "node_modules/pagoda-plugin-entity-sample": {
+      "resolved": "../plugin-entity-sample",
+      "link": true
+    },
     "node_modules/pagoda-plugin-hello-world": {
       "resolved": "../plugin-hello-world",
       "link": true
@@ -3355,7 +3377,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3365,7 +3386,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -4212,8 +4232,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -4235,7 +4254,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4359,7 +4377,6 @@
       "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -4409,7 +4426,6 @@
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",

--- a/frontend/plugins/pagoda-minimal-builder/package.json
+++ b/frontend/plugins/pagoda-minimal-builder/package.json
@@ -24,6 +24,7 @@
     "@dmm-com/pagoda-core": "file:../../..",
     "pagoda-plugin-hello-world": "file:../plugin-hello-world",
     "pagoda-plugin-dashboard": "file:../plugin-dashboard",
+    "pagoda-plugin-entity-sample": "file:../plugin-entity-sample",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "@mui/material": "^6.4.6"

--- a/frontend/plugins/pagoda-minimal-builder/plugins.config.js
+++ b/frontend/plugins/pagoda-minimal-builder/plugins.config.js
@@ -17,6 +17,7 @@ export default {
     // Default plugins
     "pagoda-plugin-hello-world",
     "pagoda-plugin-dashboard",
+    "pagoda-plugin-entity-sample",
 
     // Add custom plugins here
     // "pagoda-plugin-custom-example", // Third-party plugin example (uncomment when installed)

--- a/frontend/plugins/pagoda-minimal-builder/src/generatedPlugins.ts
+++ b/frontend/plugins/pagoda-minimal-builder/src/generatedPlugins.ts
@@ -3,6 +3,7 @@
 
 import plugin0 from "pagoda-plugin-hello-world";
 import plugin1 from "pagoda-plugin-dashboard";
+import plugin2 from "pagoda-plugin-entity-sample";
 
 // Export all plugins
-export const configuredPlugins = [plugin0, plugin1].filter(Boolean);
+export const configuredPlugins = [plugin0, plugin1, plugin2].filter(Boolean);

--- a/frontend/plugins/plugin-entity-sample/package-lock.json
+++ b/frontend/plugins/plugin-entity-sample/package-lock.json
@@ -1,0 +1,594 @@
+{
+  "name": "@airone/plugin-entity-sample",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@airone/plugin-entity-sample",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@dmm-com/pagoda-core": "file:../../..",
+        "@mui/material": "^5.11.3",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "../../..": {
+      "name": "@dmm-com/pagoda-core",
+      "version": "1.1.0",
+      "license": "GPLv2",
+      "peer": true,
+      "dependencies": {
+        "react-router": "^7.12.0"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.26.9",
+        "@babel/plugin-transform-runtime": "^7.26.9",
+        "@babel/preset-env": "^7.26.9",
+        "@babel/preset-react": "^7.26.3",
+        "@dmm-com/airone-apiclient-typescript-fetch": "^0.21.0",
+        "@emotion/react": "^11.11.3",
+        "@emotion/styled": "^11.11.0",
+        "@hookform/resolvers": "^2.9.11",
+        "@mui/icons-material": "^6.4.6",
+        "@mui/material": "^6.4.6",
+        "@mui/system": "^6.4.6",
+        "@mui/x-date-pickers": "^7.27.1",
+        "@testing-library/jest-dom": "^5.17.0",
+        "@testing-library/react": "^16.3.0",
+        "@types/encoding-japanese": "^2.2.1",
+        "@types/jest": "^29.5.14",
+        "@types/uuid": "^10.0.0",
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "@typescript-eslint/parser": "^6.21.0",
+        "babel-loader": "^8.4.1",
+        "encoding-japanese": "^2.2.0",
+        "eslint": "^8.57.1",
+        "eslint-import-resolver-webpack": "^0.13.10",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-react": "^7.37.4",
+        "eslint-plugin-unused-imports": "^4.1.4",
+        "fork-ts-checker-webpack-plugin": "^7.3.0",
+        "i18next": "^23.16.8",
+        "isomorphic-fetch": "^3.0.0",
+        "jest": "^29.5.0",
+        "jest-environment-jsdom": "^29.5.0",
+        "js-cookie": "^2.2.1",
+        "js-file-download": "^0.4.12",
+        "knip": "^5.53.0",
+        "material-ui-popup-state": "^5.3.3",
+        "msw": "^2.7.3",
+        "prettier": "^3.5.2",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
+        "react-error-boundary": "^5.0.0",
+        "react-hook-form": "^7.62.0",
+        "react-i18next": "^15.4.1",
+        "react-use": "^17.6.0",
+        "source-map-loader": "^4.0.2",
+        "ts-jest": "^29.2.6",
+        "ts-loader": "^9.5.2",
+        "typescript": "^5.9.2",
+        "undici": "^5.29.0",
+        "uuid": "^11.1.0",
+        "webpack": "^5.98.0",
+        "webpack-bundle-analyzer": "^4.10.2",
+        "webpack-cli": "^4.10.0",
+        "zod": "^3.24.2"
+      },
+      "peerDependencies": {
+        "@emotion/styled": "^11.0.0",
+        "@mui/material": "^6.0.0",
+        "notistack": "^3.0.1",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dmm-com/pagoda-core": {
+      "resolved": "../../..",
+      "link": true
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
+      "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
+      "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/core-downloads-tracker": "^5.18.0",
+        "@mui/system": "^5.18.0",
+        "@mui/types": "~7.2.15",
+        "@mui/utils": "^5.17.1",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.10",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
+      "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/utils": "^5.17.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
+      "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
+      "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/private-theming": "^5.17.1",
+        "@mui/styled-engine": "^5.18.0",
+        "@mui/types": "~7.2.15",
+        "@mui/utils": "^5.17.1",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "7.2.24",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
+      "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
+      "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/types": "~7.2.15",
+        "@types/prop-types": "^15.7.12",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.27",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
+      "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
+      "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/frontend/plugins/plugin-entity-sample/package.json
+++ b/frontend/plugins/plugin-entity-sample/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@airone/plugin-entity-sample",
+  "version": "1.0.0",
+  "description": "Sample entity view plugin for Airone - demonstrates entity page routing",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "airone",
+    "plugin",
+    "entity-view",
+    "sample"
+  ],
+  "author": "Airone Team",
+  "license": "MIT",
+  "peerDependencies": {
+    "@dmm-com/pagoda-core": "file:../../..",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "@mui/material": "^5.11.3",
+    "react-router": "^7.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "typescript": "^5.0.0"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dmm-com/airone.git",
+    "directory": "frontend/plugins/plugin-entity-sample"
+  },
+  "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=8.0.0"
+  }
+}

--- a/frontend/plugins/plugin-entity-sample/src/index.ts
+++ b/frontend/plugins/plugin-entity-sample/src/index.ts
@@ -1,0 +1,41 @@
+// @airone/plugin-entity-sample - Entity View Sample Plugin
+// Demonstrates entity-specific page routing for Phase 1 (entry.list only)
+
+import React, { FC, ReactNode } from "react";
+import SampleEntryListPage from "./pages/SampleEntryListPage";
+
+// Local type definitions (matching @dmm-com/pagoda-core)
+type EntityPageType = "entry.list";
+
+interface PluginRoute {
+  path: string;
+  element: ReactNode;
+}
+
+interface EntityViewPlugin {
+  id: string;
+  name: string;
+  version: string;
+  routes: PluginRoute[];
+  entityPages?: Partial<Record<EntityPageType, FC>>;
+}
+
+/**
+ * Sample plugin that provides entity-specific entry list page
+ * Phase 1: Only entry.list is supported
+ */
+const sampleEntityPlugin: EntityViewPlugin = {
+  id: "sample",
+  name: "Sample Entity View Plugin",
+  version: "1.0.0",
+
+  // No custom routes (we use entityPages instead)
+  routes: [],
+
+  // Entity-specific pages
+  entityPages: {
+    "entry.list": () => React.createElement(SampleEntryListPage),
+  },
+};
+
+export default sampleEntityPlugin;

--- a/frontend/plugins/plugin-entity-sample/src/pages/SampleEntryListPage.tsx
+++ b/frontend/plugins/plugin-entity-sample/src/pages/SampleEntryListPage.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Box, Typography, Card, CardContent, Chip } from "@mui/material";
+import { useParams } from "react-router";
+
+/**
+ * Sample Entry List Page - Minimal implementation for Phase 1
+ * Displays "Plugin View Active" message with entityId from URL
+ */
+const SampleEntryListPage: React.FC = () => {
+  const { entityId } = useParams<{ entityId: string }>();
+
+  return (
+    <Box sx={{ p: 4, maxWidth: 900, mx: "auto" }}>
+      <Card elevation={2}>
+        <CardContent>
+          <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
+            <Typography variant="h4" component="h1">
+              Plugin View Active
+            </Typography>
+            <Chip
+              label="Sample Plugin"
+              size="small"
+              color="primary"
+              sx={{ ml: 2 }}
+            />
+          </Box>
+
+          <Typography variant="body1" paragraph>
+            This page is rendered by the <strong>plugin-entity-sample</strong>{" "}
+            plugin instead of the default EntryListPage.
+          </Typography>
+
+          <Box
+            sx={{
+              mt: 3,
+              p: 2,
+              backgroundColor: "grey.100",
+              borderRadius: 1,
+            }}
+          >
+            <Typography variant="subtitle2" gutterBottom>
+              Route Information:
+            </Typography>
+            <Typography
+              variant="body2"
+              component="pre"
+              sx={{ fontFamily: "monospace", fontSize: "0.9rem" }}
+            >
+              {`Entity ID: ${entityId ?? "N/A"}
+Page Type: entry.list
+Plugin ID: sample`}
+            </Typography>
+          </Box>
+        </CardContent>
+      </Card>
+    </Box>
+  );
+};
+
+export default SampleEntryListPage;

--- a/frontend/plugins/plugin-entity-sample/tsconfig.json
+++ b/frontend/plugins/plugin-entity-sample/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "ES6"],
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/frontend/src/AppBase.tsx
+++ b/frontend/src/AppBase.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, useMemo } from "react";
 
 import { ErrorHandler } from "ErrorHandler";
 import { CheckTerms } from "components/common/CheckTerms";
@@ -17,10 +17,16 @@ interface Props {
 export const AppBase: FC<Props> = ({ customRoutes, plugins = [] }) => {
   const allCustomRoutes = [...(customRoutes || []), ...extractRoutes(plugins)];
 
+  // Convert plugins array to Map for O(1) lookup
+  const pluginMap = useMemo(
+    () => new Map(plugins.map((p) => [p.id, p])),
+    [plugins],
+  );
+
   return (
     <ErrorHandler>
       <CheckTerms>
-        <AppRouter customRoutes={allCustomRoutes} />
+        <AppRouter customRoutes={allCustomRoutes} pluginMap={pluginMap} />
       </CheckTerms>
     </ErrorHandler>
   );

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -2,6 +2,7 @@ export * from "./useAsyncWithThrow";
 export * from "./useFormNotification";
 export * from "./usePage";
 export * from "./usePageTitle";
+export * from "./usePluginMappings";
 export * from "./usePrompt";
 export * from "./useSimpleSearch";
 export * from "./useTranslation";

--- a/frontend/src/hooks/usePluginMappings.ts
+++ b/frontend/src/hooks/usePluginMappings.ts
@@ -1,0 +1,31 @@
+import { useMemo } from "react";
+
+import { EntityPageType, EntityPluginViewsConfig } from "../plugins";
+import { ServerContext } from "../services/ServerContext";
+
+/**
+ * Return type for usePluginMappings hook
+ */
+export interface UsePluginMappingsResult {
+  config: EntityPluginViewsConfig;
+  hasOverride: (entityId: number, pageType: EntityPageType) => boolean;
+}
+
+/**
+ * Hook to access entity-plugin view mappings from ServerContext
+ * Phase 1: Direct entityId lookup, no API calls needed
+ */
+export const usePluginMappings = (): UsePluginMappingsResult => {
+  const serverContext = ServerContext.getInstance();
+  const config = serverContext?.entityPluginViews ?? {};
+
+  const hasOverride = useMemo(() => {
+    return (entityId: number, pageType: EntityPageType): boolean => {
+      const mapping = config[String(entityId)];
+      if (!mapping) return false;
+      return mapping.pages.includes(pageType);
+    };
+  }, [config]);
+
+  return { config, hasOverride };
+};

--- a/frontend/src/plugins/index.ts
+++ b/frontend/src/plugins/index.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { FC, ReactNode } from "react";
 
 // Simple plugin interface
 export interface Plugin {
@@ -30,3 +30,42 @@ export interface ExtendedAppBaseProps {
 export const extractRoutes = (plugins: Plugin[]): CustomRoute[] => {
   return plugins.flatMap((plugin) => plugin.routes);
 };
+
+// ============================================================================
+// Entity View Plugin Types (Phase 1: entry.list only)
+// ============================================================================
+
+/**
+ * Page types that can be overridden by plugins
+ * Phase 1: Only "entry.list" is supported
+ */
+export type EntityPageType = "entry.list";
+
+/**
+ * Configuration for a single entity-to-plugin mapping
+ * Key is entityId (as string) for O(1) lookup
+ */
+export interface EntityPluginMapping {
+  plugin: string;
+  pages: EntityPageType[];
+}
+
+/**
+ * Full configuration object for entity plugin views
+ * Key is the entity ID (as string) for direct O(1) lookup
+ */
+export type EntityPluginViewsConfig = Record<string, EntityPluginMapping>;
+
+/**
+ * Extended plugin interface with entity page support
+ */
+export interface EntityViewPlugin extends Plugin {
+  entityPages?: Partial<Record<EntityPageType, FC>>;
+}
+
+/**
+ * Type guard to check if a plugin has entity page support
+ */
+export function isEntityViewPlugin(plugin: Plugin): plugin is EntityViewPlugin {
+  return "entityPages" in plugin && plugin.entityPages !== undefined;
+}

--- a/frontend/src/routes/AppRouter.tsx
+++ b/frontend/src/routes/AppRouter.tsx
@@ -18,6 +18,8 @@ import { NotFoundErrorPage } from "../pages/NotFoundErrorPage";
 import { RoleEditPage } from "../pages/RoleEditPage";
 import { RoleListPage } from "../pages/RoleListPage";
 
+import { EntityAwareRoute } from "./EntityAwareRoute";
+
 import { Header } from "components/common/Header";
 import { ACLEditPage } from "pages/ACLEditPage";
 import { AdvancedSearchPage } from "pages/AdvancedSearchPage";
@@ -38,6 +40,7 @@ import { TriggerEditPage } from "pages/TriggerEditPage";
 import { TriggerListPage } from "pages/TriggerListPage";
 import { UserEditPage } from "pages/UserEditPage";
 import { UserListPage } from "pages/UserListPage";
+import { Plugin } from "plugins";
 import {
   aclHistoryPath,
   aclPath,
@@ -85,9 +88,13 @@ interface Props {
     path: string;
     element: ReactNode;
   }[];
+  pluginMap?: Map<string, Plugin>;
 }
 
-export const AppRouter: FC<Props> = ({ customRoutes }) => {
+export const AppRouter: FC<Props> = ({
+  customRoutes,
+  pluginMap = new Map(),
+}) => {
   const router = createBrowserRouter(
     createRoutesFromElements(
       <Route errorElement={<ErrorBridge />}>
@@ -140,7 +147,13 @@ export const AppRouter: FC<Props> = ({ customRoutes }) => {
           />
           <Route
             path={entityEntriesPath(":entityId")}
-            element={<EntryListPage />}
+            element={
+              <EntityAwareRoute
+                pageType="entry.list"
+                defaultComponent={EntryListPage}
+                pluginMap={pluginMap}
+              />
+            }
           />
           <Route
             path={entityHistoryPath(":entityId")}

--- a/frontend/src/routes/EntityAwareRoute.tsx
+++ b/frontend/src/routes/EntityAwareRoute.tsx
@@ -1,0 +1,70 @@
+import { FC } from "react";
+import { useParams } from "react-router";
+
+import { usePluginMappings } from "../hooks/usePluginMappings";
+import { EntityPageType, Plugin, isEntityViewPlugin } from "../plugins";
+
+interface Props {
+  pageType: EntityPageType;
+  defaultComponent: FC;
+  pluginMap: Map<string, Plugin>;
+}
+
+/**
+ * EntityAwareRoute - Conditional routing based on entity-plugin mappings
+ * Phase 1: Only supports "entry.list" page type
+ *
+ * Renders plugin-provided component if entity has an override configured,
+ * otherwise renders the default component.
+ */
+export const EntityAwareRoute: FC<Props> = ({
+  pageType,
+  defaultComponent: DefaultComponent,
+  pluginMap,
+}) => {
+  const { entityId } = useParams<{ entityId: string }>();
+  const { config } = usePluginMappings();
+
+  // No entityId in URL - render default
+  if (!entityId) {
+    return <DefaultComponent />;
+  }
+
+  // O(1) lookup by entityId
+  const mapping = config[entityId];
+
+  // No mapping for this entity - render default
+  if (!mapping || !mapping.pages.includes(pageType)) {
+    return <DefaultComponent />;
+  }
+
+  // O(1) lookup by pluginId
+  const plugin = pluginMap.get(mapping.plugin);
+
+  if (!plugin) {
+    console.warn(
+      `EntityAwareRoute: Plugin "${mapping.plugin}" not found for entity ${entityId}`,
+    );
+    return <DefaultComponent />;
+  }
+
+  // Check if plugin supports entity pages
+  if (!isEntityViewPlugin(plugin)) {
+    console.warn(
+      `EntityAwareRoute: Plugin "${mapping.plugin}" does not support entity pages`,
+    );
+    return <DefaultComponent />;
+  }
+
+  // Get the component for this page type
+  const PluginComponent = plugin.entityPages?.[pageType];
+
+  if (!PluginComponent) {
+    console.warn(
+      `EntityAwareRoute: Plugin "${mapping.plugin}" does not provide "${pageType}" page`,
+    );
+    return <DefaultComponent />;
+  }
+
+  return <PluginComponent />;
+};

--- a/frontend/src/services/ServerContext.ts
+++ b/frontend/src/services/ServerContext.ts
@@ -1,3 +1,5 @@
+import { EntityPluginViewsConfig } from "../plugins";
+
 class User {
   id: number;
   username: string;
@@ -47,6 +49,7 @@ export class ServerContext {
   }[];
   headerColor?: string;
   flags: Record<FlagKey, boolean>;
+  entityPluginViews: EntityPluginViewsConfig;
 
   private static _instance: ServerContext | undefined;
 
@@ -85,6 +88,8 @@ export class ServerContext {
     this.flags = (context.flags as Record<FlagKey, boolean>) ?? {
       webhook: true,
     };
+    this.entityPluginViews =
+      (context.entityPluginViews as EntityPluginViewsConfig) ?? {};
   }
 
   static getInstance() {

--- a/templates/frontend/index.html
+++ b/templates/frontend/index.html
@@ -39,6 +39,7 @@
           flags: {
               webhook: {{ airone_flags.WEBHOOK|yesno:"true,false" }},
           },
+          entityPluginViews: {{ airone.ENTITY_PLUGIN_VIEWS|safe }},
       };
     </script>
     <script src="/static/js/ui.js"></script>


### PR DESCRIPTION
It allows to custom pages for specific entities.
For e.g. you specify `{"42": {"plugin": "sample", "pages": ["entry.list"]}}` as `ENTITY_PLUGIN_VIEWS`, then you can see a custom entry list page served by the sample pluin at `/ui/entities/42/entries`.

See https://github.com/syucream/airone/blob/936d392d2925fd6fb9cfdb2a7fb81f50cc412410/docs/content/advanced/plugin_entity_aware_routing.md for more details.