### PR TITLE
Reject isolated entries when setting attribute values via API

### DIFF
--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -384,7 +384,7 @@ class EntryBaseSerializer(serializers.ModelSerializer):
 
             # check attrs value
             (is_valid, msg) = AttributeValue.validate_attr_value(
-                entity_attr.type, attr["value"], entity_attr.is_mandatory
+                entity_attr.type, attr["value"], entity_attr.is_mandatory, entity_attr=entity_attr
             )
             if not is_valid:
                 raise IncorrectTypeError("attrs id(%s) - %s" % (attr["id"], msg))

--- a/entry/models.py
+++ b/entry/models.py
@@ -399,7 +399,7 @@ class AttributeValue(models.Model):
 
     @classmethod
     def validate_attr_value(
-        kls, type: int, input_value: Any, is_mandatory: bool
+        kls, type: int, input_value: Any, is_mandatory: bool, entity_attr=None
     ) -> tuple[bool, str | None]:
         """
         Validate if to add_value is a possible value.
@@ -419,17 +419,29 @@ class AttributeValue(models.Model):
 
         def _is_validate_attr_object(value: int | str) -> bool:
             try:
+                entry_id: int | None = None
                 if isinstance(value, Entry) and value.is_active:
-                    return True
-                if (
+                    entry_id = value.id
+                elif (
                     isinstance(value, ACLBase)
                     and Entry.objects.filter(id=value.id, is_active=True).exists()
                 ):
                     raise Exception("value(%s) is not valid entry" % value.name)
-                if value and not Entry.objects.filter(id=value, is_active=True).exists():
+                elif value and not Entry.objects.filter(id=value, is_active=True).exists():
                     raise Exception("value(%s) is not entry id" % value)
-                if is_mandatory and not value:
+                elif is_mandatory and not value:
                     return False
+                elif value:
+                    entry_id = int(value)
+
+                parent_entity = entity_attr.parent_entity if entity_attr is not None else None
+                if entry_id is not None and parent_entity is not None:
+                    from isolation.models import IsolationParent
+
+                    qs = Entry.objects.filter(id=entry_id, is_active=True)
+                    if IsolationParent.get_isolated_entry_ids(qs, parent_entity):
+                        raise Exception("value(%s) is isolated entry" % value)
+
                 return True
             except (ValueError, TypeError):
                 raise Exception("value(%s) is not int" % value)
@@ -1176,6 +1188,14 @@ class Attribute(ACLBase):
                         if ref_entry:
                             attrv.referral = ref_entry
 
+                    parent_entity = self.schema.parent_entity
+                    if attrv.referral is not None:
+                        from isolation.models import IsolationParent
+
+                        qs = Entry.objects.filter(id=attrv.referral.id, is_active=True)
+                        if IsolationParent.get_isolated_entry_ids(qs, parent_entity):
+                            attrv.referral = None
+
                     if not attrv.referral:
                         return None
 
@@ -1208,6 +1228,14 @@ class Attribute(ACLBase):
                         attrv.referral = val["id"]
                     else:
                         attrv.referral = None
+
+                    parent_entity = self.schema.parent_entity
+                    if attrv.referral is not None:
+                        from isolation.models import IsolationParent
+
+                        qs = Entry.objects.filter(id=attrv.referral.id, is_active=True)
+                        if IsolationParent.get_isolated_entry_ids(qs, parent_entity):
+                            attrv.referral = None
 
                     if not attrv.referral and not attrv.value:
                         return None

--- a/isolation/tests/test_api.py
+++ b/isolation/tests/test_api.py
@@ -4,6 +4,7 @@ from unittest import mock
 from airone.lib.test import AironeViewTest
 from airone.lib.types import AttrType
 from entity import tasks as entity_tasks
+from entry import tasks as entry_tasks
 from isolation.models import IsolationAction, IsolationCondition, IsolationParent
 
 
@@ -194,3 +195,88 @@ class IsolationAPITest(AironeViewTest):
         result_ids = [item["id"] for item in resp.json()]
         # The rule targets entity_unrelated, so it should not affect consumer's referral list
         self.assertIn(entry_ng.id, result_ids)
+
+    # -----------------------------------------------------------------------
+    # Entry create/update rejects isolated entries
+    # -----------------------------------------------------------------------
+
+    def _setup_isolation_rule(self):
+        """Create an isolation rule: Item with status='inactive' is isolated from Consumer."""
+        parent = IsolationParent.objects.create(entity=self.entity_item)
+        IsolationCondition.objects.create(
+            parent=parent,
+            attr=self.entity_item.attrs.get(name="status"),
+            str_cond="inactive",
+        )
+        IsolationAction.objects.create(
+            parent=parent,
+            prevent_from=self.entity_consumer,
+            is_prevent_all=False,
+        )
+        return parent
+
+    def test_entry_create_rejects_isolated_ref(self):
+        entry_ng = self.add_entry(
+            self.user, "inactive_item", self.entity_item, values={"status": "inactive"}
+        )
+        self._setup_isolation_rule()
+
+        consumer_attr = self.entity_consumer.attrs.get(name="item_ref")
+        params = {
+            "name": "consumer_entry",
+            "attrs": [{"id": consumer_attr.id, "value": entry_ng.id}],
+        }
+        resp = self.client.post(
+            f"/entity/api/v2/{self.entity_consumer.id}/entries/",
+            json.dumps(params),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    @mock.patch(
+        "entry.tasks.create_entry_v2.delay", mock.Mock(side_effect=entry_tasks.create_entry_v2)
+    )
+    def test_entry_create_allows_non_isolated_ref(self):
+        entry_ok = self.add_entry(
+            self.user, "active_item", self.entity_item, values={"status": "active"}
+        )
+        self._setup_isolation_rule()
+
+        consumer_attr = self.entity_consumer.attrs.get(name="item_ref")
+        params = {
+            "name": "consumer_entry",
+            "attrs": [{"id": consumer_attr.id, "value": entry_ok.id}],
+        }
+        resp = self.client.post(
+            f"/entity/api/v2/{self.entity_consumer.id}/entries/",
+            json.dumps(params),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, 202)
+
+    def test_entry_update_rejects_isolated_ref(self):
+        entry_ok = self.add_entry(
+            self.user, "active_item", self.entity_item, values={"status": "active"}
+        )
+        entry_ng = self.add_entry(
+            self.user, "inactive_item", self.entity_item, values={"status": "inactive"}
+        )
+        consumer_entry = self.add_entry(
+            self.user,
+            "consumer_entry",
+            self.entity_consumer,
+            values={"item_ref": entry_ok},
+        )
+        self._setup_isolation_rule()
+
+        consumer_attr = self.entity_consumer.attrs.get(name="item_ref")
+        params = {
+            "name": consumer_entry.name,
+            "attrs": [{"id": consumer_attr.id, "value": entry_ng.id}],
+        }
+        resp = self.client.put(
+            f"/entry/api/v2/{consumer_entry.id}/",
+            json.dumps(params),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, 400)


### PR DESCRIPTION
Previously isolation only hid entries from the referral selection UI.
Direct API calls could still assign isolated entries as attribute values.

- Add entity_attr param to validate_attr_value() and check isolation in
  _is_validate_attr_object(); api_v2 create/update returns 400 on violation
- Add isolation check in Attribute.add_value() for OBJECT/NAMED_OBJECT types
  to cover api_v1, import tasks, and other non-serializer paths; treats
  isolated entries the same as deleted ones (referral silently set to None)
- On restore, isolated referrals are cleared to None so restore always succeeds