### PR TITLE
Remove unused type:ignore[misc] from example plugins

### DIFF
--- a/plugin/examples/pagoda-cross-entity-plugin/pagoda_cross_entity_sample_plugin/handlers.py
+++ b/plugin/examples/pagoda-cross-entity-plugin/pagoda_cross_entity_sample_plugin/handlers.py
@@ -61,7 +61,7 @@ class ServiceHandlers:
             self._relationships = self.plugin.get_relationships()
         return self._relationships
 
-    @override_operation("create")  # type: ignore[misc]
+    @override_operation("create")
     def handle_create(self, context: OverrideContext) -> Response:
         """Handle entry creation with related entries.
 
@@ -149,7 +149,7 @@ class ServiceHandlers:
             logger.error(f"Error creating entry: {e}", exc_info=True)
             return error_response(f"Failed to create entry: {e}")
 
-    @override_operation("retrieve")  # type: ignore[misc]
+    @override_operation("retrieve")
     def handle_retrieve(self, context: OverrideContext) -> Response:
         """Handle entry retrieval with related data.
 
@@ -196,7 +196,7 @@ class ServiceHandlers:
             logger.error(f"Error retrieving entry {entry.id}: {e}", exc_info=True)
             return error_response(f"Failed to retrieve entry: {e}")
 
-    @override_operation("update")  # type: ignore[misc]
+    @override_operation("update")
     def handle_update(self, context: OverrideContext) -> Response:
         """Handle entry update with related entries.
 
@@ -247,7 +247,7 @@ class ServiceHandlers:
             logger.error(f"Error updating entry {entry.id}: {e}", exc_info=True)
             return error_response(f"Failed to update entry: {e}")
 
-    @override_operation("delete")  # type: ignore[misc]
+    @override_operation("delete")
     def handle_delete(self, context: OverrideContext) -> Response:
         """Handle entry deletion with optional cascade.
 

--- a/plugin/examples/pagoda-hello-world-plugin/pagoda_hello_world_plugin/plugin.py
+++ b/plugin/examples/pagoda-hello-world-plugin/pagoda_hello_world_plugin/plugin.py
@@ -45,7 +45,7 @@ class HelloWorldPlugin(Plugin):
 
     # Entry Lifecycle Hooks - Entity-specific for 'helloworld'
 
-    @entry_hook("after_create", entity="helloworld")  # type: ignore[misc]
+    @entry_hook("after_create", entity="helloworld")
     def log_helloworld_create(self, entity_name: str, user: Any, entry: Any, **kwargs: Any) -> None:
         """Called after an entry is created in 'helloworld' entity
 
@@ -60,7 +60,7 @@ class HelloWorldPlugin(Plugin):
             f"in entity '{entity_name}' by {user.username}"
         )
 
-    @entry_hook("before_update", entity="helloworld")  # type: ignore[misc]
+    @entry_hook("before_update", entity="helloworld")
     def log_helloworld_before_update(
         self, entity_name: str, user: Any, validated_data: Dict[str, Any], entry: Any, **kwargs: Any
     ) -> Dict[str, Any]:
@@ -82,7 +82,7 @@ class HelloWorldPlugin(Plugin):
         )
         return validated_data
 
-    @entry_hook("after_update", entity="helloworld")  # type: ignore[misc]
+    @entry_hook("after_update", entity="helloworld")
     def log_helloworld_after_update(
         self, entity_name: str, user: Any, entry: Any, **kwargs: Any
     ) -> None:
@@ -101,7 +101,7 @@ class HelloWorldPlugin(Plugin):
 
     # Entry Lifecycle Hooks - Apply to all entities
 
-    @entry_hook("before_delete")  # type: ignore[misc]
+    @entry_hook("before_delete")
     def log_entry_delete(self, entity_name: str, user: Any, entry: Any, **kwargs: Any) -> None:
         """Called before an entry is deleted (all entities)
 
@@ -118,7 +118,7 @@ class HelloWorldPlugin(Plugin):
 
     # Entry Validation Hook
 
-    @validation_hook()  # type: ignore[misc]
+    @validation_hook()
     def validate_entry(
         self,
         user: Any,
@@ -149,7 +149,7 @@ class HelloWorldPlugin(Plugin):
 
     # Entry Data Access Hook
 
-    @get_attrs_hook("entry")  # type: ignore[misc]
+    @get_attrs_hook("entry")
     def get_entry_attrs(
         self, entry: Any, attrinfo: List[Any], is_retrieve: bool, **kwargs: Any
     ) -> List[Any]:
@@ -172,7 +172,7 @@ class HelloWorldPlugin(Plugin):
 
     # Entity Lifecycle Hooks
 
-    @entity_hook("after_create")  # type: ignore[misc]
+    @entity_hook("after_create")
     def log_entity_create(self, user: Any, entity: Any, **kwargs: Any) -> None:
         """Called after an entity is created
 
@@ -183,7 +183,7 @@ class HelloWorldPlugin(Plugin):
         """
         logger.info(f"[Hello World Plugin] Entity created: '{entity.name}' by {user.username}")
 
-    @entity_hook("before_update")  # type: ignore[misc]
+    @entity_hook("before_update")
     def log_entity_before_update(
         self, user: Any, validated_data: Dict[str, Any], entity: Any, **kwargs: Any
     ) -> Dict[str, Any]:
@@ -201,7 +201,7 @@ class HelloWorldPlugin(Plugin):
         logger.info(f"[Hello World Plugin] Entity updating: '{entity.name}' by {user.username}")
         return validated_data
 
-    @entity_hook("after_update")  # type: ignore[misc]
+    @entity_hook("after_update")
     def log_entity_after_update(self, user: Any, entity: Any, **kwargs: Any) -> None:
         """Called after an entity is updated
 
@@ -214,7 +214,7 @@ class HelloWorldPlugin(Plugin):
 
     # Entity Data Access Hook
 
-    @get_attrs_hook("entity")  # type: ignore[misc]
+    @get_attrs_hook("entity")
     def get_entity_attrs(self, entity: Any, attrinfo: List[Any], **kwargs: Any) -> List[Any]:
         """Modify entity attributes before returning to client
 


### PR DESCRIPTION
mypy flags these decorator-level `# type: ignore[misc]` comments as unused (warn_unused_ignores) now that pagoda-plugin-sdk ships py.typed and the hook/ override decorators resolve as typed. Removes 10 in hello-world plugin and 4 in cross-entity plugin. No behavior change.