### PR TITLE
Fixed CSV header(at the fist line) to list attribute names by index order

### DIFF
--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -375,9 +375,11 @@ def _yaml_export_v2(
 @register_job_task(JobOperation.CREATE_ENTRY)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready_with_handlers(
-    on_cancelled=lambda job: Entry.objects.filter(id=job.target.id, is_active=True).first().delete()
-    if Entry.objects.filter(id=job.target.id, is_active=True).exists()
-    else None
+    on_cancelled=lambda job: (
+        Entry.objects.filter(id=job.target.id, is_active=True).first().delete()
+        if Entry.objects.filter(id=job.target.id, is_active=True).exists()
+        else None
+    )
 )
 def create_entry_attrs(self, job: Job) -> JobStatus | None:
     user = User.objects.filter(id=job.user.id).first()
@@ -782,7 +784,7 @@ def export_entries_v2(self, job: Job):
         output = io.StringIO(newline="")
         writer = csv.writer(output)
 
-        attrs = [x.name for x in entity.attrs.filter(is_active=True)]
+        attrs = [x.name for x in entity.attrs.filter(is_active=True).order_by("index")]
         writer.writerow(["Name"] + attrs)
 
         def data2str(data: ExportedEntryAttributeValue | None) -> str:

--- a/entry/tests/test_api_v2_import_export.py
+++ b/entry/tests/test_api_v2_import_export.py
@@ -47,20 +47,26 @@ class ViewTest(BaseViewTest):
         user = self.admin_login()
 
         entity = Entity.objects.create(name="ほげ", created_user=user)
-        for name in ["foo", "bar"]:
+        for index, name in [(2, "foo"), (1, "bar")]:
             EntityAttr.objects.create(
                 **{
                     "name": name,
                     "type": AttrType.STRING,
                     "created_user": user,
                     "parent_entity": entity,
+                    "index": index,
                 }
             )
 
-        entry = Entry.objects.create(name="fuga", schema=entity, created_user=user)
-        entry.complement_attrs(user)
-        for attr in entry.attrs.all():
-            [attr.add_value(user, x) for x in ["hoge", "fuga"]]
+        entry = self.add_entry(
+            user,
+            "Item",
+            entity,
+            values={
+                "foo": "hoge",
+                "bar": "fuga",
+            },
+        )
 
         resp = self.client.post(
             "/entry/api/v2/%d/export/" % entity.id,
@@ -86,7 +92,7 @@ class ViewTest(BaseViewTest):
 
         self.assertEqual(len(entity_data["entries"]), 1)
         entry_data = entity_data["entries"][0]
-        self.assertEqual(entry_data["name"], "fuga")
+        self.assertEqual(entry_data["name"], "Item")
         self.assertEqual(entry_data["id"], entry.id)
         self.assertTrue("attrs" in entry_data)
 
@@ -94,7 +100,7 @@ class ViewTest(BaseViewTest):
         self.assertTrue(all(["name" in x and "value" in x for x in attrs_data]))
         self.assertEqual(len(attrs_data), entry.attrs.count())
         self.assertEqual(sorted([x["name"] for x in attrs_data]), sorted(["foo", "bar"]))
-        self.assertTrue(all([x["value"] == "fuga" for x in attrs_data]))
+        self.assertTrue(all([x["value"] in ["hoge", "fuga"] for x in attrs_data]))
 
         resp = self.client.post(
             "/entry/api/v2/%d/export/" % entity.id,
@@ -102,6 +108,13 @@ class ViewTest(BaseViewTest):
             "application/json",
         )
         self.assertEqual(resp.status_code, 200)
+
+        # check exported content
+        content = Job.objects.filter(target=entity).last().get_cache().splitlines()
+        # check header content is shown by expected order
+        self.assertEqual(content[0], "Name,bar,foo")
+        # check content value has expected order
+        self.assertEqual(content[1], "Item,fuga,hoge")
 
         # append an unpermitted Attribute
         EntityAttr.objects.create(


### PR DESCRIPTION
## Execution Results
Here is the result of CSV export of a specific Model (Test02) when attribute index order was configured as below.
```CSV
Name,foo,bar
tmp01,hoge,20260202
tmp02,fuga,20210001
```
<img width="1232" height="435" alt="スクリーンショット 2026-04-06 10 50 32" src="https://github.com/user-attachments/assets/89c75a4c-c9c4-4bfa-a6e3-5442db16c0f5" />

Then, here is the result of CSV export after changing its configuration as below.
```CSV
Name,bar,foo
tmp01,20260202,hoge
tmp02,20210001,fuga
```
<img width="1230" height="436" alt="スクリーンショット 2026-04-06 11 10 21" src="https://github.com/user-attachments/assets/a97e70b0-751e-4edd-ab28-87b821c56c7f" />

These results show that the order of CSV header and contents are followed expectedly by changing its attribute index order.