### PR TITLE
fix(entry): record deleted_user on /api/v1/entry DELETE (#3460)

### DIFF
--- a/api_v1/tests/test_api.py
+++ b/api_v1/tests/test_api.py
@@ -1019,7 +1019,7 @@ class APITest(AironeViewTest):
         Entry.objects.create(name="entry21", schema=entity2, created_user=admin)
 
         # re-login for checking entries permission
-        self.guest_login()
+        guest = self.guest_login()
 
         # The case of no specifying mandatory parameter
         resp = send_request({})
@@ -1056,6 +1056,9 @@ class APITest(AironeViewTest):
         # checks specified entry would be deleted
         entry11.refresh_from_db()
         self.assertFalse(entry11.is_active)
+        # the user who issued the DELETE request must be recorded as deleted_user
+        self.assertEqual(entry11.deleted_user, guest)
+        self.assertIsNotNone(entry11.deleted_time)
 
     @mock.patch(
         "entry.tasks.notify_delete_entry.delay",

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -510,7 +510,7 @@ def delete_entry(self, job: Job) -> JobStatus:
     # for history record
     entry._history_user = job.user
 
-    entry.delete()
+    entry.delete(deleted_user=job.user)
 
     for ref_entry, actions in TriggerCondition.get_invoked_actions_on_delete(entry):
         for action in actions:


### PR DESCRIPTION
The v1 delete_entry Celery task called entry.delete() without passing deleted_user, so Entry.deleted_user stayed None.