### PR TITLE
Changed to invoke trigger when referenced object entry is deleted

### DIFF
--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -53,6 +53,7 @@ from entry.services import AdvancedSearchService
 from group.models import Group
 from job.models import Job, JobOperation, JobStatus
 from role.models import Role
+from trigger.models import TriggerCondition
 from user.models import User
 
 
@@ -510,6 +511,10 @@ def delete_entry(self, job: Job) -> JobStatus:
     entry._history_user = job.user
 
     entry.delete()
+
+    for ref_entry, actions in TriggerCondition.get_invoked_actions_on_delete(entry):
+        for action in actions:
+            action.run(job.user, ref_entry)
 
     if custom_view.is_custom("after_delete_entry", entry.schema.name):
         custom_view.call_custom("after_delete_entry", entry.schema.name, job.user, entry)
@@ -1063,6 +1068,10 @@ def delete_entry_v2(self, job: Job) -> JobStatus:
     # register operation History for deleting entry
     job.user.seth_entry_del(entry)
     entry.delete(deleted_user=job.user)
+
+    for ref_entry, actions in TriggerCondition.get_invoked_actions_on_delete(entry):
+        for action in actions:
+            action.run(job.user, ref_entry)
 
     # Send notification to the webhook URL
     job_notify: Job = Job.new_notify_delete_entry(job.user, entry)

--- a/trigger/models.py
+++ b/trigger/models.py
@@ -431,6 +431,60 @@ class TriggerCondition(models.Model):
         return False
 
     @classmethod
+    def get_invoked_actions_on_delete(
+        cls, deleted_entry: "Entry"
+    ) -> list[tuple["Entry", list["TriggerAction"]]]:
+        """
+        When an entry is deleted, return (entry, actions) pairs for entries that
+        referenced it via object-type attributes whose trigger conditions now match.
+        """
+        from django.db.models import Q as _Q
+
+        from entry.models import AttributeValue
+
+        affected: dict[int, tuple["Entry", set[int]]] = {}
+        for attrv in AttributeValue.objects.filter(
+            _Q(referral=deleted_entry, is_latest=True)
+            | _Q(referral=deleted_entry, parent_attrv__is_latest=True),
+            parent_attr__is_active=True,
+            parent_attr__schema__is_active=True,
+            parent_attr__parent_entry__is_active=True,
+        ).select_related("parent_attr__parent_entry", "parent_attr__schema"):
+            entry = attrv.parent_attr.parent_entry
+            if entry.id not in affected:
+                affected[entry.id] = (entry, set())
+            affected[entry.id][1].add(attrv.parent_attr.schema.id)
+
+        result = []
+        for entry, entity_attr_ids in affected.values():
+            recv_attrs = []
+            for aid in entity_attr_ids:
+                ea = EntityAttr.objects.get(id=aid)
+                if ea.type & AttrType._ARRAY:
+                    attr = entry.attrs.filter(schema_id=aid, is_active=True).first()
+                    parent_attrv = attr.values.filter(is_latest=True).first() if attr else None
+                    remaining = []
+                    if parent_attrv:
+                        for child in parent_attrv.data_array.filter(referral__is_active=True):
+                            remaining.append(
+                                {"name": child.value, "id": child.referral.id}
+                                if ea.type == AttrType.ARRAY_NAMED_OBJECT
+                                else child.referral.id
+                            )
+                    recv_attrs.append({"attr_id": aid, "value": remaining})
+                else:
+                    recv_attrs.append({"attr_id": aid, "value": None})
+
+            actions = [
+                a
+                for p in TriggerParent.objects.filter(entity=entry.schema)
+                for a in p.get_actions(recv_attrs)
+            ]
+            if actions:
+                result.append((entry, actions))
+        return result
+
+    @classmethod
     def register(cls, entity: Entity, conditions: list, actions: list) -> TriggerParent:
         # convert input to InputTriggerCondition
         input_trigger_conditions = [InputTriggerCondition(**condition) for condition in conditions]

--- a/trigger/tests/test_models.py
+++ b/trigger/tests/test_models.py
@@ -1021,3 +1021,113 @@ class ModelTest(AironeTestCase):
                 self.assertGreaterEqual(len(actions), 1)
             else:
                 self.assertEqual(len(actions), 0)
