### PR TITLE
fix(entry): preserve int type for NUMBER attributes (#3458)

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -10,7 +10,7 @@ from typing_extensions import TypedDict
 
 from airone.lib.acl import ACLType
 from airone.lib.log import Logger
-from airone.lib.types import AttrType, BaseIntEnum
+from airone.lib.types import AttrType, BaseIntEnum, coerce_number
 from entity.models import Entity
 from entry.settings import CONFIG
 from user.models import User
@@ -1160,8 +1160,9 @@ def make_search_results(
                     ret_attrinfo["value"] = attrinfo["value"]
 
                 case AttrType.NUMBER:
-                    # recognize empty string is None
-                    ret_attrinfo["value"] = attrinfo["value"] if attrinfo["value"] else None
+                    # Preserve int when integer-valued (#3458); coerce_number
+                    # accepts both numeric and string ES _source values.
+                    ret_attrinfo["value"] = coerce_number(attrinfo["value"])
 
                 case AttrType.DATE | AttrType.DATETIME:
                     ret_attrinfo["value"] = attrinfo["date_value"]
@@ -1211,10 +1212,8 @@ def make_search_results(
                             ret_attrinfo["value"].append(attrinfo["value"])
 
                         case AttrType.ARRAY_NUMBER:
-                            # Convert string value to number, handle empty values as None
-                            ret_attrinfo["value"].append(
-                                attrinfo["value"] if attrinfo["value"] else None
-                            )
+                            # Preserve int when integer-valued (#3458)
+                            ret_attrinfo["value"].append(coerce_number(attrinfo["value"]))
 
                         case AttrType.ARRAY_OBJECT | AttrType.ARRAY_GROUP | AttrType.ARRAY_ROLE:
                             ret_attrinfo["value"].append(

--- a/airone/lib/types.py
+++ b/airone/lib/types.py
@@ -1,5 +1,34 @@
 import enum
+import math
 from typing import Any
+
+
+def coerce_number(raw: str | int | float | None) -> int | float | None:
+    """Normalise a Number-attribute value, returning int when integer-valued.
+
+    Number values are persisted as strings (e.g. "4.0") via str(float(...))
+    in entry.models.Attribute.add_value, and Elasticsearch may return either
+    a string or a numeric type via ``_source``. Both routes used to call
+    float() unconditionally, which turned integer inputs (4) into 4.0. This
+    helper accepts any of those shapes and returns int when the parsed value
+    has no fractional part (regression for #3458).
+    """
+    if raw is None or isinstance(raw, bool):
+        return None
+    if isinstance(raw, (int, float)):
+        f = float(raw)
+    elif isinstance(raw, str):
+        if not raw.strip():
+            return None
+        try:
+            f = float(raw)
+        except ValueError:
+            return None
+    else:
+        return None
+    if not math.isfinite(f):
+        return None
+    return int(f) if f.is_integer() else f
 
 
 class BaseIntEnum(enum.IntEnum):

--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -26,7 +26,7 @@ from airone.lib.log import Logger
 from airone.lib.types import AttrDefaultValue, AttrType
 from entity.api_v2.serializers import EntitySerializer
 from entity.models import Entity, EntityAttr
-from entry.models import AliasEntry, Attribute, AttributeValue, Entry
+from entry.models import AliasEntry, Attribute, AttributeValue, Entry, coerce_number
 from entry.settings import CONFIG as CONFIG_ENTRY
 from group.models import Group
 from job.models import Job, JobStatus
@@ -136,8 +136,8 @@ class EntryAttributeValue(TypedDict, total=False):
     # date; use string instead
     as_role: EntryAttributeValueRole | None
     as_array_role: list[EntryAttributeValueRole]
-    as_number: float | None  # Added for AttrType.NUMBER
-    as_array_number: list[float | None]  # Added for AttrType.ARRAY_NUMBER
+    as_number: int | float | None  # Added for AttrType.NUMBER
+    as_array_number: list[int | float | None]  # Added for AttrType.ARRAY_NUMBER
 
 
 class EntryAttributeType(TypedDict):
@@ -162,6 +162,45 @@ class AdvancedSearchJoinAttrInfo(BaseModel):
 
 
 AdvancedSearchJoinAttrInfoList = RootModel[list[AdvancedSearchJoinAttrInfo]]
+
+
+@extend_schema_field(OpenApiTypes.NUMBER)
+class IntOrFloatField(serializers.Field):
+    """Number serializer field that preserves int vs float on output.
+
+    DRF's FloatField casts every value to float on representation, which would
+    re-introduce the "4 -> 4.0" drift fixed in entry.models.coerce_number.
+    This field passes int / float through unchanged, and accepts int, float,
+    or numeric strings on input (returning int when the value has no fractional
+    part).
+    """
+
+    default_error_messages = {"invalid": "A valid number is required."}
+
+    def to_representation(self, value):
+        if value is None or isinstance(value, (int, float)):
+            return value
+        # Fallback for unexpected stored types (e.g. legacy strings)
+        try:
+            f = float(value)
+        except (TypeError, ValueError):
+            self.fail("invalid")
+        return int(f) if f.is_integer() else f
+
+    def to_internal_value(self, data):
+        if isinstance(data, bool):
+            self.fail("invalid")
+        if isinstance(data, int):
+            return data
+        if isinstance(data, float):
+            return int(data) if data.is_integer() else data
+        if isinstance(data, str):
+            try:
+                f = float(data)
+            except ValueError:
+                self.fail("invalid")
+            return int(f) if f.is_integer() else f
+        self.fail("invalid")
 
 
 class EntityAttributeTypeSerializer(serializers.Serializer):
@@ -217,9 +256,11 @@ class EntryAttributeValueSerializer(serializers.Serializer):
     # date; use string instead
     as_role = EntryAttributeValueRoleSerializer(allow_null=True, required=False)
     as_array_role = serializers.ListField(child=EntryAttributeValueRoleSerializer(), required=False)
-    as_number = serializers.FloatField(allow_null=True, required=False)  # Added for AttrType.NUMBER
+    # Use IntOrFloatField to preserve int vs float distinction for NUMBER values
+    # (regression fix for #3458). FloatField would coerce ints back to floats.
+    as_number = IntOrFloatField(allow_null=True, required=False)
     as_array_number = serializers.ListField(
-        child=serializers.FloatField(allow_null=True), required=False
+        child=IntOrFloatField(allow_null=True), required=False
     )
 
 
@@ -709,8 +750,7 @@ class EntryRetrieveSerializer(EntryBaseSerializer):
                 case AttrType.ARRAY_NUMBER:
                     return {
                         "as_array_number": [
-                            float(x.value) if x.value and x.value.strip() else None
-                            for x in attrv.data_array.all()
+                            coerce_number(x.value) for x in attrv.data_array.all()
                         ],
                     }
 
@@ -1237,10 +1277,7 @@ class EntryHistoryAttributeValueSerializer(serializers.ModelSerializer):
 
             case AttrType.ARRAY_NUMBER:
                 return {
-                    "as_array_number": [
-                        float(x.value) if x.value and x.value.strip() else None
-                        for x in obj.data_array.all()
-                    ]
+                    "as_array_number": [coerce_number(x.value) for x in obj.data_array.all()]
                 }
 
             case AttrType.ARRAY_OBJECT:

--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -259,9 +259,7 @@ class EntryAttributeValueSerializer(serializers.Serializer):
     # Use IntOrFloatField to preserve int vs float distinction for NUMBER values
     # (regression fix for #3458). FloatField would coerce ints back to floats.
     as_number = IntOrFloatField(allow_null=True, required=False)
-    as_array_number = serializers.ListField(
-        child=IntOrFloatField(allow_null=True), required=False
-    )
+    as_array_number = serializers.ListField(child=IntOrFloatField(allow_null=True), required=False)
 
 
 class EntryAttributeTypeSerializer(serializers.Serializer):
@@ -749,9 +747,7 @@ class EntryRetrieveSerializer(EntryBaseSerializer):
 
                 case AttrType.ARRAY_NUMBER:
                     return {
-                        "as_array_number": [
-                            coerce_number(x.value) for x in attrv.data_array.all()
-                        ],
+                        "as_array_number": [coerce_number(x.value) for x in attrv.data_array.all()],
                     }
 
                 case AttrType.ARRAY_OBJECT:
@@ -1276,9 +1272,7 @@ class EntryHistoryAttributeValueSerializer(serializers.ModelSerializer):
                 return {"as_array_string": [x.value for x in obj.data_array.all()]}
 
             case AttrType.ARRAY_NUMBER:
-                return {
-                    "as_array_number": [coerce_number(x.value) for x in obj.data_array.all()]
-                }
+                return {"as_array_number": [coerce_number(x.value) for x in obj.data_array.all()]}
 
             case AttrType.ARRAY_OBJECT:
                 return {

--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -23,10 +23,10 @@ from airone.lib.drf import (
 )
 from airone.lib.elasticsearch import EntryFilterKey, FilterKey
 from airone.lib.log import Logger
-from airone.lib.types import AttrDefaultValue, AttrType
+from airone.lib.types import AttrDefaultValue, AttrType, coerce_number
 from entity.api_v2.serializers import EntitySerializer
 from entity.models import Entity, EntityAttr
-from entry.models import AliasEntry, Attribute, AttributeValue, Entry, coerce_number
+from entry.models import AliasEntry, Attribute, AttributeValue, Entry
 from entry.settings import CONFIG as CONFIG_ENTRY
 from group.models import Group
 from job.models import Job, JobStatus

--- a/entry/models.py
+++ b/entry/models.py
@@ -23,6 +23,7 @@ from airone.lib.elasticsearch import (
 from airone.lib.types import (
     AttrDefaultValue,
     AttrType,
+    coerce_number,
 )
 from entity.models import Entity, EntityAttr, ItemNameType
 from group.models import Group
@@ -30,25 +31,6 @@ from role.models import Role
 from user.models import User
 
 from .settings import CONFIG
-
-
-def coerce_number(raw: str | None) -> int | float | None:
-    """Convert a stored Number-attribute string back to int when integer-valued.
-
-    Number values are persisted as strings (e.g. "4.0") via str(float(...)),
-    so reading them back through float() always yields a float. This helper
-    returns int when the value has no fractional part so that integer inputs
-    round-trip as integers (regression for #3458).
-    """
-    if not raw or not raw.strip():
-        return None
-    try:
-        f = float(raw)
-    except ValueError:
-        return None
-    if math.isfinite(f) and f.is_integer():
-        return int(f)
-    return f
 
 
 class AttributeValue(models.Model):

--- a/entry/models.py
+++ b/entry/models.py
@@ -32,6 +32,25 @@ from user.models import User
 from .settings import CONFIG
 
 
+def coerce_number(raw: str | None) -> int | float | None:
+    """Convert a stored Number-attribute string back to int when integer-valued.
+
+    Number values are persisted as strings (e.g. "4.0") via str(float(...)),
+    so reading them back through float() always yields a float. This helper
+    returns int when the value has no fractional part so that integer inputs
+    round-trip as integers (regression for #3458).
+    """
+    if not raw or not raw.strip():
+        return None
+    try:
+        f = float(raw)
+    except ValueError:
+        return None
+    if math.isfinite(f) and f.is_integer():
+        return int(f)
+    return f
+
+
 class AttributeValue(models.Model):
     # This is a constant that indicates target object binds multiple AttributeValue objects.
     STATUS_DATA_ARRAY_PARENT = 1 << 0
@@ -200,14 +219,8 @@ class AttributeValue(models.Model):
                 value = self.value
 
             case AttrType.NUMBER:
-                # Convert string value back to number for NUMBER type
-                if self.value and self.value.strip():
-                    try:
-                        value = float(self.value)
-                    except ValueError:
-                        value = None
-                else:
-                    value = None
+                # Convert string value back to number, preserving int when possible
+                value = coerce_number(self.value)
 
             case AttrType.BOOLEAN:
                 value = self.boolean
@@ -246,10 +259,7 @@ class AttributeValue(models.Model):
                 value = [x.value for x in self.data_array.all()]
 
             case AttrType.ARRAY_NUMBER:
-                value = [
-                    float(x.value) if x.value and x.value.strip() else None
-                    for x in self.data_array.all()
-                ]
+                value = [coerce_number(x.value) for x in self.data_array.all()]
 
             case AttrType.ARRAY_OBJECT:
                 value = [
@@ -282,10 +292,7 @@ class AttributeValue(models.Model):
             case AttrType.ARRAY_STRING:
                 return [x.value for x in self.data_array.all()]
             case AttrType.ARRAY_NUMBER:
-                return [
-                    float(x.value) if x.value and x.value.strip() else None
-                    for x in self.data_array.all()
-                ]
+                return [coerce_number(x.value) for x in self.data_array.all()]
             case AttrType.ARRAY_OBJECT:
                 return [x.referral for x in self.data_array.all()]
             case AttrType.OBJECT:
@@ -293,14 +300,8 @@ class AttributeValue(models.Model):
             case AttrType.BOOLEAN:
                 return self.boolean
             case AttrType.NUMBER:
-                # Convert string value back to number for NUMBER type
-                if self.value and self.value.strip():
-                    try:
-                        return float(self.value)
-                    except ValueError:
-                        return None
-                else:
-                    return None
+                # Convert string value back to number, preserving int when possible
+                return coerce_number(self.value)
             case AttrType.DATE:
                 return self.date
             case AttrType.NAMED_OBJECT:
@@ -1965,10 +1966,9 @@ class Entry(ACLBase):
                     attrinfo["last_value"] = [x.value for x in last_value.data_array.all()]
 
                 case AttrType.ARRAY_NUMBER:
-                    # Convert string values back to numbers for ARRAY_NUMBER type
+                    # Convert string values back to numbers, preserving int when possible
                     attrinfo["last_value"] = [
-                        float(x.value) if x.value and x.value.strip() else None
-                        for x in last_value.data_array.all()
+                        coerce_number(x.value) for x in last_value.data_array.all()
                     ]
 
                 case AttrType.ARRAY_OBJECT:
@@ -2043,14 +2043,8 @@ class Entry(ACLBase):
                     attrinfo["last_value"] = last_value.datetime
 
                 case AttrType.NUMBER:
-                    # Convert string value back to number for NUMBER type
-                    if last_value.value and last_value.value.strip():
-                        try:
-                            attrinfo["last_value"] = float(last_value.value)
-                        except ValueError:
-                            attrinfo["last_value"] = None
-                    else:
-                        attrinfo["last_value"] = None
+                    # Convert string value back to number, preserving int when possible
+                    attrinfo["last_value"] = coerce_number(last_value.value)
 
             ret_attrs.append(attrinfo)
 
@@ -2360,14 +2354,9 @@ class Entry(ACLBase):
                         attrinfo["referral_id"] = role.id
 
             elif entity_attr.type & AttrType.NUMBER:
-                # Convert string value to number for NUMBER type
-                if attrv.value and attrv.value.strip():
-                    try:
-                        attrinfo["value"] = float(attrv.value)
-                    except ValueError:
-                        attrinfo["value"] = ""
-                else:
-                    attrinfo["value"] = ""
+                # Convert string value to number, preserving int when possible
+                coerced = coerce_number(attrv.value)
+                attrinfo["value"] = "" if coerced is None else coerced
 
             # Basically register attribute information whatever value doesn't exist
             if not (entity_attr.type & AttrType._ARRAY and not is_recursive):
@@ -2734,18 +2723,14 @@ class AdvancedSearchAttributeIndex(models.Model):
                     key = attrv.role.name if attrv.role else None
                     value = {"id": attrv.role.id, "name": attrv.role.name} if attrv.role else None
                 case AttrType.NUMBER:
-                    # Convert string value to number for NUMBER type
-                    if attrv.value and attrv.value.strip():
-                        try:
-                            number_value = float(attrv.value)
-                            key = str(number_value)
-                            value = number_value
-                        except ValueError:
-                            key = None
-                            value = None
-                    else:
+                    # Convert string value to number, preserving int when possible
+                    number_value = coerce_number(attrv.value)
+                    if number_value is None:
                         key = None
                         value = None
+                    else:
+                        key = str(number_value)
+                        value = number_value
                 case AttrType.ARRAY_STRING:
                     value = [v.value for v in attrv.data_array.all()]
                     key = ",".join(value)
@@ -2778,11 +2763,8 @@ class AdvancedSearchAttributeIndex(models.Model):
                     ]
                     key = ",".join([v["name"] for v in value])
                 case AttrType.ARRAY_NUMBER:
-                    # Convert string values to numbers for ARRAY_NUMBER type
-                    value = [
-                        float(v.value) if v.value and v.value.strip() else None
-                        for v in attrv.data_array.all()
-                    ]
+                    # Convert string values to numbers, preserving int when possible
+                    value = [coerce_number(v.value) for v in attrv.data_array.all()]
                     key = ",".join([str(v) if v is not None else "" for v in value])
                 case _:
                     print("TODO implement it")

--- a/entry/tests/test_api_v2_create_special.py
+++ b/entry/tests/test_api_v2_create_special.py
@@ -320,6 +320,48 @@ class ViewTest(BaseViewTest):
         self.assertEqual(number_negative_value.get_latest_value().get_value(), -123.45)
 
     @patch("entry.tasks.create_entry_v2.delay", Mock(side_effect=tasks.create_entry_v2))
+    def test_number_attr_api_response_preserves_int_type(self):
+        # Regression test for #3458: integer values posted to NUMBER / ARRAY_NUMBER
+        # attributes must come back as ints (not 4.0) on the GET response.
+        num_entity_attr = self.entity.attrs.get(name="num")
+        nums_entity_attr = self.entity.attrs.get(name="nums")
+
+        payload = {
+            "name": "int_number_entry",
+            "schema": self.entity.id,
+            "attrs": [
+                {"id": num_entity_attr.id, "value": 4},
+                {"id": nums_entity_attr.id, "value": [1, 2, 3]},
+            ],
+        }
+        resp = self.client.post(
+            f"/entity/api/v2/{self.entity.id}/entries/", payload, "application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED, resp.content)
+
+        created = Entry.objects.get(name="int_number_entry", schema=self.entity)
+        resp = self.client.get(f"/entry/api/v2/{created.id}/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+
+        # Use json.loads on raw content to avoid DRF int/float coercion in helpers
+        data = json.loads(resp.content)
+        num_attr = next(a for a in data["attrs"] if a["schema"]["name"] == "num")
+        self.assertEqual(num_attr["value"]["as_number"], 4)
+        self.assertIsInstance(num_attr["value"]["as_number"], int)
+        self.assertNotIsInstance(num_attr["value"]["as_number"], float)
+        # JSON wire-format check: must serialise as 4, not 4.0
+        body = resp.content.decode()
+        self.assertIn('"as_number":4', body.replace(" ", ""))
+        self.assertNotIn('"as_number":4.0', body.replace(" ", ""))
+        self.assertNotIn('"as_array_number":[1.0,2.0,3.0]', body.replace(" ", ""))
+
+        nums_attr = next(a for a in data["attrs"] if a["schema"]["name"] == "nums")
+        self.assertEqual(nums_attr["value"]["as_array_number"], [1, 2, 3])
+        for v in nums_attr["value"]["as_array_number"]:
+            self.assertIsInstance(v, int)
+            self.assertNotIsInstance(v, float)
+
+    @patch("entry.tasks.create_entry_v2.delay", Mock(side_effect=tasks.create_entry_v2))
     def test_create_and_retrieve_entry_with_number_attr(self):
         entry_name = "test_entry_with_number"
         number_value = 123.45

--- a/entry/tests/test_model.py
+++ b/entry/tests/test_model.py
@@ -620,3 +620,51 @@ class ModelTest(BaseModelTest):
         self.assertFalse(attr.is_updated([123.45, None, 67.89]))  # Same values should not update
         self.assertFalse(attr.is_updated([67.89, 123.45]))  # Order doesn't matter, None filtered
         self.assertTrue(attr.is_updated([123.45, 67.89, 999]))  # Adding value should update
+
+    def test_number_attr_export_preserves_int_type(self):
+        # Regression test for #3458: Number-type attributes should keep int type
+        # when an integer is provided, instead of being coerced to float
+        # (e.g. 4 -> 4.0). Existing tests use assertEqual which passes for
+        # 4 == 4.0, so the type drift is invisible without isinstance checks.
+        num_attr = self.make_attr("attr_number", AttrType.NUMBER)
+        num_attr.add_value(self._user, 4)
+
+        latest_value = num_attr.get_latest_value().get_value()
+        self.assertEqual(latest_value, 4)
+        self.assertIsInstance(
+            latest_value,
+            int,
+            "NUMBER attr with integer input should keep int type, got %r" % latest_value,
+        )
+        self.assertNotIsInstance(latest_value, float)
+
+        arr_attr = self.make_attr("attr_array_number", AttrType.ARRAY_NUMBER)
+        arr_attr.add_value(self._user, [1, 2, 3.5])
+
+        arr_value = arr_attr.get_latest_value().get_value()
+        self.assertEqual(arr_value, [1, 2, 3.5])
+        self.assertIsInstance(arr_value[0], int)
+        self.assertNotIsInstance(arr_value[0], float)
+        self.assertIsInstance(arr_value[1], int)
+        self.assertNotIsInstance(arr_value[1], float)
+        self.assertIsInstance(arr_value[2], float)
+
+        # entry.export() drives the yaml export reported in the issue
+        exported = self._entry.export(self._user)
+        self.assertEqual(exported["attrs"]["attr_number"], 4)
+        self.assertIsInstance(exported["attrs"]["attr_number"], int)
+        self.assertNotIsInstance(exported["attrs"]["attr_number"], float)
+        self.assertEqual(exported["attrs"]["attr_array_number"], [1, 2, 3.5])
+        self.assertIsInstance(exported["attrs"]["attr_array_number"][0], int)
+        self.assertNotIsInstance(exported["attrs"]["attr_array_number"][0], float)
+
+        # export_v2() returns a list of {name, value} dicts
+        exported_v2 = self._entry.export_v2(self._user)
+        num_entry = next(a for a in exported_v2["attrs"] if a["name"] == "attr_number")
+        self.assertEqual(num_entry["value"], 4)
+        self.assertIsInstance(num_entry["value"], int)
+        self.assertNotIsInstance(num_entry["value"], float)
+        arr_entry = next(a for a in exported_v2["attrs"] if a["name"] == "attr_array_number")
+        self.assertEqual(arr_entry["value"], [1, 2, 3.5])
+        self.assertIsInstance(arr_entry["value"][0], int)
+        self.assertNotIsInstance(arr_entry["value"][0], float)


### PR DESCRIPTION
The number type stores values with float-typed. It implicitly convert float -> int on loading the values from DB.