### PR TITLE
eslint: add path groups for external imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -90,6 +90,13 @@ export default tseslint.config(
             "object",
             "type",
           ],
+          pathGroups: [
+            {
+              pattern: "@dmm-com/**",
+              group: "external",
+            },
+          ],
+          pathGroupsExcludedImportTypes: ["type"],
           alphabetize: { order: "asc" },
           "newlines-between": "always",
         },


### PR DESCRIPTION
`npm run fix` breaks the file formats if we combine it with `npm run link:client`.  It mitigates the problem.