### PR TITLE
Fix apply_join_attrs dropping referred entries due to search limit

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -261,6 +261,7 @@ def make_query(
     allow_missing_attributes: bool = False,
     exclude_referrals: list[int] = [],
     include_referrals: list[int] = [],
+    entry_ids: list[int] | None = None,
 ) -> dict[str, Any]:
     """Create a search query for Elasticsearch.
 
@@ -336,6 +337,10 @@ def make_query(
     query["query"]["bool"]["filter"].append(
         {"nested": {"path": "entity", "query": {"term": {"entity.id": hint_entity.id}}}}
     )
+
+    # Restrict results to specific entry IDs when provided
+    if entry_ids:
+        query["query"]["bool"]["filter"].append({"ids": {"values": [str(i) for i in entry_ids]}})
 
     # Included in query if refinement is entered for 'Name' in advanced search
     if hint_entry is not None and hint_entry.keyword is not None:

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -438,10 +438,6 @@ class AdvancedSearchAPI(generics.GenericAPIView):
             request.user,
             resp,
             join_attrs,
-            entry_limit=entry_limit,
-            is_output_all=is_output_all,
-            exclude_referrals=exclude_referrals,
-            include_referrals=include_referrals,
         )
 
         # convert field values to fit entry retrieve API data type, as a workaround.

--- a/entry/services.py
+++ b/entry/services.py
@@ -44,6 +44,7 @@ class AdvancedSearchService:
         allow_missing_attributes: bool = False,
         exclude_referrals: list[int] = [],
         include_referrals: list[int] = [],
+        entry_ids: list[int] | None = None,
     ) -> AdvancedSearchResults:
         """Main method called from advanced search.
 
@@ -83,6 +84,10 @@ class AdvancedSearchService:
             include_referrals (list(int)): Default []
                 If it's set, this method only targets items that are referred by
                 items of specified Models.
+            entry_ids (list(int) | None): Default None.
+                When provided, restricts search results to entries with these IDs.
+                The effective limit is automatically set to len(entry_ids) to ensure
+                all specified entries are returned.
 
         Returns:
             AdvancedSearchResults: As a result of the search,
@@ -138,10 +143,15 @@ class AdvancedSearchService:
                 allow_missing_attributes=allow_missing_attributes,
                 exclude_referrals=exclude_referrals,
                 include_referrals=include_referrals,
+                entry_ids=entry_ids,
             )
 
+            # When entry_ids is specified, use its length as the effective limit to ensure
+            # all requested entries are returned regardless of the default limit.
+            effective_limit = len(entry_ids) if entry_ids else limit
+
             # sending request to elasticsearch with making query
-            resp = execute_query(query, limit, offset)
+            resp = execute_query(query, effective_limit, offset)
 
             tmp_hint_attrs = [attr.model_copy(deep=True) for attr in hint_attrs]
             # Check for has permission to EntityAttr, when is_output_all flag
@@ -166,12 +176,13 @@ class AdvancedSearchService:
                 resp,
                 tmp_hint_attrs,
                 hint_referral,
-                limit,
+                effective_limit,
             )
             results.ret_count += search_result.ret_count
             results.ret_values.extend(search_result.ret_values)
-            limit -= len(search_result.ret_values)
-            offset = max(0, offset - search_result.ret_count)
+            if not entry_ids:
+                limit -= len(search_result.ret_values)
+                offset = max(0, offset - search_result.ret_count)
 
         return results
 
@@ -302,10 +313,6 @@ class AdvancedSearchService:
         user: User,
         resp: AdvancedSearchResults,
         join_attrs: list,
