### PR TITLE
Prepare to upgrade elasticsearch to 8.x

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -90,12 +90,13 @@ jobs:
         ports:
           - 5672:5672
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.28
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
         ports:
           - 9200:9200
         env:
           discovery.type: single-node
           ES_JAVA_OPTS: -Xms512m -Xmx512m
+          xpack.security.enabled: false
         options: >-
           --health-cmd "curl http://localhost:9200/_cluster/health"
           --health-interval 10s

--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -997,11 +997,13 @@ def execute_query(
 
     """
     # Include sort in body for compatibility with both ES7 and ES8 servers
-    query_with_sort = {**query, "sort": [{"name.keyword": "asc"}]}
+    # Only add default sort if not already specified in the query
+    if "sort" not in query:
+        query = {**query, "sort": [{"name.keyword": "asc"}]}
     kwargs = {
         "size": min(size, 500000) if size else settings.ES_CONFIG["MAXIMUM_RESULTS_NUM"],
         "from_": offset,
-        "body": query_with_sort,
+        "body": query,
         "ignore": [404],
         "track_total_hits": True,
     }

--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -996,12 +996,13 @@ def execute_query(
         dict[str, Any]: Search execution result
 
     """
+    # Include sort in body for compatibility with both ES7 and ES8 servers
+    query_with_sort = {**query, "sort": [{"name.keyword": "asc"}]}
     kwargs = {
         "size": min(size, 500000) if size else settings.ES_CONFIG["MAXIMUM_RESULTS_NUM"],
         "from_": offset,
-        "body": query,
+        "body": query_with_sort,
         "ignore": [404],
-        "sort": ["name.keyword:asc"],
         "track_total_hits": True,
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,12 +14,13 @@ services:
       - mysql:/var/lib/mysql
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.6
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
     container_name: elasticsearch
     hostname: elasticsearch
     environment:
       discovery.type: "single-node"
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      xpack.security.enabled: "false"
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
ES7 is no longer supported. ( ref. https://endoflife.date/elasticsearch ) And it will block upgrading Django.

ES language (python) client supports forward compatibility so we should upgrade ES server side first. This PR prepares for that.
https://github.com/elastic/elasticsearch-py?tab=readme-ov-file#compatibility