### PR TITLE
Upgrade RabbitMQ to version 4.1.3 in Docker and Helm configurations

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -86,7 +86,7 @@ jobs:
         target: ${{ fromJson(needs.setup_python.outputs.targets) }}
     services:
       rabbitmq:
-        image: rabbitmq:3.8.19-management
+        image: rabbitmq:4.1.3-management
         ports:
           - 5672:5672
       elasticsearch:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - elasticsearch-data:/usr/share/elasticsearch/data
 
   rabbitmq:
-    image: rabbitmq:3.8.19-management
+    image: rabbitmq:4.1.3-management
     container_name: rabbitmq
     hostname: rabbitmq
     ports:

--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 7.17.3
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.1
-digest: sha256:1df8dd917ab3dbf8a01f53a5d65170f3ee57993da45b4e8d7d3441b28f9c7f49
-generated: "2026-01-23T11:17:17.936407811+09:00"
+  version: 16.0.14
+digest: sha256:669d2595b0c9e7e78970bb81ade5703e96d084c68a279da797bf97685f356273
+generated: "2026-02-24T12:22:39.454459+09:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -21,4 +21,4 @@ dependencies:
   - condition: rabbitmq.enabled
     name: rabbitmq
     repository: https://charts.bitnami.com/bitnami
-    version: 11.1.1
+    version: 16.0.14

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -146,8 +146,6 @@ externalRabbitmq:
 
 rabbitmq:
   enabled: true
-  image:
-    tag: 3.8.19-debian-10-r30
   auth:
     username: airone
     password: password


### PR DESCRIPTION
RabbitMQ 3.8.x is too old...
https://endoflife.date/rabbitmq