### PR TITLE
Minor change of discription of non-disclosure rules in Model configuration.

### DIFF
--- a/frontend/src/components/entity/entityForm/IsolationRulesFields.tsx
+++ b/frontend/src/components/entity/entityForm/IsolationRulesFields.tsx
@@ -435,8 +435,9 @@ export const IsolationRulesFields: FC<Props> = ({
             <HeaderTableCell width="200px">対象モデル</HeaderTableCell>
             <HeaderTableCell width="100px">全モデル</HeaderTableCell>
             <HeaderTableCell sx={{ display: "flex", gap: "8px" }}>
-              <Box width="200px">除外条件</Box>
+              <Box width="200px">属性</Box>
               <Box>NOT</Box>
+              <Box>除外するアイテムの属性値</Box>
             </HeaderTableCell>
             <HeaderTableCell width="60px">削除</HeaderTableCell>
             <HeaderTableCell width="60px">追加</HeaderTableCell>

--- a/frontend/src/pages/__snapshots__/EntityEditPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntityEditPage.test.tsx.snap
@@ -666,12 +666,17 @@ exports[`EditEntityPage should match snapshot 1`] = `
                   <div
                     class="MuiBox-root css-1domaf0"
                   >
-                    除外条件
+                    属性
                   </div>
                   <div
                     class="MuiBox-root css-0"
                   >
                     NOT
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    除外するアイテムの属性値
                   </div>
                 </th>
                 <th
@@ -1511,12 +1516,17 @@ exports[`EditEntityPage should match snapshot 1`] = `
                 <div
                   class="MuiBox-root css-1domaf0"
                 >
-                  除外条件
+                  属性
                 </div>
                 <div
                   class="MuiBox-root css-0"
                 >
                   NOT
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  除外するアイテムの属性値
                 </div>
               </th>
               <th


### PR DESCRIPTION
Because current table headers are hard to explain what they are.

AsIs:
<img width="1242" height="153" alt="スクリーンショット 2026-04-16 11 46 37" src="https://github.com/user-attachments/assets/4394f393-dc2c-4c3a-85a6-2d932c0f728b" />

ToBe:
<img width="1225" height="150" alt="スクリーンショット 2026-04-16 16 47 42" src="https://github.com/user-attachments/assets/a1c2138f-da13-4265-a25a-61f49025fc2e" />
