### PR TITLE
Fixed results were missing when there were many search targets in SearchChainAPI

### DIFF
--- a/api_v1/entry/serializer.py
+++ b/api_v1/entry/serializer.py
@@ -307,10 +307,10 @@ class EntrySearchChainSerializer(serializers.Serializer[dict[str, Any]]):
         # digging into the condition tree to get to leaf condition by depth-first search
         accumulated_result: list[dict[str, Any]] = []
 
-        def _do_forward_search(
+        def _build_attr_hint(
             sub_query: dict[str, Any], sub_query_result: list[dict[str, Any]]
-        ) -> list[AdvancedSearchResultRecordIdNamePair]:
-            # make query to search Entries using AdvancedSearchService.search_entries()
+        ) -> AttrHint:
+            # make hint to search Entries using AdvancedSearchService.search_entries()
             search_keyword = "|".join(["^%s$" % x["name"] for x in sub_query_result])
             if isinstance(sub_query.get("value"), str) and len(sub_query["value"]) > 0:
                 search_keyword = sub_query["value"]
@@ -320,14 +320,14 @@ class EntrySearchChainSerializer(serializers.Serializer[dict[str, Any]]):
                 # which will match Entries that refers nothing Entry at specified Attribute.
                 search_keyword = "\\"
 
-            # Query for forward search
-            hint_attrs = [
-                AttrHint(
-                    name=sub_query["name"],
-                    keyword=search_keyword,
-                )
-            ]
+            return AttrHint(
+                name=sub_query["name"],
+                keyword=search_keyword,
+            )
 
+        def _run_search(
+            hint_attrs: list[AttrHint],
+        ) -> list[AdvancedSearchResultRecordIdNamePair]:
             hint_item = None
             if hint_item_name:
                 hint_item = EntryHint(
@@ -352,14 +352,38 @@ class EntrySearchChainSerializer(serializers.Serializer[dict[str, Any]]):
             # All results of this request would be joined and pass to next request. It might be
             # huge request and leads to glitch of Elasticsearch by just a single request.
             # This is our original curcit breaker to prevent overload because of them.
-            if len(search_result.ret_values) > CONFIG.SEARCH_CHAIN_ACCEPTABLE_RESULT_COUNT:
+            if search_result.ret_count > CONFIG.SEARCH_CHAIN_ACCEPTABLE_RESULT_COUNT:
                 Logger.warning("Search Chain API error: SEARCH_CHAIN_ACCEPTABLE_RESULT_COUNT")
                 raise ElasticsearchException()
 
             return [x.entry for x in search_result.ret_values]
 
+        def _do_forward_search(
+            sub_query: dict[str, Any], sub_query_result: list[dict[str, Any]]
+        ) -> list[AdvancedSearchResultRecordIdNamePair]:
+            return _run_search([_build_attr_hint(sub_query, sub_query_result)])
+
+        # Leaf conditions (that have no nested "attrs"/"refers") combined by AND (is_any=False)
+        # are bundled into a single Elasticsearch query with multiple AttrHints, which are
+        # AND-combined at the ES level. This avoids decomposing them into separate per-condition
+        # queries whose intermediate results might exceed SEARCH_CHAIN_ACCEPTABLE_RESULT_COUNT
+        # even though the AND-ed result is small.
+        leaf_queries: list[dict[str, Any]] = []
+        non_leaf_queries = queries
+        if not is_any:
+            leaf_queries = [q for q in queries if not q.get("attrs") and not q.get("refers")]
+            non_leaf_queries = [q for q in queries if q.get("attrs") or q.get("refers")]
+
+        if leaf_queries:
+            leaf_results = _run_search([_build_attr_hint(q, []) for q in leaf_queries])
+            if not leaf_results:
+                # These leaf conditions are real AND constraints; an empty result means no Entry
+                # can satisfy the whole condition, so it's useless to continue.
+                return (False, [])
+            accumulated_result = self.merge_search_result(accumulated_result, leaf_results, is_any)
+
         # This expects only AttrSerialized sub-query
-        for sub_query in queries:
+        for sub_query in non_leaf_queries:
             (is_leaf, sub_query_result) = self.search_entries(user, sub_query)
             if not is_leaf and not sub_query_result:
                 # In this case, it's useless to continue to search processing because

--- a/api_v1/tests/entry/test_api_search_chain.py
+++ b/api_v1/tests/entry/test_api_search_chain.py
@@ -1343,6 +1343,76 @@ class APITest(AironeViewTest):
             ),
         )
 
