### PR TITLE
Perfectly remove poetry

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,4 +32,4 @@ RUN bash -c '\
 # python
 RUN pip install --no-cache-dir --upgrade \
     pip \
-    poetry
+    uv

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   ],
   "service": "airone",
   "workspaceFolder": "/workspace/airone",
-  "postCreateCommand": "poetry config virtualenvs.in-project true && poetry config virtualenvs.path .venv && poetry install && npm install",
+  "postCreateCommand": "uv sync --extra dev && npm install",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/docs/content/advanced/plugin_quickstart_guide.md
+++ b/docs/content/advanced/plugin_quickstart_guide.md
@@ -518,7 +518,7 @@ To test job tasks, you need to run both a Celery worker and the Django server:
 
 ```bash
 # Terminal 1: Start Celery worker
-poetry run celery -A airone worker -l info
+uv run celery -A airone worker -l info
 
 # Terminal 2: Start Django server
 ENABLED_PLUGINS=my-first python manage.py runserver
@@ -564,7 +564,7 @@ curl http://localhost:8080/api/v2/jobs/123/ \
 
 | Issue | Cause | Solution |
 |-------|-------|----------|
-| Task not executing | Celery worker not running | Start Celery worker: `poetry run celery -A airone worker -l info` |
+| Task not executing | Celery worker not running | Start Celery worker: `uv run celery -A airone worker -l info` |
 | Operation ID error | Range not configured | Add plugin to `PLUGIN_OPERATION_ID_CONFIG` |
 | Import error | Registry not called | Ensure `PluginTaskRegistry.register()` is in `apps.py` ready() |
 | Job status stuck at PREPARING | Task handler not found | Check decorator `@register_plugin_job_task(offset)` is present |

--- a/docs/content/advanced/plugin_system.md
+++ b/docs/content/advanced/plugin_system.md
@@ -530,7 +530,7 @@ pip install https://github.com/user/my-plugin/releases/download/v1.0.0/my_plugin
 # Development editable install
 pip install -e .
 
-# Development install in Poetry environment
+# Development install in uv environment
 pip install -e .
 ```
 
@@ -850,7 +850,7 @@ Always test plugin tasks with a running Celery worker:
 
 ```bash
 # Terminal 1: Start Celery worker
-poetry run celery -A airone worker -l info
+uv run celery -A airone worker -l info
 
 # Terminal 2: Start Django server
 ENABLED_PLUGINS=my-plugin python manage.py runserver
@@ -1283,7 +1283,7 @@ def log_after_create(self, entity_name, user, entry, **kwargs):
 
 #### 4. Plugin Development Environment Issues
 
-**Development with Poetry**:
+**Development with uv**:
 ```bash
 # If pagoda-core is not found
 cd pagoda-core/


### PR DESCRIPTION
We've already used `uv` instead of `poetry` but some docs still expect using `poetry`, so I'd like to remove them.