### PR TITLE
fix: add postinstall script and update airone-apiclient dependency to optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@dmm-com/pagoda-core",
       "version": "1.1.0",
+      "hasInstallScript": true,
       "license": "GPLv2",
       "dependencies": {
         "react-router": "^7.12.0",
@@ -18,7 +19,6 @@
         "@babel/preset-env": "^7.26.9",
         "@babel/preset-react": "^7.26.3",
         "@biomejs/biome": "^2.4.4",
-        "@dmm-com/airone-apiclient-typescript-fetch": "^0.25.0",
         "@hookform/resolvers": "^2.9.11",
         "@mui/icons-material": "^6.4.6",
         "@mui/material": "^6.4.6",
@@ -59,6 +59,9 @@
         "webpack-bundle-analyzer": "^4.10.2",
         "webpack-cli": "^4.10.0",
         "zod": "^3.24.2"
+      },
+      "optionalDependencies": {
+        "@dmm-com/airone-apiclient-typescript-fetch": "^0.25.0"
       },
       "peerDependencies": {
         "@mui/material": "^6.0.0",
@@ -2312,8 +2315,8 @@
       "version": "0.25.0",
       "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.25.0/7395917b27af700df71876a5b5ceafbc38c2cd51",
       "integrity": "sha512-AqKIBnhvm1EQy0Tc2B+kKOzYEfnwQSB5JnQQP0oiqMVjcPqZG3gg2CG+kGEk19a8c3I5gRmw0/oVuoisAShAYw==",
-      "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -16366,7 +16369,7 @@
       "version": "0.25.0",
       "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.25.0/7395917b27af700df71876a5b5ceafbc38c2cd51",
       "integrity": "sha512-AqKIBnhvm1EQy0Tc2B+kKOzYEfnwQSB5JnQQP0oiqMVjcPqZG3gg2CG+kGEk19a8c3I5gRmw0/oVuoisAShAYw==",
-      "dev": true
+      "optional": true
     },
     "@emnapi/core": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "doc": "docs"
   },
   "scripts": {
+    "postinstall": "node -e \"try{require.resolve('@dmm-com/airone-apiclient-typescript-fetch')}catch{console.warn('\\n⚠ @dmm-com/airone-apiclient-typescript-fetch is not installed.\\n  Run: npm run generate:client && npm run link:client\\n')}\"",
     "build": "npm run build:development",
     "build:development": "webpack build --entry ./frontend/src/App.tsx --mode development",
     "build:development:analyze": "webpack build --entry ./frontend/src/App.tsx --mode development --analyze",
@@ -64,7 +65,6 @@
     "@babel/plugin-transform-runtime": "^7.26.9",
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-react": "^7.26.3",
-    "@dmm-com/airone-apiclient-typescript-fetch": "^0.25.0",
     "@hookform/resolvers": "^2.9.11",
     "@mui/icons-material": "^6.4.6",
     "@mui/material": "^6.4.6",
@@ -112,6 +112,9 @@
     "notistack": "^3.0.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
+  },
+  "optionalDependencies": {
+    "@dmm-com/airone-apiclient-typescript-fetch": "^0.25.0"
   },
   "dependencies": {
     "react-router": "^7.12.0",


### PR DESCRIPTION
Probably GitHub Registry at dmm-com restricts clients in the outside of the org, so `npm install` will fails. The change has a chance to avoid the issue with generate-client script.