### PR TITLE
fix(entry): self-heal Attribute when all AttributeValues lost is_latest=True

### DIFF
--- a/entry/models.py
+++ b/entry/models.py
@@ -603,6 +603,14 @@ class Attribute(ACLBase):
             else:
                 return recv_value
 
+        # Self-heal: when the invariant "exactly one AttributeValue with
+        # is_latest=True" has been broken (e.g. by a race between concurrent
+        # imports racing in unset_latest_flag), force the next write to be
+        # treated as an update so add_value() creates a fresh AV and
+        # unset_latest_flag() restores the invariant.
+        if not self.values.filter(is_latest=True).exists():
+            return True
+
         last_value = self.values.last()
         match self.schema.type:
             case AttrType.STRING | AttrType.TEXT:

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -776,6 +776,54 @@ class ViewTest(BaseViewTest):
         search_result = self._es.search(body={"query": {"term": {"name": "entry-change"}}})
         self.assertEqual(search_result["hits"]["total"]["value"], 1)
 
+    def test_update_entry_when_all_attribute_values_have_is_latest_false(self):
+        """When all AttributeValues of an Attribute have lost is_latest=True
+        (e.g. due to a race between concurrent imports racing in
+        unset_latest_flag), Attribute.is_updated must self-heal by treating
+        the next write as an update even if recv_value matches
+        last_value.value. Otherwise EntryUpdateSerializer.update would
+        short-circuit on is_updated()==False and the broken invariant
+        (zero AV with is_latest=True) would never be restored.
+        """
+        from entry.api_v2.serializers import EntryUpdateSerializer
+
+        entry: Entry = self.add_entry(self.user, "entry", self.entity, values={"val": "same"})
+        attr = entry.attrs.get(schema__name="val")
+        self.assertEqual(attr.values.filter(is_latest=True).count(), 1)
+
+        # In a healthy state, resending the identical value is a no-op
+        self.assertFalse(attr.is_updated("same"))
+
+        # Reproduce the broken state: every AttributeValue becomes is_latest=False
+        attr.values.update(is_latest=False)
+        self.assertEqual(attr.values.filter(is_latest=True).count(), 0)
+        before_count = attr.values.count()
+
+        # With the invariant broken, is_updated must return True even for the
+        # same value so the next write restores is_latest=True
+        self.assertTrue(attr.is_updated("same"))
+
+        # Drive the serializer the API would invoke (independent of the Celery pipeline)
+        params = {
+            "name": "entry",
+            "attrs": [{"id": attr.schema.id, "value": "same"}],
+            "delay_trigger": False,
+        }
+        serializer = EntryUpdateSerializer(
+            instance=entry, data=params, context={"_user": self.user}
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        serializer.update(entry, serializer.validated_data)
+
+        # A new AttributeValue is created and the invariant (exactly one
+        # is_latest=True) is restored.
+        self.assertEqual(attr.values.count(), before_count + 1)
+        self.assertEqual(attr.values.filter(is_latest=True).count(), 1)
+        latest = attr.get_latest_value()
+        self.assertIsNotNone(latest)
+        self.assertEqual(latest.value, "same")
+        self.assertTrue(latest.is_latest)
+
     def test_update_entry_without_permission(self):
         params = {
             "name": "entry-change",


### PR DESCRIPTION
When concurrent imports race in Attribute.add_value (non-atomic create + add + unset_latest_flag), every AttributeValue can end up with is_latest=False. In that state, Attribute.is_updated short-circuits on last_value.value == recv_value and EntryUpdateSerializer.update skips add_value, so the broken invariant never recovers.

Force is_updated to return True when no AttributeValue has is_latest=True so the next write creates a fresh is_latest=True AV via add_value and unset_latest_flag restores the "exactly one is_latest=True" invariant.
