### PR TITLE
Fix stray ^M control character in CSV export of array attributes

### DIFF
--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -19,7 +19,10 @@ def _csv_export(
     job: Job, values: list[AdvancedSearchResultRecord], recv_data: dict, has_referral: bool
 ) -> io.StringIO | None:
     output = io.StringIO(newline="")
-    writer = csv.writer(output)
+    # Use LF as the row terminator to match the LF used when joining array
+    # values; mixing CRLF terminators with bare-LF cell separators makes
+    # editors render the row-terminating CR as a stray ^M control character.
+    writer = csv.writer(output, lineterminator="\n")
 
     # write first line of CSV
     if has_referral is not False:

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -721,7 +721,10 @@ def export_entries(self: Task, job: Job) -> None:
         # newline is blank because csv module performs universal newlines
         # https://docs.python.org/ja/3/library/csv.html#id3
         output = io.StringIO(newline="")
-        writer = csv.writer(output)
+        # Use LF as the row terminator to match the LF used when joining array
+        # values; mixing CRLF terminators with bare-LF cell separators makes
+        # editors render the row-terminating CR as a stray ^M control character.
+        writer = csv.writer(output, lineterminator="\n")
 
         attrs = [x.name for x in entity.attrs.filter(is_active=True)]
         writer.writerow(["Name"] + attrs)
@@ -788,7 +791,10 @@ def export_entries_v2(self: Task, job: Job) -> None:
         # newline is blank because csv module performs universal newlines
         # https://docs.python.org/ja/3/library/csv.html#id3
         output = io.StringIO(newline="")
-        writer = csv.writer(output)
+        # Use LF as the row terminator to match the LF used when joining array
+        # values; mixing CRLF terminators with bare-LF cell separators makes
+        # editors render the row-terminating CR as a stray ^M control character.
+        writer = csv.writer(output, lineterminator="\n")
 
         attrs = [x.name for x in entity.attrs.filter(is_active=True).order_by("index")]
         writer.writerow(["Name"] + attrs)
@@ -824,7 +830,10 @@ def _csv_export_v2(
 ) -> io.StringIO | None:
     """CSV export for v2. No Entity column; adds sub-attribute columns from join_attrs."""
     output = io.StringIO(newline="")
-    writer = csv.writer(output)
+    # Use LF as the row terminator to match the LF used when joining array
+    # values; mixing CRLF terminators with bare-LF cell separators makes
+    # editors render the row-terminating CR as a stray ^M control character.
+    writer = csv.writer(output, lineterminator="\n")
 
     join_attrs = recv_data.get("join_attrs", [])
     join_attr_col_names = [attr["name"] for jattr in join_attrs for attr in jattr["attrinfo"]]

--- a/entry/tests/test_api_v2_import_export.py
+++ b/entry/tests/test_api_v2_import_export.py
@@ -1624,6 +1624,67 @@ class ViewTest(BaseViewTest):
             data = content.replace(header, "", 1).strip()
             self.assertEqual(data, '"%s,""ENTRY""",%s,%s' % (type_name, test_entity.name, expected))
 
+    @patch(
+        "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)
+    )
+    def test_csv_export_array_string_uses_consistent_newlines(self):
+        # Regression test for stray ^M (CR) control characters in CSV export.
+        #
+        # csv.writer terminates each row with CRLF ("\r\n"), while ARRAY_STRING
+        # values are joined with a bare LF ("\n") via "\n".join(). When an
+        # exported entry contains an array attribute, the CSV ends up mixing
+        # CRLF row terminators with bare-LF in-cell separators. Editors that
+        # then guess the file as LF-only render the row-terminating CR as a
+        # stray "^M" control character. The export must use a single,
+        # consistent newline convention.
+        user = self._create_user("admin", is_superuser=True)
+
+        entity = Entity.objects.create(name="ArrayStringEntity", created_user=user)
+        entity_attr = EntityAttr.objects.create(
+            name="arr",
+            type=AttrType.ARRAY_STRING,
+            created_user=user,
+            parent_entity=entity,
+        )
+
+        entry = Entry.objects.create(name="entry1", schema=entity, created_user=user)
+        attr = Attribute.objects.create(
+            name="arr", schema=entity_attr, created_user=user, parent_entry=entry
+        )
+
+        parent_val = AttributeValue.create(user=user, attr=attr)
+        parent_val.set_status(AttributeValue.STATUS_DATA_ARRAY_PARENT)
+        for child in ["one", "two", "three"]:
+            AttributeValue.create(user=user, attr=attr, value=child, parent_attrv=parent_val)
+        parent_val.save()
+        attr.values.add(parent_val)
+        attr.save()
+
+        entry.register_es()
+
+        resp = self.client.post(
+            "/entry/api/v2/advanced_search_result_export/",
+            json.dumps(
+                {
+                    "entities": [entity.id],
+                    "attrinfo": [{"name": "arr", "keyword": ""}],
+                    "export_style": "csv",
+                }
+            ),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        content = Job.objects.last().get_cache()
+
+        has_crlf = "\r\n" in content
+        has_bare_lf = "\n" in content.replace("\r\n", "")
+        self.assertFalse(
+            has_crlf and has_bare_lf,
+            "CSV export mixes CRLF row terminators with bare-LF in-cell separators, "
+            "which makes editors render the CR as a stray ^M. raw=%r" % content,
+        )
+
     @patch("entry.tasks.import_entries_v2.delay", Mock(side_effect=tasks.import_entries_v2))
     @patch(
         "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)


### PR DESCRIPTION
Eliminate noisy ^M control character's on exported CSV has an array string typed values.