### PR TITLE
fix: update endpoint filtering to include plugin endpoints in schema generation

### DIFF
--- a/airone/spectacular.py
+++ b/airone/spectacular.py
@@ -10,9 +10,11 @@ def exclude_customview_hook(endpoints):
     api_v1 endpoints are excluded because they are legacy APIs that use APIView without
     serializer_class, which causes DRF Spectacular to fail schema generation.
     This includes /api/v1/, /group/api/v1/, /role/api/v1/, etc.
+    plugin endpoints are excluded because they are external plugin APIs that use APIView
+    without serializer_class.
     """
     result = []
     for path, path_regex, method, callback in endpoints:
-        if "/custom/" not in path and "/api/v1/" not in path:
+        if "/custom/" not in path and "/api/v1/" not in path and "/plugins/" not in path:
             result.append((path, path_regex, method, callback))
     return result

--- a/group/api_v2/serializers.py
+++ b/group/api_v2/serializers.py
@@ -107,6 +107,7 @@ class GroupTreeSerializer(serializers.ModelSerializer):
         model = Group
         fields = ["id", "name", "children"]
 
+    @extend_schema_field(serializers.ListField(child=serializers.DictField()))
     def get_children(self, obj: Group) -> list[dict[str, object]]:
         def _make_hierarchical_group(groups: list[Group]) -> list[dict[str, object]]:
             return [


### PR DESCRIPTION
It resolves some errors on `npm run generate:client`