### PR TITLE
Added new API to rollback item attribute values at specified datetime

### DIFF
--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -1735,3 +1735,8 @@ class EntryBulkUpdateSerializer(serializers.Serializer):
     attrinfo = AdvancedSearchResultAttrInfoSerializer(many=True, required=False)
     referral_name = serializers.CharField(required=False, allow_blank=True)
     hint_entry = EntryHintSerializer(required=False)
+
+
+class ItemRollbackSerializer(serializers.Serializer):
+    targets = serializers.ListField(child=serializers.IntegerField(), min_length=1)
+    at = serializers.DateTimeField()

--- a/entry/api_v2/urls.py
+++ b/entry/api_v2/urls.py
@@ -121,6 +121,10 @@ urlpatterns = [
         "<int:pk>/attrv_restore/",
         views.EntryAttributeValueRestoreAPI.as_view(),
     ),
+    path(
+        "rollback/",
+        views.ItemRollbackAPI.as_view(),
+    ),
     path("advanced_search/", views.AdvancedSearchAPI.as_view()),
     path("advanced_search_chain/", views.AdvancedSearchChainAPI.as_view()),
     path("import/", views.EntryImportAPI.as_view()),

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -59,6 +59,7 @@ from entry.api_v2.serializers import (
     EntryUpdateSerializer,
     ExportTaskParams,
     GetEntryAttrReferralSerializer,
+    ItemRollbackSerializer,
 )
 from entry.models import AliasEntry, Attribute, AttributeValue, Entry
 from entry.services import AdvancedSearchService
@@ -796,6 +797,110 @@ class EntryBulkUpdateAPI(generics.UpdateAPIView):
         job.run()
 
         return Response({}, status=status.HTTP_202_ACCEPTED)
