### PR TITLE
Replaced pkg_resources because deprecated

### DIFF
--- a/airone/plugins/discovery.py
+++ b/airone/plugins/discovery.py
@@ -28,26 +28,20 @@ def discover_external_plugins():
     plugins installed as external packages. Only loads plugins
     specified in ENABLED_PLUGINS setting.
     """
-    try:
-        # Import pkg_resources (planned migration to importlib.metadata in the future)
-        import pkg_resources
+    from importlib.metadata import entry_points
 
-        enabled_plugins = getattr(settings, "ENABLED_PLUGINS", [])
-        if not enabled_plugins:
-            logger.info("No plugins specified in ENABLED_PLUGINS, skipping plugin discovery")
-            return
+    enabled_plugins = getattr(settings, "ENABLED_PLUGINS", [])
+    if not enabled_plugins:
+        logger.info("No plugins specified in ENABLED_PLUGINS, skipping plugin discovery")
+        return
 
-        for entry_point in pkg_resources.iter_entry_points("pagoda.plugins"):
-            if entry_point.name in enabled_plugins:
-                try:
-                    plugin_class = entry_point.load()
-                    plugin_registry.register(plugin_class)
-                    logger.info(f"Loaded external plugin: {entry_point.name}")
-                except Exception as e:
-                    logger.error(f"Failed to load external plugin {entry_point.name}: {e}")
-            else:
-                logger.debug(f"Skipping plugin {entry_point.name} (not in enabled list)")
-
-    except ImportError:
-        # If pkg_resources is not available
-        logger.debug("pkg_resources not available, skipping external plugin discovery")
+    for entry_point in entry_points(group="pagoda.plugins"):
+        if entry_point.name in enabled_plugins:
+            try:
+                plugin_class = entry_point.load()
+                plugin_registry.register(plugin_class)
+                logger.info(f"Loaded external plugin: {entry_point.name}")
+            except Exception as e:
+                logger.error(f"Failed to load external plugin {entry_point.name}: {e}")
+        else:
+            logger.debug(f"Skipping plugin {entry_point.name} (not in enabled list)")

--- a/docs/content/advanced/plugin_architecture_diagrams.md
+++ b/docs/content/advanced/plugin_architecture_diagrams.md
@@ -66,7 +66,7 @@ sequenceDiagram
     AI->>PD: Start plugin discovery
 
     par External Plugin Discovery
-        PD->>PD: pkg_resources.iter_entry_points('pagoda.plugins')
+        PD->>PD: entry_points(group="pagoda.plugins")
         PD->>PR: Register external plugins
     and Example Plugin Discovery
         PD->>PD: Scan plugin/examples/ directory

--- a/docs/content/advanced/plugin_quickstart_guide.md
+++ b/docs/content/advanced/plugin_quickstart_guide.md
@@ -715,8 +715,8 @@ for p in plugins:
 
 # 3. Check entry points
 python -c "
-import pkg_resources
-entries = list(pkg_resources.iter_entry_points('pagoda.plugins'))
+from importlib.metadata import entry_points
+entries = list(entry_points(group='pagoda.plugins'))
 print(f'Found {len(entries)} entry points:')
 for ep in entries:
     print(f'  {ep.name} -> {ep.module_name}')

--- a/docs/content/advanced/plugin_system.md
+++ b/docs/content/advanced/plugin_system.md
@@ -1222,8 +1222,8 @@ The plugin system adopts explicit control:
 1. **Check Entry points**:
 ```bash
 python -c "
-import pkg_resources
-for ep in pkg_resources.iter_entry_points('pagoda.plugins'):
+from importlib.metadata import entry_points
+for ep in entry_points(group='pagoda.plugins'):
     print(f'{ep.name} -> {ep.module_name}:{ep.attrs[0]}')
     try:
         plugin_class = ep.load()
@@ -1335,7 +1335,7 @@ print(f'Registered hooks: {stats[\"registered_hooks\"]}')
 
 ```
 1. External Plugin Discovery (Entry Points)
-   ├─ pkg_resources.iter_entry_points('pagoda.plugins')
+   ├─ entry_points(group='pagoda.plugins')
    ├─ Load plugin class from entry point
    └─ Register with plugin_registry
 


### PR DESCRIPTION
Since pkg_resources was removed from setuptools, it has been replaced by importlib.metadata.