### PR TITLE
fix: enable disallow_untyped_calls in mypy

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from airone.lib.log import Logger
 
 
-def main():
+def main() -> None:
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "airone.settings")
     os.environ.setdefault("DJANGO_CONFIGURATION", "Dev")
 

--- a/plugin/examples/pagoda-cross-entity-plugin/pagoda_cross_entity_sample_plugin/handlers.py
+++ b/plugin/examples/pagoda-cross-entity-plugin/pagoda_cross_entity_sample_plugin/handlers.py
@@ -10,6 +10,7 @@ Updated to use the new ID-based override system with OverrideContext.
 
 import logging
 from datetime import datetime
+from typing import Any
 
 from pagoda_plugin_sdk.override import (
     OverrideContext,
@@ -21,6 +22,8 @@ from pagoda_plugin_sdk.override import (
     success_response,
 )
 from rest_framework.response import Response
+
+from pagoda_cross_entity_sample_plugin.relationships import EntityRelationship
 
 logger = logging.getLogger(__name__)
 
@@ -42,14 +45,14 @@ class ServiceHandlers:
     - Cascade delete related entries based on params configuration
     """
 
-    def __init__(self, plugin):
+    def __init__(self, plugin: Any) -> None:
         """Initialize handlers with plugin reference.
 
         Args:
             plugin: The plugin instance that owns these handlers
         """
         self.plugin = plugin
-        self._relationships = None
+        self._relationships: list[EntityRelationship] | None = None
 
     @property
     def relationships(self):

--- a/plugin/examples/pagoda-cross-entity-plugin/pagoda_cross_entity_sample_plugin/plugin.py
+++ b/plugin/examples/pagoda-cross-entity-plugin/pagoda_cross_entity_sample_plugin/plugin.py
@@ -57,7 +57,7 @@ class CrossEntityPlugin(Plugin):
     # Plugin capabilities
     capabilities: Set[str] = {"cross_entity", "composite_entries", "endpoint_override"}
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         # Initialize handlers
         self._handlers = ServiceHandlers(self)

--- a/plugin/examples/pagoda-cross-entity-plugin/pagoda_cross_entity_sample_plugin/relationships.py
+++ b/plugin/examples/pagoda-cross-entity-plugin/pagoda_cross_entity_sample_plugin/relationships.py
@@ -50,7 +50,7 @@ SERVICE_ENVIRONMENT_RELATIONSHIP = EntityRelationship(
 )
 
 
-def get_plugin_relationships():
+def get_plugin_relationships() -> list[EntityRelationship]:
     """Get all entity relationships for this plugin.
 
     Returns:

--- a/plugin/sdk/pagoda_plugin_sdk/__init__.py
+++ b/plugin/sdk/pagoda_plugin_sdk/__init__.py
@@ -6,6 +6,8 @@ It offers base classes, interfaces, and utilities that enable plugins to be comp
 independent from the host application.
 """
 
+from typing import Any
+
 from .exceptions import (
     PagodaError,
     PluginError,
@@ -18,7 +20,7 @@ from .utils import get_pagoda_version
 
 
 # Lazy import for Django-dependent components
-def _lazy_import_mixins():
+def _lazy_import_mixins() -> Any:
     """Lazy import of Django-dependent mixins"""
     try:
         from .mixins import PluginAPIViewMixin
@@ -35,7 +37,7 @@ def _lazy_import_mixins():
         raise
 
 
-def _lazy_import_api():
+def _lazy_import_api() -> Any:
     """Lazy import of Django REST Framework dependent API components"""
     try:
         from .api import (
@@ -63,7 +65,7 @@ def _lazy_import_api():
         raise
 
 
-def _lazy_import_tasks():
+def _lazy_import_tasks() -> Any:
     """Lazy import of task-related components"""
     try:
         from .tasks import (
@@ -97,7 +99,7 @@ def _lazy_import_tasks():
         raise
 
 
-def _lazy_import_override():
+def _lazy_import_override() -> Any:
     """Lazy import of entry operation override components"""
     try:
         from .override import (
@@ -152,7 +154,7 @@ _OVERRIDE_NAMES = [
 
 
 # Define lazy properties for mixins, API components, and task components
-def __getattr__(name):
+def __getattr__(name: str) -> Any:
     if name == "PluginAPIViewMixin":
         return _lazy_import_mixins()
     elif name in (

--- a/plugin/sdk/pagoda_plugin_sdk/api/base.py
+++ b/plugin/sdk/pagoda_plugin_sdk/api/base.py
@@ -131,11 +131,11 @@ class PluginViewSet(viewsets.ModelViewSet):
     plugin_id: Optional[str] = None
     plugin_version: Optional[str] = None
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._validate_plugin_configuration()
 
-    def _validate_plugin_configuration(self):
+    def _validate_plugin_configuration(self) -> None:
         """Validate plugin configuration
 
         Ensures required plugin attributes are properly configured.
@@ -182,7 +182,7 @@ class PluginViewSet(viewsets.ModelViewSet):
             "user": getattr(self.request, "user", None) if hasattr(self, "request") else None,
         }
 
