### PR TITLE
feat(advanced-search): add retrieve_all option to search_entries

### DIFF
--- a/api_v1/entry/serializer.py
+++ b/api_v1/entry/serializer.py
@@ -238,7 +238,7 @@ class EntrySearchChainSerializer(serializers.Serializer):
                 "hint_entity_ids": entity_id_list,
                 "hint_referral": search_keyword,
                 "hint_referral_entity_id": sub_query["entity_id"],
-                "limit": 99999,
+                "retrieve_all": True,
             }
 
             # get Entry informations from result

--- a/entry/services.py
+++ b/entry/services.py
@@ -45,6 +45,7 @@ class AdvancedSearchService:
         exclude_referrals: list[int] = [],
         include_referrals: list[int] = [],
         entry_ids: list[int] | None = None,
+        retrieve_all: bool = False,
     ) -> AdvancedSearchResults:
         """Main method called from advanced search.
 
@@ -60,7 +61,8 @@ class AdvancedSearchService:
             hint_attrs (list(dict[str, str])): Defaults to Empty list.
                 A list of search strings and attribute sets
             limit (int): Defaults to 100.
-                Maximum number of search results to return
+                Maximum number of search results to return.
+                Ignored when retrieve_all=True.
             entry_name (str): Search string for entry name
             hint_referral (str): Defaults to None.
                 Input value used to refine the reference entry.
@@ -88,6 +90,12 @@ class AdvancedSearchService:
                 When provided, restricts search results to entries with these IDs.
                 The effective limit is automatically set to len(entry_ids) to ensure
                 all specified entries are returned.
+            retrieve_all (bool): Defaults to False.
+                When True, returns all entries that match the conditions, ignoring
+                the `limit` argument. The effective upper bound is the Elasticsearch
+                `max_result_window` (settings.ES_CONFIG["MAXIMUM_RESULTS_NUM"]).
+                If the matched count exceeds this bound the result is silently
+                truncated and a warning is logged.
 
         Returns:
             AdvancedSearchResults: As a result of the search,
@@ -95,6 +103,12 @@ class AdvancedSearchService:
         """
         if not hint_attrs:
             hint_attrs = []
+
+        if retrieve_all:
+            # Use the Elasticsearch max_result_window as the upper bound. Beyond this
+            # value ES rejects the query, and execute_query also clamps to the same
+            # ceiling — so this is the largest size we can request in a single shot.
+            limit = settings.ES_CONFIG["MAXIMUM_RESULTS_NUM"]
 
         results = AdvancedSearchResults(
             ret_count=0,
@@ -180,9 +194,21 @@ class AdvancedSearchService:
             )
             results.ret_count += search_result.ret_count
             results.ret_values.extend(search_result.ret_values)
-            if not entry_ids:
+            if not entry_ids and not retrieve_all:
                 limit -= len(search_result.ret_values)
                 offset = max(0, offset - search_result.ret_count)
+
+        if retrieve_all and results.ret_count > len(results.ret_values):
+            # When retrieve_all=True, the caller expects every matched entry. If the
+            # matched total exceeds the Elasticsearch max_result_window, the result is
+            # silently truncated. Surface this so the truncation does not go unnoticed.
+            Logger.warning(
+                "search_entries(retrieve_all=True) truncated: matched=%d returned=%d "
+                "(max_result_window=%d)",
+                results.ret_count,
+                len(results.ret_values),
+                settings.ES_CONFIG["MAXIMUM_RESULTS_NUM"],
+            )
 
         return results
 

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -1094,7 +1094,7 @@ def bulk_update_entries(self, job: Job) -> JobStatus | tuple[JobStatus, str, ACL
         if job_params.get("hint_entry")
         else None,
         hint_referral=job_params.get("referral_name"),
-        limit=999999,
+        retrieve_all=True,
     )
 
     # update each items in accordance with job_params.value parameter

--- a/entry/tests/test_service.py
+++ b/entry/tests/test_service.py
@@ -224,6 +224,13 @@ class AdvancedSearchServiceTest(AironeTestCase):
         self.assertEqual(ret.ret_count, 11)
         self.assertEqual(len(ret.ret_values), 5)
 
+        # retrieve_all=True overrides the `limit` argument and returns every matched entry
+        ret = AdvancedSearchService.search_entries(
+            user, [entity.id], [AttrHint(name="str")], 5, retrieve_all=True
+        )
+        self.assertEqual(ret.ret_count, 11)
+        self.assertEqual(len(ret.ret_values), 11)
+
         # search entries with keyword
         ret = AdvancedSearchService.search_entries(
             user, [entity.id], [AttrHint(name="str", keyword="foo-5")]


### PR DESCRIPTION
Expand the max number of advanced search results, from 99999(hard-coded) to `MAXIMUM_RESULTS_NUM`