### PR TITLE
Fix nav_jobs loading icon to use a local asset instead of an external URL

### DIFF
--- a/templates/nav_jobs.html
+++ b/templates/nav_jobs.html
@@ -2,7 +2,7 @@
   <img src='/static/images/jobs.png' class="dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
   </img>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-    <img class='dropdown-item job-loading' src='http://kuraline.jp/read/content/images/common/loading.gif'></img>
+    <img class='dropdown-item job-loading' src='/static/images/icon_loading.gif'></img>
 
     <div class='job-container'>
     </div>


### PR DESCRIPTION
## Summary

The job loading indicator in `templates/nav_jobs.html` referenced a
hardcoded external image:

http://kuraline.jp/read/content/images/common/loading.gif



This domain is unreachable in many environments (CI, local dev,
restricted networks). Because an `<img>` resource blocks the page
`load` event, the job-notification navigation bar — shared across all
authenticated legacy (Django-rendered) pages such as `/entity/` —
caused the whole page to hang until the external request timed out.

## Changes

- Replace the external `kuraline.jp` loading GIF with the local static
  asset `/static/images/icon_loading.gif` (already present in the repo).

## Why

This is a fix in `nav_jobs.html` itself, not a test change. The external
reference made every authenticated legacy page depend on an unrelated
third-party host, hurting load performance and reliability. It also
surfaced as a `Page.goto` load-event timeout in browser-based E2E runs.

## Verification

- Confirmed `/entity/` (and other authenticated legacy pages) now fire
  the `load` event without waiting on the external host.