-    def get_queryset(self):
+    def get_queryset(self) -> Any:
         """Get filtered queryset for the viewset
 
         Can be overridden by subclasses to add plugin-specific filtering.
@@ -196,7 +196,7 @@ class PluginViewSet(viewsets.ModelViewSet):
         # This is a hook for subclasses to customize
         return self.filter_queryset_for_plugin(queryset)
 
-    def filter_queryset_for_plugin(self, queryset):
+    def filter_queryset_for_plugin(self, queryset: Any) -> Any:
         """Apply plugin-specific filtering to queryset
 
         Override this method to add custom filtering logic.

--- a/plugin/sdk/pagoda_plugin_sdk/api/serializers.py
+++ b/plugin/sdk/pagoda_plugin_sdk/api/serializers.py
@@ -36,11 +36,11 @@ class PluginSerializerMixin:
 
     plugin_id: Optional[str] = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._setup_plugin_context()
 
-    def _setup_plugin_context(self):
+    def _setup_plugin_context(self) -> None:
         """Setup plugin context for the serializer"""
         # Get plugin context from request if available
         request = getattr(self, "context", {}).get("request")

--- a/plugin/sdk/pagoda_plugin_sdk/mixins.py
+++ b/plugin/sdk/pagoda_plugin_sdk/mixins.py
@@ -31,11 +31,11 @@ class PluginAPIViewMixin(APIView):
 
     permission_classes = [IsAuthenticated]
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._validate_plugin_context()
 
-    def _validate_plugin_context(self):
+    def _validate_plugin_context(self) -> None:
         """Validate plugin execution context
 
         This method can be overridden by subclasses or host applications

--- a/plugin/sdk/pagoda_plugin_sdk/plugin.py
+++ b/plugin/sdk/pagoda_plugin_sdk/plugin.py
@@ -80,11 +80,11 @@ class Plugin:
             if meta:
                 cls._override_handlers[meta.operation] = attr_name
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the plugin instance"""
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         """Validate plugin configuration
 
         Raises:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ warn_redundant_casts = true
 strict_equality = true
 warn_unreachable = true
 no_implicit_reexport = true
+disallow_untyped_calls = true
 
 [[tool.mypy.overrides]]
 module = ["*.tests.*", "*/tests/*", "tests.*"]

--- a/tools/generate_testdata.py
+++ b/tools/generate_testdata.py
@@ -14,7 +14,7 @@ import string
 import sys
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import date, datetime, timezone
-from optparse import OptionParser
+from optparse import OptionParser, Values
 
 import configurations
 
@@ -264,7 +264,7 @@ def generate_testdata(num_entities: int, num_entries: int, suffix: str):
             print(f"Progress: entry creation {i}/{len(futures)}")
 
 
-def get_options():
+def get_options() -> tuple[Values, list[str]]:
     parser = OptionParser(usage="%prog [options] [num_entities] [num_entries]")
     return parser.parse_args()
 

--- a/tools/initialize_es_document.py
+++ b/tools/initialize_es_document.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from optparse import OptionParser
+from optparse import OptionParser, Values
 
 import configurations
 
@@ -19,7 +19,7 @@ from entity.models import Entity  # NOQA
 from job.models import Job  # NOQA
 
 
-def initialize_es_document(entities):
+def initialize_es_document(entities: list[str]) -> None:
     es = ESS()
 
     # clear previous index
@@ -36,7 +36,7 @@ def initialize_es_document(entities):
         Job.new_update_documents(entity, "", {"is_update": True}).run()
 
 
-def get_options():
+def get_options() -> tuple[Values, list[str]]:
     parser = OptionParser(usage="%prog [options] [target-Entities]")
 
     return parser.parse_args()

--- a/tools/update_es_document.py
+++ b/tools/update_es_document.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from optparse import OptionParser
+from optparse import OptionParser, Values
 
 import configurations
 
@@ -18,7 +18,7 @@ from entity.models import Entity  # NOQA
 from job.models import Job  # NOQA
 
 
-def update_es_document(entities):
+def update_es_document(entities: list[str]) -> None:
     target_entity = Entity.objects.filter(is_active=True)
     if entities:
         target_entity = target_entity.filter(name__in=entities)
@@ -27,7 +27,7 @@ def update_es_document(entities):
         Job.new_update_documents(entity).run(will_delay=False)
 
 
-def get_options():
+def get_options() -> tuple[Values, list[str]]:
     parser = OptionParser(usage="%prog [options] [target-Entities]")
 
     return parser.parse_args()


### PR DESCRIPTION
Enable disallow_untyped_calls globally and annotate the 17 untyped callees that were previously invoked from typed contexts