### PR TITLE
feat(entity): improve autoname UX on entity edit page

### DIFF
--- a/entity/api_v2/serializers.py
+++ b/entity/api_v2/serializers.py
@@ -295,6 +295,10 @@ class EntityAttrCreateSerializer(serializers.ModelSerializer):
                     "When specified object type, referral field is required"
                 )
 
+        name_order = attr.get("name_order", 0)
+        if name_order > 0 and attr.get("type") not in Entity.ITEM_NAME_SELECTABLE_TYPES:
+            raise ValidationError("This attribute type is not supported for autoname configuration")
+
         return attr
 
 
@@ -416,6 +420,13 @@ class EntityAttrUpdateSerializer(serializers.ModelSerializer):
             if not attr["is_deleted"] and not user.has_permission(entity_attr, ACLType.Writable):
                 raise PermissionDenied("Does not have permission to update")
 
+            name_order = attr.get("name_order")
+            if name_order is not None and name_order > 0:
+                if entity_attr.type not in Entity.ITEM_NAME_SELECTABLE_TYPES:
+                    raise ValidationError(
+                        "This attribute type is not supported for autoname configuration"
+                    )
+
         # case create EntityAttr
         else:
             if "name" not in attr or "type" not in attr:
@@ -425,6 +436,12 @@ class EntityAttrUpdateSerializer(serializers.ModelSerializer):
             if attr["type"] & AttrType.OBJECT and not len(referral):
                 raise RequiredParameterError(
                     "When specified object type, referral field is required"
+                )
+
+            name_order = attr.get("name_order", 0)
+            if name_order > 0 and attr["type"] not in Entity.ITEM_NAME_SELECTABLE_TYPES:
+                raise ValidationError(
+                    "This attribute type is not supported for autoname configuration"
                 )
 
         # Only String, Text, Boolean, Number types support default values (MVP)

--- a/entity/models.py
+++ b/entity/models.py
@@ -154,7 +154,7 @@ class Entity(ACLBase):
     STATUS_EDITING = 1 << 2
 
     # This describes which Attribute types are selectable when itm_name_type is ATTR
-    ITEM_NAME_SELECTABLE_TYPES = [AttrType.STRING, AttrType.OBJECT]
+    ITEM_NAME_SELECTABLE_TYPES = [AttrType.STRING, AttrType.OBJECT, AttrType.NUMBER]
 
     note = models.CharField(max_length=200, blank=True)
 

--- a/entity/tests/test_api_v2_serializers.py
+++ b/entity/tests/test_api_v2_serializers.py
@@ -376,3 +376,39 @@ class EntityAttrSerializerTest(AironeViewTest):
             )
             with self.assertRaises(ValidationError, msg=f"Should fail for: {invalid_value}"):
                 serializer.is_valid(raise_exception=True)
+
+    def test_create_attr_with_name_order_and_unsupported_type_raises_error(self):
+        for unsupported_type in [AttrType.TEXT, AttrType.BOOLEAN, AttrType.DATE, AttrType.GROUP]:
+            data = {"name": "test_attr", "type": unsupported_type, "name_order": 1}
+            serializer = EntityAttrCreateSerializer(
+                data=data, context=self._get_serializer_context()
+            )
+            self.assertFalse(
+                serializer.is_valid(), msg=f"type={unsupported_type} should be invalid"
+            )
+
+    def test_create_attr_with_name_order_and_supported_type_is_valid(self):
+        ref_entity = Entity.objects.create(name="ref_entity", created_user=self.user)
+        for supported_type, extra in [
+            (AttrType.STRING, {}),
+            (AttrType.NUMBER, {}),
+            (AttrType.OBJECT, {"referral": [ref_entity.id]}),
+        ]:
+            data = {"name": "test_attr", "type": supported_type, "name_order": 1, **extra}
+            serializer = EntityAttrCreateSerializer(
+                data=data, context=self._get_serializer_context()
+            )
+            self.assertTrue(
+                serializer.is_valid(), msg=f"type={supported_type}: {serializer.errors}"
+            )
+
+    def test_update_attr_name_order_with_unsupported_type_raises_error(self):
+        attr = EntityAttr.objects.create(
+            name="bool_attr",
+            type=AttrType.BOOLEAN,
+            created_user=self.user,
+            parent_entity=self.entity,
+        )
+        data = {"id": attr.id, "name_order": 1, "is_deleted": False}
+        serializer = EntityAttrUpdateSerializer(data=data, context=self._get_serializer_context())
+        self.assertFalse(serializer.is_valid())