+
+
+class ItemRollbackAPI(generics.GenericAPIView):
+    serializer_class = ItemRollbackSerializer
+
+    @extend_schema(request=ItemRollbackSerializer)
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        user: User = request.user
+        if user.is_readonly:
+            return Response(status=status.HTTP_403_FORBIDDEN)
+
+        serializer = ItemRollbackSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        targets: list[int] = serializer.validated_data["targets"]
+        at = serializer.validated_data["at"]
+
+        for entry_id in targets:
+            entry = Entry.objects.filter(id=entry_id, is_active=True).first()
+            if entry is None or not user.has_permission(entry, ACLType.Writable):
+                continue
+
+            for attr in entry.attrs.filter(is_active=True, schema__is_active=True):
+                if not user.has_permission(attr, ACLType.Writable):
+                    continue
+
+                # Find the oldest AttributeValue created strictly after `at`
+                v_first_after = (
+                    AttributeValue.objects.filter(
+                        parent_attr=attr,
+                        parent_attrv__isnull=True,
+                        created_time__gt=at,
+                    )
+                    .order_by("created_time")
+                    .first()
+                )
+                if v_first_after is None:
+                    # No changes since `at`; nothing to roll back for this attribute
+                    continue
+
+                # Find the value that was active just before that first change
+                v_before = (
+                    AttributeValue.objects.filter(
+                        parent_attr=attr,
+                        parent_attrv__isnull=True,
+                        created_time__lt=v_first_after.created_time,
+                    )
+                    .prefetch_related("data_array")
+                    .order_by("-created_time")
+                    .first()
+                )
+                if v_before is None:
+                    # Attribute had no value before `at`; skip
+                    continue
+
+                value: Any
+                match v_before.data_type:
+                    case AttrType.STRING | AttrType.TEXT | AttrType.NUMBER:
+                        value = v_before.value
+                    case AttrType.BOOLEAN:
+                        value = v_before.boolean
+                    case AttrType.DATE:
+                        value = v_before.date.isoformat() if v_before.date else None
+                    case AttrType.DATETIME:
+                        value = v_before.datetime.isoformat() if v_before.datetime else None
+                    case AttrType.OBJECT:
+                        value = v_before.referral.id if v_before.referral else None
+                    case AttrType.GROUP:
+                        value = v_before.group.id if v_before.group else None
+                    case AttrType.ROLE:
+                        value = v_before.role.id if v_before.role else None
+                    case AttrType.NAMED_OBJECT:
+                        value = {
+                            "name": v_before.value or "",
+                            "id": v_before.referral.id if v_before.referral else None,
+                        }
+                    case AttrType.ARRAY_STRING | AttrType.ARRAY_NUMBER:
+                        value = [item.value for item in v_before.data_array.all()]
+                    case AttrType.ARRAY_OBJECT:
+                        value = [
+                            item.referral.id for item in v_before.data_array.all() if item.referral
+                        ]
+                    case AttrType.ARRAY_GROUP:
+                        value = [item.group.id for item in v_before.data_array.all() if item.group]
+                    case AttrType.ARRAY_ROLE:
+                        value = [item.role.id for item in v_before.data_array.all() if item.role]
+                    case AttrType.ARRAY_NAMED_OBJECT:
+                        value = [
+                            {
+                                "name": item.value or "",
+                                "id": item.referral.id if item.referral else None,
+                            }
+                            for item in v_before.data_array.all()
+                        ]
+                    case _:
+                        value = v_before.value
+
+                attr.add_value(user, value)
+
+            entry.register_es()
+            job = Job.new_notify_update_entry(user, entry)
+            job.run()
+
+        return Response(status=status.HTTP_200_OK)
 
 
 @extend_schema(

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -2209,3 +2209,72 @@ class ItemRollbackAPITest(BaseViewTest):
             "application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch("entry.tasks.edit_entry_v2.delay", Mock(side_effect=tasks.edit_entry_v2))
+    def test_rollback_multiple_entries(self):
+        """Rolling back multiple entries at once restores each to its state before `at`"""
+        entry1: Entry = self.add_entry(
+            self.user,
+            "entry1",
+            self.entity,
+            values={"val": "initial-1"},
+        )
+        entry2: Entry = self.add_entry(
+            self.user,
+            "entry2",
+            self.entity,
+            values={"val": "initial-2"},
+        )
+        attr1 = entry1.attrs.get(schema__name="val")
+        attr2 = entry2.attrs.get(schema__name="val")
+
+        at = datetime.datetime.now(tz=datetime.timezone.utc)
+
+        for entry, value in [(entry1, "updated-1"), (entry2, "updated-2")]:
+            attr = entry.attrs.get(schema__name="val")
+            params = {
+                "name": entry.name,
+                "attrs": [{"id": attr.schema.id, "value": value}],
+            }
+            resp = self.client.put(
+                f"/entry/api/v2/{entry.id}/", json.dumps(params), "application/json"
+            )
+            self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED)
+
+        resp = self.client.post(
+            "/entry/api/v2/rollback/",
+            json.dumps({"targets": [entry1.id, entry2.id], "at": at.isoformat()}),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(attr1.get_latest_value().value, "initial-1")
+        self.assertEqual(attr2.get_latest_value().value, "initial-2")
+
+    @patch("entry.tasks.edit_entry_v2.delay", Mock(side_effect=tasks.edit_entry_v2))
+    def test_rollback_skips_nonexistent_target(self):
+        """Non-existent entry IDs in targets are skipped; valid entries are still rolled back"""
+        entry: Entry = self.add_entry(
+            self.user,
+            "entry",
+            self.entity,
+            values={"val": "initial"},
+        )
+        attr = entry.attrs.get(schema__name="val")
+
+        at = datetime.datetime.now(tz=datetime.timezone.utc)
+
+        params = {
+            "name": "entry",
+            "attrs": [{"id": attr.schema.id, "value": "updated"}],
+        }
+        resp = self.client.put(f"/entry/api/v2/{entry.id}/", json.dumps(params), "application/json")
+        self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED)
+
+        nonexistent_id = 999999
+        resp = self.client.post(
+            "/entry/api/v2/rollback/",
+            json.dumps({"targets": [entry.id, nonexistent_id], "at": at.isoformat()}),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(attr.get_latest_value().value, "initial")

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -2071,3 +2071,141 @@ class ReadonlyUserPermissionTest(BaseViewTest):
     def test_attrv_restore_is_forbidden_for_readonly_user(self):
         resp = self.client.put("/entry/api/v2/0/attrv_restore/")
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class ItemRollbackAPITest(BaseViewTest):
+    @patch("entry.tasks.edit_entry_v2.delay", Mock(side_effect=tasks.edit_entry_v2))
+    def test_rollback_entry(self):
+        """Rolling back to state before `at` restores the attribute value"""
+        model_ref = self.create_entity(name="ref", user=self.user)
+        item_refs = [self.add_entry(self.user, "item-%d" % i, model_ref) for i in range(3)]
+        item_tgt: Entry = self.add_entry(
+            self.user,
+            "entry",
+            self.entity,
+            values={
+                "val": "initial",
+                "ref": None,
+            },
+        )
+        attrs = {x: item_tgt.attrs.get(schema__name=x) for x in ["val", "ref"]}
+
+        # update item_tgt multiple times and rollback to the state at each points.
+        timepoints = []
+        for i, value in enumerate(["first", "second", "third"]):
+            # save timepoint before update to be rolled back to later at this point.
+            timepoints.append(datetime.datetime.now(tz=datetime.timezone.utc))
+
+            # update target item
+            params = {
+                "name": "entry",
+                "attrs": [
+                    {"id": attrs["val"].schema.id, "value": value},
+                    {"id": attrs["ref"].schema.id, "value": item_refs[i].id},
+                ],
+            }
+            resp = self.client.put(
+                f"/entry/api/v2/{item_tgt.id}/", json.dumps(params), "application/json"
+            )
+            self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED)
+
+        # rollback to state at timepoinrts[2] (middle point)
+        resp = self.client.post(
+            "/entry/api/v2/rollback/",
+            json.dumps({"targets": [item_tgt.id], "at": timepoints[2].isoformat()}),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(attrs["val"].get_latest_value().value, "second")
+        self.assertEqual(attrs["ref"].get_latest_value().referral.id, item_refs[1].id)
+
+        # rollback to state at timepoinrts[0] (initial point)
+        resp = self.client.post(
+            "/entry/api/v2/rollback/",
+            json.dumps({"targets": [item_tgt.id], "at": timepoints[0].isoformat()}),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(attrs["val"].get_latest_value().value, "initial")
+        self.assertIsNone(attrs["ref"].get_latest_value().referral)
+
+    @patch("entry.tasks.edit_entry_v2.delay", Mock(side_effect=tasks.edit_entry_v2))
+    def test_item_history_by_rollback(self):
+        """Rolling back to state before `at` restores the attribute value"""
+        item_tgt: Entry = self.add_entry(
+            self.user,
+            "entry",
+            self.entity,
+            values={
+                "val": "initial",
+            },
+        )
+        attrs = {x: item_tgt.attrs.get(schema__name=x) for x in ["val"]}
+
+        # update item_tgt multiple times and rollback
+        t0 = datetime.datetime.now(tz=datetime.timezone.utc)
+        for i, value in enumerate(["first", "second", "third"]):
+            # update target item
+            params = {
+                "name": "entry",
+                "attrs": [
+                    {"id": attrs["val"].schema.id, "value": value},
+                ],
+            }
+            resp = self.client.put(
+                f"/entry/api/v2/{item_tgt.id}/", json.dumps(params), "application/json"
+            )
+            self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED)
+
+        # rollback to state at (initial point)
+        resp = self.client.post(
+            "/entry/api/v2/rollback/",
+            json.dumps({"targets": [item_tgt.id], "at": t0.isoformat()}),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        # check updating history, only initial value should be added
+        # after the last value by calling rollback API
+        self.assertEqual(
+            [v.value for v in attrs["val"].values.order_by("created_time")],
+            ["initial", "first", "second", "third", "initial"],
+        )
+
+    @patch("entry.tasks.edit_entry_v2.delay", Mock(side_effect=tasks.edit_entry_v2))
+    def test_rollback_skips_no_change_since_at(self):
+        """When no attribute changed after `at`, rollback leaves the value unchanged"""
+        entry: Entry = self.add_entry(self.user, "entry", self.entity, values={"val": "stable"})
+        attr = entry.attrs.get(schema__name="val")
+
+        # `at` is set to now so there are no changes after it
+        at = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+
+        resp = self.client.post(
+            "/entry/api/v2/rollback/",
+            json.dumps({"targets": [entry.id], "at": at}),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(attr.get_latest_value().value, "stable")
+
+    def test_rollback_is_forbidden_for_readonly_user(self):
+        user = User.objects.get(username="guest")
+        user.is_readonly = True
+        user.save()
+
+        resp = self.client.post(
+            "/entry/api/v2/rollback/",
+            json.dumps({"targets": [], "at": "2020-01-01T00:00:00Z"}),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_rollback_invalid_params(self):
+        """Missing required fields returns 400"""
+        resp = self.client.post(
+            "/entry/api/v2/rollback/",
+            json.dumps({"targets": []}),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)

--- a/entry/tests/test_model_operations.py
+++ b/entry/tests/test_model_operations.py
@@ -1196,9 +1196,9 @@ class ModelOperationsTest(BaseModelTest):
             {
                 "attr": "arr_name",
                 "input": [{"foo": "Ref Entry"}],
-                "checker": lambda x: len(x) == 1
-                and x[0]["name"] == "foo"
-                and x[0]["id"].id == ref_entry.id,
+                "checker": lambda x: (
+                    len(x) == 1 and x[0]["name"] == "foo" and x[0]["id"].id == ref_entry.id
+                ),
             },
             {
                 "attr": "arr_name",

--- a/entry/tests/test_view_import_export.py
+++ b/entry/tests/test_view_import_export.py
@@ -442,23 +442,27 @@ class ViewImportExportTest(BaseViewTest):
             {"attr": "arr1", "checker": lambda x: x.data_array.count() == 3},
             {
                 "attr": "arr2",
-                "checker": lambda x: x.data_array.count() == 1
-                and x.data_array.first().referral.id == ref_entry.id,
+                "checker": lambda x: (
+                    x.data_array.count() == 1 and x.data_array.first().referral.id == ref_entry.id
+                ),
             },
             {
                 "attr": "arr3",
-                "checker": lambda x: x.data_array.count() == 1
-                and x.data_array.first().referral.id == ref_entry.id,
+                "checker": lambda x: (
+                    x.data_array.count() == 1 and x.data_array.first().referral.id == ref_entry.id
+                ),
             },
             {
                 "attr": "arr4",
-                "checker": lambda x: x.data_array.count() == 1
-                and x.data_array.first().group == group,
+                "checker": lambda x: (
+                    x.data_array.count() == 1 and x.data_array.first().group == group
+                ),
             },
             {
                 "attr": "arr5",
-                "checker": lambda x: x.data_array.count() == 1
-                and x.data_array.first().role == role,
+                "checker": lambda x: (
+                    x.data_array.count() == 1 and x.data_array.first().role == role
+                ),
             },
         ]
         for info in checklist:


### PR DESCRIPTION
The `/entry/api/v2/{attribute-value-id}/attrv_restore/` API can only retrieve just single attribute value.
But there is an use-case to rollback item(s) to be the one(s) that have values at specified date time.
New API `/entry/api/v2/rollback` enables it.