### PR TITLE
use database replica for advanced search

### DIFF
--- a/airone/lib/multidb.py
+++ b/airone/lib/multidb.py
@@ -1,0 +1,59 @@
+from typing import Any, Callable
+
+from django.http import HttpRequest, HttpResponse
+from multidb.middleware import PinningRouterMiddleware
+from multidb.pinning import unpin_this_thread
+
+ViewT = Any  # may be a function, a DRF view class, or a DRF view_func with .cls
+
+
+def db_readonly(view: ViewT) -> ViewT:
+    """Mark a view as read-only at the DB layer.
+
+    Counterpart to ``multidb.pinning.db_write``. Overrides the
+    HTTP-method-based heuristic in ``PinningRouterMiddleware`` that would
+    otherwise pin a non-safe-method (POST/PUT/PATCH/DELETE) request, and the
+    next ``MULTIDB_PINNING_SECONDS`` seconds of reads from the same client,
+    to the primary DB.
+
+    Use this for views that must accept a non-safe HTTP method for payload
+    size reasons (e.g. the advanced-search APIs that ship complex filters in
+    the request body) but do not perform any DB writes.
+    """
+    view._db_readonly = True
+    return view
+
+
+def _view_opts_in_to_replica(view_func: Callable[..., Any]) -> bool:
+    cls = getattr(view_func, "cls", None)
+    if cls is not None and getattr(cls, "_db_readonly", False):
+        return True
+    return bool(getattr(view_func, "_db_readonly", False))
+
+
+class AironePinningRouterMiddleware(PinningRouterMiddleware):
+    """Pagoda-flavored PinningRouterMiddleware.
+
+    Honors the ``@db_readonly`` marker on a resolved view by undoing the
+    parent middleware's master-pin and skipping the ``MULTIDB_PINNING_COOKIE``
+    so that the request reads from a replica and subsequent reads from the
+    same client are not forced to the primary.
+    """
+
+    def process_view(
+        self,
+        request: HttpRequest,
+        view_func: Callable[..., Any],
+        view_args: list[Any],
+        view_kwargs: dict[str, Any],
+    ) -> None:
+        if _view_opts_in_to_replica(view_func):
+            unpin_this_thread()
+            request._airone_db_readonly = True
+
+    def process_response(self, request: HttpRequest, response: HttpResponse) -> HttpResponse:
+        if getattr(request, "_airone_db_readonly", False) and not getattr(
+            response, "_db_write", False
+        ):
+            return response
+        return super().process_response(request, response)

--- a/airone/settings_common.py
+++ b/airone/settings_common.py
@@ -96,7 +96,7 @@ class Common(Configuration):
         "django.contrib.messages.middleware.MessageMiddleware",
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
         "social_django.middleware.SocialAuthExceptionMiddleware",
-        "multidb.middleware.PinningRouterMiddleware",
+        "airone.lib.multidb.AironePinningRouterMiddleware",
         "airone.middleware.gate_keeper.URLGateKeeper",
         "simple_history.middleware.HistoryRequestMiddleware",
     ] + env.list("AIRONE_MIDDLEWARE", None, [])

--- a/airone/tests/test_db.py
+++ b/airone/tests/test_db.py
@@ -1,5 +1,9 @@
 from django.conf import settings
+from django.http import HttpResponse
+from django.test import RequestFactory, SimpleTestCase
+from multidb.pinning import this_thread_is_pinned, unpin_this_thread
 
+from airone.lib.multidb import AironePinningRouterMiddleware, db_readonly
 from airone.lib.test import AironeViewTest
 
 COOKIE_NAME = settings.MULTIDB_PINNING_COOKIE
@@ -30,3 +34,94 @@ class ViewTest(AironeViewTest):
         self.assertNotIn(COOKIE_NAME, self.client.cookies)
         response = self.client.get("/dashboard/")
         self.assertNotIn(COOKIE_NAME, response.cookies)
