### PR TITLE
Implement notification messages for job registration and completion; update snackbar handling in various components

### DIFF
--- a/frontend/src/AironeSnackbarProvider.tsx
+++ b/frontend/src/AironeSnackbarProvider.tsx
@@ -1,5 +1,7 @@
 import CheckCircleOutlineOutlinedIcon from "@mui/icons-material/CheckCircleOutlineOutlined";
 import ErrorOutlinedIcon from "@mui/icons-material/ErrorOutlined";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import WarningAmberOutlinedIcon from "@mui/icons-material/WarningAmberOutlined";
 import { styled } from "@mui/material/styles";
 import { SnackbarProvider } from "notistack";
 import { FC, ReactNode } from "react";
@@ -11,6 +13,12 @@ const StyledSnackbarProvider = styled(SnackbarProvider)(({ theme }) => ({
   variantError: {
     backgroundColor: theme.palette.error.main + "!important",
   },
+  variantWarning: {
+    backgroundColor: theme.palette.warning.main + "!important",
+  },
+  variantInfo: {
+    backgroundColor: theme.palette.info.main + "!important",
+  },
 }));
 
 export const AironeSnackbarProvider: FC<{ children: ReactNode }> = ({
@@ -18,7 +26,7 @@ export const AironeSnackbarProvider: FC<{ children: ReactNode }> = ({
 }) => {
   return (
     <StyledSnackbarProvider
-      maxSnack={3}
+      maxSnack={5}
       iconVariant={{
         success: (
           <CheckCircleOutlineOutlinedIcon
@@ -26,6 +34,10 @@ export const AironeSnackbarProvider: FC<{ children: ReactNode }> = ({
           />
         ),
         error: <ErrorOutlinedIcon sx={{ fontSize: "20px", mr: "8px" }} />,
+        warning: (
+          <WarningAmberOutlinedIcon sx={{ fontSize: "20px", mr: "8px" }} />
+        ),
+        info: <InfoOutlinedIcon sx={{ fontSize: "20px", mr: "8px" }} />,
       }}
     >
       {children}

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from "../../hooks/useTranslation";
 
 import { SearchBox } from "components/common/SearchBox";
 import { useInterval } from "hooks/useInterval";
+import { useJobCompletionNotification } from "hooks/useJobCompletionNotification";
 import { useSimpleSearch } from "hooks/useSimpleSearch";
 import { aironeApiClient } from "repository/AironeApiClient";
 import {
@@ -138,6 +139,8 @@ export const Header: FC = () => {
       console.warn("failed to get recent jobs. will auto retried ...");
     }
   }, JobRefreshIntervalMilliSec);
+
+  useJobCompletionNotification(recentJobs);
 
   const uncheckedJobsCount = useMemo(() => {
     return latestCheckDate != null

--- a/frontend/src/components/entity/EntityControlMenu.test.tsx
+++ b/frontend/src/components/entity/EntityControlMenu.test.tsx
@@ -2,11 +2,12 @@
  * @jest-environment jsdom
  */
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { EntityControlMenu } from "./EntityControlMenu";
 
 import { TestWrapper } from "TestWrapper";
+import { aironeApiClient } from "repository/AironeApiClient";
 import { ACLType } from "services/ACLUtil";
 
 describe("EntityControlMenu", () => {
@@ -160,6 +161,49 @@ describe("EntityControlMenu", () => {
         expect(screen.getByText("ACL 設定")).toBeInTheDocument();
         expect(screen.getByText("インポート")).toBeInTheDocument();
         expect(screen.getByText("削除")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("export notification", () => {
+    const defaultProps = {
+      entityId: 1,
+      anchorElem: document.createElement("button"),
+      handleClose: () => {},
+      setOpenImportModal: () => false,
+    };
+
+    test("should show info variant snackbar on successful export", async () => {
+      jest.spyOn(aironeApiClient, "exportEntries").mockResolvedValue(undefined);
+
+      render(<EntityControlMenu {...defaultProps} />, {
+        wrapper: TestWrapper,
+      });
+
+      fireEvent.click(screen.getByText("エクスポート(YAML)"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("エクスポートのジョブ登録に成功しました"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test("should show error variant snackbar on failed export", async () => {
+      jest
+        .spyOn(aironeApiClient, "exportEntries")
+        .mockRejectedValue(new Error("export failed"));
+
+      render(<EntityControlMenu {...defaultProps} />, {
+        wrapper: TestWrapper,
+      });
+
+      fireEvent.click(screen.getByText("エクスポート(CSV)"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("エクスポートのジョブ登録に失敗しました"),
+        ).toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/components/entity/EntityControlMenu.tsx
+++ b/frontend/src/components/entity/EntityControlMenu.tsx
@@ -26,6 +26,7 @@ import {
   aclHistoryPath,
 } from "routes/Routes";
 import { canEdit, canModifyACL } from "services/ACLUtil";
+import { NotificationMessages } from "services/NotificationMessages";
 
 type ExportFormatType = "YAML" | "CSV";
 
@@ -70,13 +71,16 @@ export const EntityControlMenu: FC<Props> = ({
   const handleExport = async (entityId: number, format: ExportFormatType) => {
     try {
       await aironeApiClient.exportEntries(entityId, format);
-      enqueueSnackbar("モデルのエクスポートのジョブ登録が成功しました", {
-        variant: "success",
+      enqueueSnackbar(NotificationMessages.jobRegistered("エクスポート"), {
+        variant: "info",
       });
     } catch (e) {
-      enqueueSnackbar("モデルのエクスポートのジョブ登録が失敗しました", {
-        variant: "error",
-      });
+      enqueueSnackbar(
+        NotificationMessages.jobRegistrationFailed("エクスポート"),
+        {
+          variant: "error",
+        },
+      );
     }
   };
 

--- a/frontend/src/hooks/useFormNotification.tsx
+++ b/frontend/src/hooks/useFormNotification.tsx
@@ -1,5 +1,7 @@
 import { SnackbarKey, useSnackbar } from "notistack";
 
+import { NotificationMessages } from "services/NotificationMessages";
+
 interface formNotification {
   enqueueSubmitResult: (
     finished: boolean,
@@ -21,14 +23,12 @@ export const useFormNotification = (
 
   return {
     enqueueSubmitResult: (finished: boolean, additionalMessage?: string) => {
-      return enqueueSnackbar(
-        `${targetName}の${operationName}が${
-          finished ? "完了" : "失敗"
-        }しました。${additionalMessage ?? ""}`,
-        {
-          variant: finished ? "success" : "error",
-        },
-      );
+      const message = finished
+        ? NotificationMessages.operationCompleted(targetName, operationName)
+        : NotificationMessages.operationFailed(targetName, operationName);
+      return enqueueSnackbar(`${message}${additionalMessage ?? ""}`, {
+        variant: finished ? "success" : "error",
+      });
     },
   };
 };

--- a/frontend/src/hooks/useJobCompletionNotification.test.tsx
+++ b/frontend/src/hooks/useJobCompletionNotification.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { JobSerializers } from "@dmm-com/airone-apiclient-typescript-fetch";
+import { renderHook, act } from "@testing-library/react";
+import { SnackbarProvider } from "notistack";
+import { FC, ReactNode } from "react";
+
+import { useJobCompletionNotification } from "./useJobCompletionNotification";
+
+import { JobOperations, JobStatuses } from "services/Constants";
+
+const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+  <SnackbarProvider maxSnack={5}>{children}</SnackbarProvider>
+);
+
+const makeJob = (
+  overrides: Partial<JobSerializers> & { id: number },
+): JobSerializers => {
+  const { id, ...rest } = overrides;
+  return {
+    id,
+    status: JobStatuses.DONE,
+    operation: JobOperations.CREATE_ENTRY,
+    target: { name: `job-${id}` },
+    createdAt: new Date(),
+    passedTime: 0,
+    text: "",
+    ...rest,
+  } as JobSerializers;
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("useJobCompletionNotification", () => {
+  test("should not show toasts on first load for already-terminal jobs", () => {
+    const jobs = [
+      makeJob({ id: 1, status: JobStatuses.DONE }),
+      makeJob({ id: 2, status: JobStatuses.ERROR }),
+    ];
+
+    const { result } = renderHook(
+      ({ recentJobs }) => useJobCompletionNotification(recentJobs),
+      { wrapper, initialProps: { recentJobs: jobs } },
+    );
+
+    // Hook should complete without error
+    expect(result.current).toBeUndefined();
+
+    // IDs should be persisted to localStorage as notified
+    const stored = JSON.parse(
+      localStorage.getItem("job__notified_ids") ?? "[]",
+    );
+    expect(stored).toContain(1);
+    expect(stored).toContain(2);
+  });
+
+  test("should show toast when a new job reaches terminal status after first load", () => {
+    const initialJobs = [makeJob({ id: 1, status: JobStatuses.PROCESSING })];
+
+    const { rerender } = renderHook(
+      ({ recentJobs }) => useJobCompletionNotification(recentJobs),
+      { wrapper, initialProps: { recentJobs: initialJobs } },
+    );
+
+    // Job completes on next poll
+    const updatedJobs = [makeJob({ id: 1, status: JobStatuses.DONE })];
+
+    act(() => {
+      rerender({ recentJobs: updatedJobs });
+    });
+
+    // ID should be stored as notified
+    const stored = JSON.parse(
+      localStorage.getItem("job__notified_ids") ?? "[]",
+    );
+    expect(stored).toContain(1);
+  });
+
+  test("should not show duplicate toast for already-notified job", () => {
+    const initialJobs = [makeJob({ id: 1, status: JobStatuses.PROCESSING })];
+
+    const { rerender } = renderHook(
+      ({ recentJobs }) => useJobCompletionNotification(recentJobs),
+      { wrapper, initialProps: { recentJobs: initialJobs } },
+    );
+
+    const completedJobs = [makeJob({ id: 1, status: JobStatuses.DONE })];
+
+    act(() => {
+      rerender({ recentJobs: completedJobs });
+    });
+
+    // Rerender again with same completed job - should not duplicate
+    act(() => {
+      rerender({ recentJobs: completedJobs });
+    });
+
+    const stored = JSON.parse(
+      localStorage.getItem("job__notified_ids") ?? "[]",
+    );
+    // Should still only have one entry
+    expect(stored.filter((id: number) => id === 1)).toHaveLength(1);
+  });
+
+  test("should handle empty recentJobs without error", () => {
+    const { result } = renderHook(
+      ({ recentJobs }) => useJobCompletionNotification(recentJobs),
+      { wrapper, initialProps: { recentJobs: [] as JobSerializers[] } },
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  test("should skip non-terminal jobs", () => {
+    const initialJobs = [makeJob({ id: 10, status: JobStatuses.PREPARING })];
+
+    const { rerender } = renderHook(
+      ({ recentJobs }) => useJobCompletionNotification(recentJobs),
+      { wrapper, initialProps: { recentJobs: initialJobs } },
+    );
+
+    // Still processing on next poll
+    const stillProcessing = [
+      makeJob({ id: 10, status: JobStatuses.PROCESSING }),
+    ];
+
+    act(() => {
+      rerender({ recentJobs: stillProcessing });
+    });
+
+    const stored = localStorage.getItem("job__notified_ids");
+    const ids = stored ? JSON.parse(stored) : [];
+    expect(ids).not.toContain(10);
+  });
+
+  test("should handle export job with DONE status", () => {
+    const initialJobs = [
+      makeJob({
+        id: 5,
+        status: JobStatuses.PROCESSING,
+        operation: JobOperations.EXPORT_ENTRY,
+      }),
+    ];
+
+    const { rerender } = renderHook(
+      ({ recentJobs }) => useJobCompletionNotification(recentJobs),
+      { wrapper, initialProps: { recentJobs: initialJobs } },
+    );
+
+    const completedJobs = [
+      makeJob({
+        id: 5,
+        status: JobStatuses.DONE,
+        operation: JobOperations.EXPORT_ENTRY,
+      }),
+    ];
+
+    act(() => {
+      rerender({ recentJobs: completedJobs });
+    });
+
+    const stored = JSON.parse(
+      localStorage.getItem("job__notified_ids") ?? "[]",
+    );
+    expect(stored).toContain(5);
+  });
+
+  test("should handle ERROR status job", () => {
+    const initialJobs = [makeJob({ id: 7, status: JobStatuses.PROCESSING })];
+
+    const { rerender } = renderHook(
+      ({ recentJobs }) => useJobCompletionNotification(recentJobs),
+      { wrapper, initialProps: { recentJobs: initialJobs } },
+    );
+
+    const failedJobs = [makeJob({ id: 7, status: JobStatuses.ERROR })];
+
+    act(() => {
+      rerender({ recentJobs: failedJobs });
+    });
+
+    const stored = JSON.parse(
+      localStorage.getItem("job__notified_ids") ?? "[]",
+    );
+    expect(stored).toContain(7);
+  });
+
+  test("should handle TIMEOUT status job", () => {
+    const initialJobs = [makeJob({ id: 8, status: JobStatuses.PROCESSING })];
+
+    const { rerender } = renderHook(
+      ({ recentJobs }) => useJobCompletionNotification(recentJobs),
+      { wrapper, initialProps: { recentJobs: initialJobs } },
+    );
+
+    const timedOutJobs = [makeJob({ id: 8, status: JobStatuses.TIMEOUT })];
+
+    act(() => {
+      rerender({ recentJobs: timedOutJobs });
+    });
+
+    const stored = JSON.parse(
+      localStorage.getItem("job__notified_ids") ?? "[]",
+    );
+    expect(stored).toContain(8);
+  });
+
+  test("should prune IDs no longer in recentJobs", () => {
+    // Pre-seed localStorage with an old notified ID
+    localStorage.setItem("job__notified_ids", JSON.stringify([999]));
+
+    const initialJobs = [makeJob({ id: 1, status: JobStatuses.PROCESSING })];
+
+    const { rerender } = renderHook(
+      ({ recentJobs }) => useJobCompletionNotification(recentJobs),
+      { wrapper, initialProps: { recentJobs: initialJobs } },
+    );
+
+    const completedJobs = [makeJob({ id: 1, status: JobStatuses.DONE })];
+
+    act(() => {
+      rerender({ recentJobs: completedJobs });
+    });
+
+    const stored = JSON.parse(
+      localStorage.getItem("job__notified_ids") ?? "[]",
+    );
+    expect(stored).toContain(1);
+    expect(stored).not.toContain(999);
+  });
+
+  test("should restore notified IDs from localStorage across instances", () => {
+    // Simulate a previous session having notified job 42
+    localStorage.setItem("job__notified_ids", JSON.stringify([42]));
+
+    const jobs = [makeJob({ id: 42, status: JobStatuses.DONE })];
+
+    // First render (first load marks existing terminals, but 42 is already in localStorage)
+    renderHook(({ recentJobs }) => useJobCompletionNotification(recentJobs), {
+      wrapper,
+      initialProps: { recentJobs: jobs },
+    });
+
+    const stored = JSON.parse(
+      localStorage.getItem("job__notified_ids") ?? "[]",
+    );
+    expect(stored).toContain(42);
+  });
+});

--- a/frontend/src/hooks/useJobCompletionNotification.tsx
+++ b/frontend/src/hooks/useJobCompletionNotification.tsx
@@ -1,0 +1,181 @@
+import { JobSerializers } from "@dmm-com/airone-apiclient-typescript-fetch";
+import CloseIcon from "@mui/icons-material/Close";
+import { Button, IconButton } from "@mui/material";
+import { SnackbarKey, useSnackbar } from "notistack";
+import { useEffect, useRef } from "react";
+
+import {
+  LocalStorageKey,
+  localStorageUtil,
+} from "../repository/LocalStorageUtil";
+
+import { jobsPath } from "routes/Routes";
+import { JobOperations, JobStatuses } from "services/Constants";
+import { jobOperationLabel } from "services/JobUtil";
+import { NotificationMessages } from "services/NotificationMessages";
+
+const EXPORT_OPERATIONS = new Set([
+  JobOperations.EXPORT_ENTRY,
+  JobOperations.EXPORT_SEARCH_RESULT,
+  JobOperations.EXPORT_ENTRY_V2,
+  JobOperations.EXPORT_SEARCH_RESULT_V2,
+]);
+
+const isTerminalStatus = (status: number | undefined): boolean =>
+  status === JobStatuses.DONE ||
+  status === JobStatuses.ERROR ||
+  status === JobStatuses.TIMEOUT;
+
+const loadNotifiedIds = (): Set<number> => {
+  const raw = localStorageUtil.get(LocalStorageKey.JobNotifiedIds);
+  if (raw == null) return new Set();
+  try {
+    return new Set(JSON.parse(raw) as number[]);
+  } catch {
+    return new Set();
+  }
+};
+
+const saveNotifiedIds = (ids: Set<number>) => {
+  localStorageUtil.set(
+    LocalStorageKey.JobNotifiedIds,
+    JSON.stringify([...ids]),
+  );
+};
+
+export const useJobCompletionNotification = (
+  recentJobs: JobSerializers[],
+): void => {
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+  const notifiedIdsRef = useRef<Set<number>>(loadNotifiedIds());
+  const isFirstLoadRef = useRef(true);
+
+  useEffect(() => {
+    if (recentJobs.length === 0) return;
+
+    // On first load, mark all existing terminal jobs as notified without showing toasts
+    if (isFirstLoadRef.current) {
+      isFirstLoadRef.current = false;
+      for (const job of recentJobs) {
+        if (isTerminalStatus(job.status)) {
+          notifiedIdsRef.current.add(job.id);
+        }
+      }
+      saveNotifiedIds(notifiedIdsRef.current);
+      return;
+    }
+
+    const newlyNotified: number[] = [];
+
+    for (const job of recentJobs) {
+      if (!isTerminalStatus(job.status)) continue;
+      if (notifiedIdsRef.current.has(job.id)) continue;
+
+      const targetName = job.target?.name ?? jobOperationLabel(job.operation);
+
+      const closeAction = (snackbarId: SnackbarKey) => (
+        <IconButton
+          size="small"
+          color="inherit"
+          onClick={() => closeSnackbar(snackbarId)}
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      );
+
+      if (job.status === JobStatuses.DONE) {
+        if (EXPORT_OPERATIONS.has(job.operation ?? 0)) {
+          enqueueSnackbar(NotificationMessages.exportReady(targetName), {
+            variant: "success",
+            persist: true,
+            action: (snackbarId) => (
+              <>
+                <Button
+                  size="small"
+                  color="inherit"
+                  href={`/job/api/v2/${job.id}/download?encode=utf-8`}
+                  onClick={() => closeSnackbar(snackbarId)}
+                >
+                  ダウンロード
+                </Button>
+                {closeAction(snackbarId)}
+              </>
+            ),
+          });
+        } else {
+          enqueueSnackbar(NotificationMessages.jobCompleted(targetName), {
+            variant: "success",
+            autoHideDuration: 8000,
+            action: (snackbarId) => (
+              <>
+                <Button
+                  size="small"
+                  color="inherit"
+                  href={jobsPath()}
+                  onClick={() => closeSnackbar(snackbarId)}
+                >
+                  詳細
+                </Button>
+                {closeAction(snackbarId)}
+              </>
+            ),
+          });
+        }
+      } else if (job.status === JobStatuses.ERROR) {
+        enqueueSnackbar(NotificationMessages.jobFailed(targetName), {
+          variant: "error",
+          persist: true,
+          action: (snackbarId) => (
+            <>
+              <Button
+                size="small"
+                color="inherit"
+                href={jobsPath()}
+                onClick={() => closeSnackbar(snackbarId)}
+              >
+                詳細
+              </Button>
+              {closeAction(snackbarId)}
+            </>
+          ),
+        });
+      } else if (job.status === JobStatuses.TIMEOUT) {
+        enqueueSnackbar(NotificationMessages.jobTimedOut(targetName), {
+          variant: "warning",
+          autoHideDuration: 8000,
+          action: (snackbarId) => (
+            <>
+              <Button
+                size="small"
+                color="inherit"
+                href={jobsPath()}
+                onClick={() => closeSnackbar(snackbarId)}
+              >
+                詳細
+              </Button>
+              {closeAction(snackbarId)}
+            </>
+          ),
+        });
+      }
+
+      newlyNotified.push(job.id);
+    }
+
+    if (newlyNotified.length > 0) {
+      for (const id of newlyNotified) {
+        notifiedIdsRef.current.add(id);
+      }
+
+      // Prune IDs no longer in recentJobs
+      const currentJobIds = new Set(recentJobs.map((j) => j.id));
+      for (const id of notifiedIdsRef.current) {
+        if (!currentJobIds.has(id)) {
+          notifiedIdsRef.current.delete(id);
+        }
+      }
+
+      saveNotifiedIds(notifiedIdsRef.current);
+    }
+  }, [recentJobs, enqueueSnackbar, closeSnackbar]);
+};

--- a/frontend/src/pages/AdvancedSearchResultsPage.tsx
+++ b/frontend/src/pages/AdvancedSearchResultsPage.tsx
@@ -37,6 +37,7 @@ import { usePage } from "hooks/usePage";
 import { aironeApiClient } from "repository/AironeApiClient";
 import { advancedSearchPath, topPath } from "routes/Routes";
 import { AdvancedSerarchResultListParam } from "services/Constants";
+import { NotificationMessages } from "services/NotificationMessages";
 import { extractAdvancedSearchParams } from "services/entry/AdvancedSearch";
 
 function isAttrInfoSet(info: AdvancedSearchResultAttrInfo) {
@@ -236,13 +237,16 @@ export const AdvancedSearchResultsPage: FC = () => {
         exportStyle,
         hintEntry,
       );
-      enqueueSnackbar("エクスポートジョブの登録に成功しました", {
-        variant: "success",
+      enqueueSnackbar(NotificationMessages.jobRegistered("エクスポート"), {
+        variant: "info",
       });
     } catch (e) {
-      enqueueSnackbar("エクスポートジョブの登録に失敗しました", {
-        variant: "error",
-      });
+      enqueueSnackbar(
+        NotificationMessages.jobRegistrationFailed("エクスポート"),
+        {
+          variant: "error",
+        },
+      );
     }
   };
 

--- a/frontend/src/pages/EntryCopyPage.test.tsx
+++ b/frontend/src/pages/EntryCopyPage.test.tsx
@@ -2,7 +2,13 @@
  * @jest-environment jsdom
  */
 
-import { act, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { createMemoryRouter, RouterProvider } from "react-router";
@@ -10,6 +16,7 @@ import { createMemoryRouter, RouterProvider } from "react-router";
 import { EntryCopyPage } from "./EntryCopyPage";
 
 import { TestWrapperWithoutRoutes } from "TestWrapper";
+import { aironeApiClient } from "repository/AironeApiClient";
 import { copyEntryPath } from "routes/Routes";
 
 const server = setupServer(
@@ -70,4 +77,51 @@ test("should match snapshot", async () => {
   });
 
   expect(result).toMatchSnapshot();
+});
+
+test("should show info variant snackbar on successful copy submission", async () => {
+  jest
+    .spyOn(aironeApiClient, "copyEntry")
+    .mockResolvedValue(
+      {} as ReturnType<typeof aironeApiClient.copyEntry> extends Promise<
+        infer T
+      >
+        ? T
+        : never,
+    );
+
+  const router = createMemoryRouter(
+    [
+      {
+        path: copyEntryPath(":entityId", ":entryId"),
+        element: <EntryCopyPage />,
+      },
+    ],
+    {
+      initialEntries: [copyEntryPath(2, 1)],
+    },
+  );
+
+  await act(async () => {
+    render(<RouterProvider router={router} />, {
+      wrapper: TestWrapperWithoutRoutes,
+    });
+  });
+  await waitFor(() => {
+    expect(screen.queryByTestId("loading")).not.toBeInTheDocument();
+  });
+
+  // Enter copy target names in the textarea
+  const textarea = screen.getByPlaceholderText("コピーするアイテム名");
+  fireEvent.change(textarea, { target: { value: "copy-entry-1" } });
+
+  // Click the copy button
+  const copyButton = screen.getByRole("button", { name: "コピーを作成" });
+  fireEvent.click(copyButton);
+
+  await waitFor(() => {
+    expect(
+      screen.getByText("コピーのジョブ登録に成功しました"),
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/EntryCopyPage.tsx
+++ b/frontend/src/pages/EntryCopyPage.tsx
@@ -18,6 +18,7 @@ import { EntryBreadcrumbs } from "components/entry/EntryBreadcrumbs";
 import { usePrompt } from "hooks/usePrompt";
 import { aironeApiClient } from "repository/AironeApiClient";
 import { entityEntriesPath, entryDetailsPath } from "routes/Routes";
+import { NotificationMessages } from "services/NotificationMessages";
 
 interface Props {
   CopyForm?: FC<CopyFormProps>;
@@ -78,11 +79,11 @@ const EntryCopyContent: FC<Props> = ({ CopyForm = DefaultCopyForm }) => {
 
       setEdited(false);
       setSubmitted(true);
-      enqueueSnackbar("アイテムコピーのジョブ登録が成功しました", {
-        variant: "success",
+      enqueueSnackbar(NotificationMessages.jobRegistered("コピー"), {
+        variant: "info",
       });
     } catch {
-      enqueueSnackbar("アイテムコピーのジョブ登録が失敗しました", {
+      enqueueSnackbar(NotificationMessages.jobRegistrationFailed("コピー"), {
         variant: "error",
       });
     }

--- a/frontend/src/repository/LocalStorageUtil.ts
+++ b/frontend/src/repository/LocalStorageUtil.ts
@@ -1,5 +1,6 @@
 export const LocalStorageKey = {
   JobLatestCheckDate: "job__latest_check_date",
+  JobNotifiedIds: "job__notified_ids",
 } as const;
 
 type LocalStorageKey = (typeof LocalStorageKey)[keyof typeof LocalStorageKey];

--- a/frontend/src/services/NotificationMessages.test.ts
+++ b/frontend/src/services/NotificationMessages.test.ts
@@ -1,0 +1,81 @@
+import { NotificationMessages } from "./NotificationMessages";
+
+describe("NotificationMessages", () => {
+  describe("jobRegistered", () => {
+    test("should include operation name", () => {
+      expect(NotificationMessages.jobRegistered("エクスポート")).toBe(
+        "エクスポートのジョブ登録に成功しました",
+      );
+    });
+  });
+
+  describe("jobRegistrationFailed", () => {
+    test("should include operation name", () => {
+      expect(NotificationMessages.jobRegistrationFailed("コピー")).toBe(
+        "コピーのジョブ登録に失敗しました",
+      );
+    });
+  });
+
+  describe("jobCompleted", () => {
+    test("should include label", () => {
+      expect(NotificationMessages.jobCompleted("テストジョブ")).toBe(
+        "テストジョブが完了しました",
+      );
+    });
+  });
+
+  describe("jobFailed", () => {
+    test("should include label", () => {
+      expect(NotificationMessages.jobFailed("テストジョブ")).toBe(
+        "テストジョブが失敗しました",
+      );
+    });
+  });
+
+  describe("jobTimedOut", () => {
+    test("should include label", () => {
+      expect(NotificationMessages.jobTimedOut("テストジョブ")).toBe(
+        "テストジョブがタイムアウトしました",
+      );
+    });
+  });
+
+  describe("operationCompleted", () => {
+    test("should include target and operation names", () => {
+      expect(NotificationMessages.operationCompleted("アイテム", "作成")).toBe(
+        "アイテムの作成が完了しました。",
+      );
+    });
+  });
+
+  describe("operationFailed", () => {
+    test("should include target and operation names", () => {
+      expect(NotificationMessages.operationFailed("アイテム", "更新")).toBe(
+        "アイテムの更新が失敗しました。",
+      );
+    });
+  });
+
+  describe("exportReady", () => {
+    test("should include target name", () => {
+      expect(NotificationMessages.exportReady("テストエンティティ")).toBe(
+        "テストエンティティのエクスポートが完了しました",
+      );
+    });
+  });
+
+  describe("uploadFailed", () => {
+    test("should show base message without detail", () => {
+      expect(NotificationMessages.uploadFailed()).toBe(
+        "ファイルのアップロードに失敗しました",
+      );
+    });
+
+    test("should include detail when provided", () => {
+      expect(NotificationMessages.uploadFailed("サイズ超過")).toBe(
+        "ファイルのアップロードに失敗しました: サイズ超過",
+      );
+    });
+  });
+});

--- a/frontend/src/services/NotificationMessages.ts
+++ b/frontend/src/services/NotificationMessages.ts
@@ -1,0 +1,24 @@
+export const NotificationMessages = {
+  // Job lifecycle
+  jobRegistered: (operationName: string) =>
+    `${operationName}のジョブ登録に成功しました`,
+  jobRegistrationFailed: (operationName: string) =>
+    `${operationName}のジョブ登録に失敗しました`,
+  jobCompleted: (label: string) => `${label}が完了しました`,
+  jobFailed: (label: string) => `${label}が失敗しました`,
+  jobTimedOut: (label: string) => `${label}がタイムアウトしました`,
+
+  // CRUD operations (used by useFormNotification)
+  operationCompleted: (targetName: string, operationName: string) =>
+    `${targetName}の${operationName}が完了しました。`,
+  operationFailed: (targetName: string, operationName: string) =>
+    `${targetName}の${operationName}が失敗しました。`,
+
+  // Export
+  exportReady: (targetName: string) =>
+    `${targetName}のエクスポートが完了しました`,
+
+  // File
+  uploadFailed: (detail?: string) =>
+    `ファイルのアップロードに失敗しました${detail ? `: ${detail}` : ""}`,
+} as const;


### PR DESCRIPTION
Current snackbar show just `ジョブ登録が成功しました` on export operations. On the change, it has two messages on subnmitted/succeeded statuses, and the success notification contains a download link newly.