+
+    def test_invoke_trigger_when_ref_entry_deleted(self):
+        # Register trigger: ref_trigger = None → str_action = "changed_by_delete"
+        ref_attr = self.entity.attrs.get(name="ref_trigger")
+        str_action_attr = self.entity.attrs.get(name="str_action")
+        TriggerCondition.register(
+            self.entity,
+            [{"attr_id": ref_attr.id, "cond": None}],
+            [{"attr_id": str_action_attr.id, "value": "changed_by_delete"}],
+        )
+
+        # Create entry with ref_trigger pointing to a deletable entry
+        ref_entry = self.add_entry(self.user, "deletable_ref", self.entity_ref)
+        entry = self.add_entry(
+            self.user, "test_entry", self.entity, values={"ref_trigger": ref_entry}
+        )
+
+        # Delete the referenced entry and evaluate triggers
+        ref_entry.delete()
+        results = TriggerCondition.get_invoked_actions_on_delete(ref_entry)
+
+        self.assertEqual(len(results), 1)
+        ref_entry_result, actions = results[0]
+        self.assertEqual(ref_entry_result.id, entry.id)
+        self.assertEqual(len(actions), 1)
+
+        # Run the action and verify the entry was updated
+        actions[0].run(self.user, entry)
+        self.assertEqual(entry.get_attrv("str_action").value, "changed_by_delete")
+
+    def test_invoke_trigger_when_named_ref_entry_deleted(self):
+        # Register trigger: named_trigger = None (empty ref+name) → str_action = "changed_by_delete"
+        named_attr = self.entity.attrs.get(name="named_trigger")
+        str_action_attr = self.entity.attrs.get(name="str_action")
+        TriggerCondition.register(
+            self.entity,
+            [{"attr_id": named_attr.id, "cond": None}],
+            [{"attr_id": str_action_attr.id, "value": "changed_by_delete"}],
+        )
+
+        # Create entry with named_trigger referencing a deletable entry
+        ref_entry = self.add_entry(self.user, "deletable_named_ref", self.entity_ref)
+        entry = self.add_entry(
+            self.user,
+            "test_entry",
+            self.entity,
+            values={"named_trigger": {"name": "test_name", "id": ref_entry.id}},
+        )
+
+        # Delete the referenced entry and evaluate triggers
+        ref_entry.delete()
+        results = TriggerCondition.get_invoked_actions_on_delete(ref_entry)
+
+        self.assertEqual(len(results), 1)
+        ref_entry_result, actions = results[0]
+        self.assertEqual(ref_entry_result.id, entry.id)
+
+        actions[0].run(self.user, entry)
+        self.assertEqual(entry.get_attrv("str_action").value, "changed_by_delete")
+
+    def test_invoke_trigger_when_last_arr_ref_deleted(self):
+        # Register trigger: arr_ref_trigger = None (empty array) → str_action = "changed_by_delete"
+        arr_ref_attr = self.entity.attrs.get(name="arr_ref_trigger")
+        str_action_attr = self.entity.attrs.get(name="str_action")
+        TriggerCondition.register(
+            self.entity,
+            [{"attr_id": arr_ref_attr.id, "cond": None}],
+            [{"attr_id": str_action_attr.id, "value": "changed_by_delete"}],
+        )
+
+        # Create entry with arr_ref_trigger = [ref_entry] (single element)
+        ref_entry = self.add_entry(self.user, "deletable_arr_ref", self.entity_ref)
+        entry = self.add_entry(
+            self.user, "test_entry", self.entity, values={"arr_ref_trigger": [ref_entry]}
+        )
+
+        # Delete the only referenced entry → array becomes empty → trigger fires
+        ref_entry.delete()
+        results = TriggerCondition.get_invoked_actions_on_delete(ref_entry)
+
+        self.assertEqual(len(results), 1)
+        _, actions = results[0]
+        actions[0].run(self.user, entry)
+        self.assertEqual(entry.get_attrv("str_action").value, "changed_by_delete")
+
+    def test_no_trigger_when_arr_ref_partially_deleted(self):
+        # Register trigger: arr_ref_trigger = None (empty array) → str_action = "changed_by_delete"
+        arr_ref_attr = self.entity.attrs.get(name="arr_ref_trigger")
+        str_action_attr = self.entity.attrs.get(name="str_action")
+        TriggerCondition.register(
+            self.entity,
+            [{"attr_id": arr_ref_attr.id, "cond": None}],
+            [{"attr_id": str_action_attr.id, "value": "changed_by_delete"}],
+        )
+
+        # Create entry with arr_ref_trigger = [ref_entry_a, ref_entry_b]
+        ref_entry_a = self.add_entry(self.user, "deletable_arr_ref_a", self.entity_ref)
+        ref_entry_b = self.add_entry(self.user, "deletable_arr_ref_b", self.entity_ref)
+        self.add_entry(
+            self.user,
+            "test_entry",
+            self.entity,
+            values={"arr_ref_trigger": [ref_entry_a, ref_entry_b]},
+        )
+
+        # Delete only one entry → array still has ref_entry_b → trigger must NOT fire
+        ref_entry_a.delete()
+        results = TriggerCondition.get_invoked_actions_on_delete(ref_entry_a)
+
+        self.assertEqual(results, [])

--- a/uv.lock
+++ b/uv.lock
@@ -1,8 +1,9 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '4'",
+    "python_full_version >= '3.13' and python_full_version < '4'",
     "python_full_version < '3.13'",
 ]
 
@@ -1096,8 +1097,8 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=3.2" },
-    { name = "djangorestframework", specifier = ">=3.12" },
+    { name = "django", specifier = "==5.2.13" },
+    { name = "djangorestframework", specifier = "==3.16.1" },
     { name = "pagoda-plugin-sdk", git = "https://github.com/dmm-com/pagoda.git?subdirectory=plugin%2Fsdk&tag=v3.153.0" },
 ]
 
@@ -1112,8 +1113,8 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=3.2" },
-    { name = "djangorestframework", specifier = ">=3.12" },
+    { name = "django", specifier = "==5.2.13" },
+    { name = "djangorestframework", specifier = "==3.16.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
closed: https://github.com/dmm-com/airone/issues/3445

When an object-type attribute's referral is deleted (soft-delete), the
attribute value is effectively None. Add TriggerCondition.get_invoked_actions_on_delete()
to evaluate trigger conditions at deletion time, and hook it into the
delete_entry / delete_entry_v2 tasks.

ARRAY types correctly compute remaining elements after deletion to avoid
false positives when the array still has other valid references.