### PR TITLE
Fix entry details page 404 when no triggers exist

### DIFF
--- a/trigger/api_v2/views.py
+++ b/trigger/api_v2/views.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from django.db.models import QuerySet
-from django.http import Http404
 from rest_framework import serializers, status, viewsets
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import BasePermission, IsAuthenticated
@@ -45,11 +44,7 @@ class TriggerAPI(viewsets.ModelViewSet):
         if filter_entity_id:
             filters["entity__id"] = filter_entity_id
 
-        qs = TriggerParent.objects.filter(**filters)
-        if not qs.exists():
-            raise Http404
-
-        return qs
+        return TriggerParent.objects.filter(**filters)
 
     def destroy(self, request: Request, pk: int | str) -> Response:
         trigger_parent = TriggerParent.objects.filter(pk=pk).last()

--- a/trigger/tests/test_api_v2.py
+++ b/trigger/tests/test_api_v2.py
@@ -683,3 +683,12 @@ class ReadonlyUserPermissionTest(AironeViewTest):
     def test_list_triggers_is_allowed_for_readonly_user(self):
         resp = self.client.get("/trigger/api/v2/")
         self.assertEqual(resp.status_code, 200)
+
+    def test_list_triggers_returns_empty_result_when_no_trigger_exists(self):
+        TriggerParent.objects.all().delete()
+
+        resp = self.client.get("/trigger/api/v2/")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["count"], 0)
+        self.assertEqual(resp.json()["results"], [])


### PR DESCRIPTION
This PR fixes an issue where the entry details page could fail with a 404 error when no trigger records existed.

Previously, the trigger list API returned 404 when the queryset was empty. The entry details page always fetched trigger data, so that response was propagated to the UI as a not found error.

Changes:

Return an empty paginated result from the trigger list API when no triggers exist
Add a regression test for the empty trigger list case
Impact:

Entry details pages no longer fail just because no triggers are configured
Trigger list behavior is now consistent with standard list API expectations