-        entry_limit: int,
-        is_output_all: bool,
-        exclude_referrals: list[int] = [],
-        include_referrals: list[int] = [],
     ) -> AdvancedSearchResults:
         """Join referred Entry attributes based on join_attrs and filter/expand the results.
 
@@ -345,17 +352,22 @@ class AdvancedSearchService:
                 ).select_related("schema"):
                     ref_entries_by_entity.setdefault(ref_entry.schema_id, []).append(ref_entry.id)
 
-            # Call search_entries() per Entity to apply keyword filters
+            # Call search_entries() per Entity to apply keyword filters.
+            # Use entry_ids to restrict the search to only the known ref IDs, avoiding the
+            # limit-based data loss that occurs when an entity has more entries than the limit.
+            # Process in chunks of 1000 to keep ES query size manageable.
+            CHUNK_SIZE = 1000
             matched_results: dict[int, AdvancedSearchResultRecord] = {}
             for entity_id, ref_ids_in_entity in ref_entries_by_entity.items():
-                search_result = kls.search_entries(
-                    user,
-                    [str(entity_id)],
-                    hint_attrs,
-                    limit=len(ref_ids_in_entity) + 100,
-                )
-                for record in search_result.ret_values:
-                    if record.entry["id"] in ref_ids_in_entity:
+                for i in range(0, len(ref_ids_in_entity), CHUNK_SIZE):
+                    chunk = ref_ids_in_entity[i : i + CHUNK_SIZE]
+                    search_result = kls.search_entries(
+                        user,
+                        [str(entity_id)],
+                        hint_attrs,
+                        entry_ids=chunk,
+                    )
+                    for record in search_result.ret_values:
                         matched_results[record.entry["id"]] = record
 
             # Process each entry and build new_ret_values

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -946,10 +946,6 @@ def export_search_result_v2(self, job: Job):
         user,
         resp,
         join_attr_objects,
-        entry_limit=settings.ES_CONFIG["MAXIMUM_RESULTS_NUM"],
-        is_output_all=False,
-        exclude_referrals=[],
-        include_referrals=[],
     )
 
     output: io.StringIO | None = None

--- a/entry/tests/test_service.py
+++ b/entry/tests/test_service.py
@@ -1100,3 +1100,58 @@ class AdvancedSearchServiceTest(AironeTestCase):
                 self.assertEqual(ret_val.attrs["common_attr"]["value"], "common_value_B")
                 # BetaEntity does not have 'alpha_only_attr', so it should not be in its results.
                 self.assertNotIn("alpha_only_attr", ret_val.attrs)
+
+    def test_search_entries_with_entry_ids(self):
+        user = User.objects.create(username="entry_ids_user1")
+        entity = Entity.objects.create(name="entry_ids_entity1", created_user=user)
+        EntityAttr.objects.create(
+            name="val", type=AttrType.STRING, created_user=user, parent_entity=entity
+        )
+
+        entries = []
+        for i in range(10):
+            entry = Entry.objects.create(name="e-%d" % i, schema=entity, created_user=user)
+            entry.complement_attrs(user)
+            entry.attrs.get(name="val").add_value(user, "v-%d" % i)
+            entry.register_es()
+            entries.append(entry)
+
+        target_ids = [entries[2].id, entries[5].id, entries[8].id]
+        ret = AdvancedSearchService.search_entries(
+            user,
+            [str(entity.id)],
+            [AttrHint(name="val")],
+            entry_ids=target_ids,
+        )
+        self.assertEqual(ret.ret_count, 3)
+        returned_ids = {r.entry["id"] for r in ret.ret_values}
+        self.assertEqual(returned_ids, set(target_ids))
+
+    def test_search_entries_with_entry_ids_and_keyword(self):
+        user = User.objects.create(username="entry_ids_user2")
+        entity = Entity.objects.create(name="entry_ids_entity2", created_user=user)
+        EntityAttr.objects.create(
+            name="val", type=AttrType.STRING, created_user=user, parent_entity=entity
+        )
+
+        entries = []
+        for i in range(6):
+            entry = Entry.objects.create(name="e-%d" % i, schema=entity, created_user=user)
+            entry.complement_attrs(user)
+            # Even indexes have "apple" value, odd indexes have "banana"
+            entry.attrs.get(name="val").add_value(user, "apple" if i % 2 == 0 else "banana")
+            entry.register_es()
+            entries.append(entry)
+
+        # Specify only entries[0,1,2] in entry_ids, further narrow down with keyword="apple"
+        target_ids = [entries[0].id, entries[1].id, entries[2].id]
+        ret = AdvancedSearchService.search_entries(
+            user,
+            [str(entity.id)],
+            [AttrHint(name="val", keyword="apple")],
+            entry_ids=target_ids,
+        )
+        # entries[0] and entries[2] have "apple" and are within target_ids
+        self.assertEqual(ret.ret_count, 2)
+        returned_ids = {r.entry["id"] for r in ret.ret_values}
+        self.assertEqual(returned_ids, {entries[0].id, entries[2].id})


### PR DESCRIPTION
- Fix a bug in `apply_join_attrs` where referred entries were silently
  dropped when the referred entity had more active entries than the
  `limit=len(ref_ids_in_entity)+100` cap passed to `search_entries`
- Add `entry_ids` parameter to `search_entries` and `make_query` to
  restrict ES search to specific entry IDs via an `ids` query filter,
  eliminating the limit-based data loss
- Rewrite the fetch loop in `apply_join_attrs` to use `entry_ids` with
  a chunk size of 1000, guaranteeing all referred entries are returned
  regardless of the total entity size
- Remove unused parameters (`entry_limit`, `is_output_all`,
  `exclude_referrals`, `include_referrals`) from the `apply_join_attrs`
  signature and all call sites