--- a/entry/models.py
+++ b/entry/models.py
@@ -1728,7 +1728,17 @@ class Entry(ACLBase):
                 if attr.schema.type not in Entity.ITEM_NAME_SELECTABLE_TYPES:
                     continue
 
-                username += attr.schema.name_prefix + attrv.get_value() + attr.schema.name_postfix
+                value = attrv.get_value()
+                if value is None:
+                    continue
+
+                # NUMBER type returns float; represent whole numbers without decimal point
+                str_value = (
+                    str(int(value))
+                    if isinstance(value, float) and value.is_integer()
+                    else str(value)
+                )
+                username += attr.schema.name_prefix + str_value + attr.schema.name_postfix
 
             return username
 

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -83,7 +83,7 @@ class ViewTest(BaseViewTest):
                     "name": "number",
                     "type": AttrType.NUMBER,
                     "name_order": 4,
-                },  # This should be ignored
+                },
                 {
                     "name": "dict",
                     "type": AttrType.NAMED_OBJECT,
@@ -1765,6 +1765,7 @@ class ViewTest(BaseViewTest):
                 "lb": item_lb.id,
                 "domain": "test.example.com",
                 "port": "10000",
+                "number": 1,
             },
         )
         item_sg.save_autoname()

--- a/entry/tests/test_api_v2_create_special.py
+++ b/entry/tests/test_api_v2_create_special.py
@@ -42,7 +42,8 @@ class ViewTest(BaseViewTest):
                     "name": "number",
                     "type": AttrType.NUMBER,
                     "name_order": 4,
-                },  # This should be ignored
+                    "name_prefix": " #",
+                },
                 {
                     "name": "dict",
                     "type": AttrType.NAMED_OBJECT,
@@ -487,7 +488,8 @@ class ViewTest(BaseViewTest):
 
         # Check create Item's name is expected one that is generated from autoname pattern
         self.assertEqual(
-            Entry.objects.filter(schema=model_sg).last().name, "[LB0001] test.example.com:8080"
+            Entry.objects.filter(schema=model_sg).last().name,
+            "[LB0001] test.example.com:8080 #123.456",
         )
 
     @patch("entry.tasks.edit_entry_v2.delay", Mock(side_effect=tasks.edit_entry_v2))
@@ -519,7 +521,7 @@ class ViewTest(BaseViewTest):
 
         # Check updated Item's name is expected one that is generated from autoname pattern
         item_sg.refresh_from_db()
-        self.assertEqual(item_sg.name, "[LB0001] test.example.com:8080")
+        self.assertEqual(item_sg.name, "[LB0001] test.example.com:8080 #123.456")
 
     @patch("entry.tasks.import_entries_v2.delay", Mock(side_effect=tasks.import_entries_v2))
     def test_import_update_items_for_autoname(self):

--- a/entry/tests/test_model_validation.py
+++ b/entry/tests/test_model_validation.py
@@ -1466,7 +1466,8 @@ class ModelValidationTest(BaseModelTest):
                     "name": "number",
                     "type": AttrType.NUMBER,
                     "name_order": 4,
-                },  # This should be ignored
+                    "name_prefix": " #",
+                },
                 {
                     "name": "dict",
                     "type": AttrType.NAMED_OBJECT,
@@ -1490,7 +1491,7 @@ class ModelValidationTest(BaseModelTest):
                 "dict": {"name": "TestDict", "id": lb1},
             },
         )
