### PR TITLE
fix: enable warn_unused_configs and extra_checks in mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,13 @@ mypy_path = "."
 # Gradual type checking improvements
 check_untyped_defs = true
 warn_unused_ignores = true
+warn_unused_configs = true
 warn_redundant_casts = true
 strict_equality = true
 warn_unreachable = true
 no_implicit_reexport = true
 disallow_untyped_calls = true
+extra_checks = true
 
 [[tool.mypy.overrides]]
 module = ["*.tests.*", "*/tests/*", "tests.*"]


### PR DESCRIPTION
Both flags produce zero new errors on the current codebase:
- warn_unused_configs: detects dead [[tool.mypy.overrides]] sections, keeping the config honest as modules are added/removed.
- extra_checks: enables additional correctness checks (TypedDict item access, Final, stricter cast handling) that mypy leaves out of the default for backward compatibility.