+    def test_search_chain_bundles_leaf_attrs_into_single_and_query(self):
+        # Regression test: leaf-level Attribute conditions combined by AND (is_any=False) must be
+        # bundled into a single Elasticsearch query so that their AND-ed result is evaluated on the
+        # ES side. Otherwise each condition is searched separately and an intermediate result that
+        # alone exceeds SEARCH_CHAIN_ACCEPTABLE_RESULT_COUNT wrongly raises a data overflow error,
+        # even though the AND-ed result is small.
+        ENTRY_CONFIG.conf["SEARCH_CHAIN_ACCEPTABLE_RESULT_COUNT"] = 2
+
+        entity_server = self.create_entity(
+            self.user,
+            "Server",
+            attrs=[
+                {"name": "team", "type": AttrType.STRING},
+                {"name": "category", "type": AttrType.STRING},
+            ],
+        )
+        # team="teamA" alone matches 3 Entries (> acceptable count),
+        # category="catX" alone matches 3 Entries (> acceptable count),
+        # but (team="teamA" AND category="catX") matches only srv1.
+        srv1 = self.add_entry(
+            self.user, "srv1", entity_server, values={"team": "teamA", "category": "catX"}
+        )
+        self.add_entry(
+            self.user, "srv2", entity_server, values={"team": "teamA", "category": "catY"}
+        )
+        self.add_entry(
+            self.user, "srv3", entity_server, values={"team": "teamA", "category": "catZ"}
+        )
+        self.add_entry(
+            self.user, "srv4", entity_server, values={"team": "teamB", "category": "catX"}
+        )
+        self.add_entry(
+            self.user, "srv5", entity_server, values={"team": "teamC", "category": "catX"}
+        )
+
+        # A single leaf condition alone exceeds the acceptable count -> data overflow.
+        resp = self.client.post(
+            "/api/v1/entry/search_chain",
+            json.dumps({"entities": ["Server"], "attrs": [{"name": "team", "value": "teamA"}]}),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(
+            resp.json(),
+            {"reason": "Data overflow was happened. Please narrow down intermediate conditions"},
+        )
+
+        # The two leaf conditions combined by AND are bundled into a single query whose result
+        # stays within the acceptable count, so the search succeeds.
+        resp = self.client.post(
+            "/api/v1/entry/search_chain",
+            json.dumps(
+                {
+                    "entities": ["Server"],
+                    "is_any": False,
+                    "attrs": [
+                        {"name": "team", "value": "teamA"},
+                        {"name": "category", "value": "catX"},
+                    ],
+                }
+            ),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["ret_count"], 1)
+        self.assertEqual(
+            [x["entry"] for x in resp.json()["ret_values"]],
+            [{"id": srv1.id, "name": srv1.name}],
+        )
+
     @skip("""
     A situation that raises ElasticsearchException because of exceeding search count because of
     installing workaround limitation cap won't be happened.


### PR DESCRIPTION
This fixes an issue where specifying multiple AND conditions for the `attrs` of a leaf node in `POST /api/v1/entry/search_chain` (and `POST /api/v2/entry/advanced_search_chain`, which uses the same serializer) would result in a 400 error—"Data overflow was happened. Please narrow down intermediate conditions"—even if the final result set was small.