-        self.assertEqual(lb_sg1.autoname, "[LB0001] pagoda-test.example.com:80")
+        self.assertEqual(lb_sg1.autoname, "[LB0001] pagoda-test.example.com:80 #100")
 
     def test_save_autoname_with_duplicated_values(self):
         model = self.create_entity(

--- a/frontend/src/components/entity/entityForm/AttributeField.tsx
+++ b/frontend/src/components/entity/entityForm/AttributeField.tsx
@@ -45,6 +45,13 @@ const StyledBox = styled(Box)(({ theme }) => ({
   gap: "8px",
 }));
 
+// Attribute types that support autoname (mirrors backend Entity.ITEM_NAME_SELECTABLE_TYPES)
+const AUTONAME_SELECTABLE_TYPES = [
+  AttributeTypes.string.type,
+  AttributeTypes.object.type,
+  AttributeTypes.number.type,
+];
+
 // Define the custom display order for attribute types
 const ATTRIBUTE_TYPE_ORDER = [
   "string",
@@ -113,6 +120,7 @@ export const AttributeField: FC<Props> = ({
   }, []);
 
   const isObjectLikeType = ((attrType ?? 0) & AttributeTypes.object.type) > 0;
+  const isAutoNameSupported = AUTONAME_SELECTABLE_TYPES.includes(attrType ?? 0);
 
   const handleCloseModal = () => setOpenModal(false);
   const handleCloseAutoNameConfigModal = () =>
@@ -322,7 +330,10 @@ export const AttributeField: FC<Props> = ({
             </ListItemButton>
 
             {/* Open modal for setting Attribute auto-naming configuration */}
-            <ListItemButton onClick={() => setOpenAutoNameConfigModal(true)}>
+            <ListItemButton
+              onClick={() => setOpenAutoNameConfigModal(true)}
+              disabled={!isAutoNameSupported}
+            >
               <ListItemIcon>
                 <BadgeIcon />
               </ListItemIcon>

--- a/frontend/src/components/entity/entityForm/BasicFields.tsx
+++ b/frontend/src/components/entity/entityForm/BasicFields.tsx
@@ -11,7 +11,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { FC } from "react";
+import { FC, useMemo } from "react";
 import { Control, Controller, useWatch } from "react-hook-form";
 import { UseFormSetValue } from "react-hook-form/dist/types/form";
 
@@ -35,6 +35,16 @@ export const BasicFields: FC<Props> = ({
   setValue,
 }) => {
   const currItemNameType = useWatch({ control, name: "itemNameType" });
+  const attrs = useWatch({ control, name: "attrs" });
+
+  const autoNamePreview = useMemo(() => {
+    if (currItemNameType !== "AT") return "";
+    return attrs
+      .filter((attr) => Number(attr.nameOrder) > 0)
+      .sort((a, b) => Number(a.nameOrder) - Number(b.nameOrder))
+      .map((attr) => `${attr.namePrefix}${attr.name}${attr.namePostfix}`)
+      .join("");
+  }, [currItemNameType, attrs]);
 
   return (
     <Box>
@@ -114,17 +124,28 @@ export const BasicFields: FC<Props> = ({
                   </Select>
                 )}
               />
+              {currItemNameType === "AT" && (
+                <Typography
+                  variant="body2"
+                  sx={{
+                    mt: 1,
+                    color: autoNamePreview ? "text.primary" : "text.disabled",
+                  }}
+                >
+                  {autoNamePreview ||
+                    "（自動命名が設定された属性がありません）"}
+                </Typography>
+              )}
             </TableCell>
           </StyledTableRow>
           <StyledTableRow>
-            <TableCell>
-              <Typography
-                color={
-                  currItemNameType !== "US" ? "text.disabled" : "text.primary"
-                }
-              >
-                アイテム名の許可パターン
-              </Typography>
+            <TableCell
+              sx={{
+                color:
+                  currItemNameType !== "US" ? "text.disabled" : "text.primary",
+              }}
+            >
+              アイテム名の許可パターン
             </TableCell>
             <TableCell>
               <Controller

--- a/frontend/src/pages/__snapshots__/EntityEditPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntityEditPage.test.tsx.snap
@@ -353,13 +353,9 @@ exports[`EditEntityPage should match snapshot 1`] = `
                   class="MuiTableRow-root css-1lvq97o-MuiTableRow-root"
                 >
                   <td
-                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1dc80h3-MuiTableCell-root"
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1enp6ye-MuiTableCell-root"
                   >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1 css-4leci6-MuiTypography-root"
-                    >
-                      アイテム名の許可パターン
-                    </p>
+                    アイテム名の許可パターン
                   </td>
                   <td
                     class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1dc80h3-MuiTableCell-root"
@@ -1203,13 +1199,9 @@ exports[`EditEntityPage should match snapshot 1`] = `
                 class="MuiTableRow-root css-1lvq97o-MuiTableRow-root"
               >
                 <td
-                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1dc80h3-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1enp6ye-MuiTableCell-root"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body1 css-4leci6-MuiTypography-root"
-                  >
-                    アイテム名の許可パターン
-                  </p>
+                  アイテム名の許可パターン
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1dc80h3-MuiTableCell-root"


### PR DESCRIPTION
close: https://github.com/dmm-com/airone/issues/3456
close: https://github.com/dmm-com/airone/issues/3457
close: https://github.com/dmm-com/airone/issues/3465

- Add validation to EntityAttrCreateSerializer and EntityAttrUpdateSerializer
to raise a ValidationError when name_order > 0 is set on an attribute whose
type is not in Entity.ITEM_NAME_SELECTABLE_TYPES (STRING / OBJECT / NUMBER).
Previously such configurations were silently ignored at runtime.
- Disable the autoname config button for attribute types that do not support
autoname (TEXT, BOOLEAN, DATE, GROUP, ROLE, and array variants)
- Show a live preview of the generated item name in the "アイテム名の登録方法"
row when ATTR mode is selected, computed from name_order / prefix / postfix