+
+
+class AironePinningRouterMiddlewareTest(SimpleTestCase):
+    """Unit tests for the @db_readonly override."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.middleware = AironePinningRouterMiddleware(get_response=lambda r: HttpResponse())
+        unpin_this_thread()
+
+    def tearDown(self):
+        unpin_this_thread()
+
+    def _plain_view(self, request):
+        return HttpResponse()
+
+    def _decorated_view_func(self):
+        @db_readonly
+        def view(request):
+            return HttpResponse()
+
+        return view
+
+    def _decorated_drf_view(self):
+        @db_readonly
+        class View:
+            pass
+
+        # DRF attaches the view class to view_func via .cls
+        def view_func(request):
+            return HttpResponse()
+
+        view_func.cls = View
+        return view_func
+
+    def test_post_without_marker_pins_thread_and_sets_cookie(self):
+        request = self.factory.post("/foo/")
+        self.middleware.process_request(request)
+        self.assertTrue(this_thread_is_pinned())
+
+        self.middleware.process_view(request, self._plain_view, [], {})
+        # Plain view does not opt in; pin remains.
+        self.assertTrue(this_thread_is_pinned())
+
+        response = self.middleware.process_response(request, HttpResponse())
+        self.assertIn(COOKIE_NAME, response.cookies)
+
+    def test_post_with_function_marker_unpins_and_skips_cookie(self):
+        request = self.factory.post("/foo/")
+        self.middleware.process_request(request)
+        self.assertTrue(this_thread_is_pinned())
+
+        view = self._decorated_view_func()
+        self.middleware.process_view(request, view, [], {})
+        self.assertFalse(this_thread_is_pinned())
+        self.assertTrue(getattr(request, "_airone_db_readonly", False))
+
+        response = self.middleware.process_response(request, HttpResponse())
+        self.assertNotIn(COOKIE_NAME, response.cookies)
+
+    def test_post_with_drf_class_marker_unpins_and_skips_cookie(self):
+        request = self.factory.post("/foo/")
+        self.middleware.process_request(request)
+        self.assertTrue(this_thread_is_pinned())
+
+        view_func = self._decorated_drf_view()
+        self.middleware.process_view(request, view_func, [], {})
+        self.assertFalse(this_thread_is_pinned())
+
+        response = self.middleware.process_response(request, HttpResponse())
+        self.assertNotIn(COOKIE_NAME, response.cookies)
+
+    def test_get_does_not_pin_regardless_of_marker(self):
+        request = self.factory.get("/foo/")
+        self.middleware.process_request(request)
+        self.assertFalse(this_thread_is_pinned())
+
+        response = self.middleware.process_response(request, HttpResponse())
+        self.assertNotIn(COOKIE_NAME, response.cookies)
+
+    def test_explicit_db_write_response_wins_over_marker(self):
+        """response._db_write=True must always set the cookie, even on a marked view."""
+        request = self.factory.post("/foo/")
+        self.middleware.process_request(request)
+        view = self._decorated_view_func()
+        self.middleware.process_view(request, view, [], {})
+
+        response = HttpResponse()
+        response._db_write = True
+        response = self.middleware.process_response(request, response)
+        self.assertIn(COOKIE_NAME, response.cookies)

--- a/api_v1/entry/views.py
+++ b/api_v1/entry/views.py
@@ -17,6 +17,7 @@ from airone.lib.elasticsearch import (
     AdvancedSearchResults,
     AttrHint,
 )
+from airone.lib.multidb import db_readonly
 from api_v1.entry.serializer import EntrySearchChainSerializer
 from entity.models import Entity
 from entry.models import Entry
@@ -56,6 +57,7 @@ class EntrySearchAPIResponse(BaseModel):
     result: AdvancedSearchResults
 
 
+@db_readonly
 class EntrySearchChainAPI(APIView):
     def post(self, request: Request) -> Response:
         serializer = EntrySearchChainSerializer(data=request.data)
@@ -101,6 +103,7 @@ class EntrySearchChainAPI(APIView):
             )
 
 
+@db_readonly
 class EntrySearchAPI(APIView):
     def post(self, request: Request, format: str | None = None) -> Response:
         if not isinstance(request.data, dict):

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -33,6 +33,7 @@ from airone.lib.elasticsearch import (
     EntryHint,
     FilterKey,
 )
+from airone.lib.multidb import db_readonly
 from airone.lib.plugin_dispatch import PluginOverrideMixin
 from airone.lib.types import AttrType
 from api_v1.entry.serializer import EntrySearchChainSerializer
@@ -336,6 +337,7 @@ class searchAPI(viewsets.ReadOnlyModelViewSet):
         return list(results["ret_values"])
 
 
+@db_readonly
 class AdvancedSearchAPI(generics.GenericAPIView):
     serializer_class = AdvancedSearchSerializer
     """
@@ -529,6 +531,7 @@ class AdvancedSearchAPI(generics.GenericAPIView):
         return Response(serializer.initial_data)
 
 
+@db_readonly
 class AdvancedSearchChainAPI(generics.GenericAPIView):
     serializer_class = EntrySearchChainSerializer
     """


### PR DESCRIPTION
Currently POST method handlers forward DB requests to the master instance by default. The advanced search accepts POST requests but it doesn't store any data into the DB, so I want an option to refer replica instances in that case.