### PR TITLE
Enable coding AI agents to flexibly use multiple ways to run tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,12 @@ Pagoda (formerly AirOne) is an entity/metadata management platform with flexible
   `--parallel` is slower here, while CI keeps using `--parallel`). The test DB is
   isolated per checkout, so parallel worktrees/sessions don't corrupt each other.
   Use `tools/test_local.sh --fresh <target>` after changing models/migrations.
+- **Fastest (development iteration):** `tools/test_local.sh --sqlite <target>...`
+  runs against in-memory SQLite. SQL round-trips dominate local test time, so
+  this cuts the whole backend suite from ~19min to ~3min (entity: 99s → 14s).
+  Migrations run in-memory each time; `--keepdb`/DB isolation are unnecessary.
+  Backend behavior differs slightly from MySQL (collation case-sensitivity,
+  integer bounds), so run the final pre-push check in MySQL mode or rely on CI.
 - **Lint (ruff):** `uv run ruff check .`
 - **Type check:** `uv run mypy .`
 - **Generate test data:** `uv run python tools/generate_testdata.py`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,10 @@ Pagoda (formerly AirOne) is an entity/metadata management platform with flexible
 ### Backend (Python/Django)
 - **Run all tests for an app:** `uv run python manage.py test <app_name>`
 - **Run a specific test:** `uv run python manage.py test <app_name>.tests.<test_file>.<TestClass>.<test_method>`
+- **Fast local test runs:** `tools/test_local.sh <target>...` — serial + `--keepdb`
+  (skips ~28s of test-DB creation per run; local Docker MySQL/ES is I/O-bound so
+  `--parallel` is slower here, while CI keeps using `--parallel`). Use
+  `tools/test_local.sh --fresh <target>` after changing models/migrations.
 - **Lint (ruff):** `uv run ruff check .`
 - **Type check:** `uv run mypy .`
 - **Generate test data:** `uv run python tools/generate_testdata.py`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,9 @@ Pagoda (formerly AirOne) is an entity/metadata management platform with flexible
 - **Run a specific test:** `uv run python manage.py test <app_name>.tests.<test_file>.<TestClass>.<test_method>`
 - **Fast local test runs:** `tools/test_local.sh <target>...` — serial + `--keepdb`
   (skips ~28s of test-DB creation per run; local Docker MySQL/ES is I/O-bound so
-  `--parallel` is slower here, while CI keeps using `--parallel`). Use
-  `tools/test_local.sh --fresh <target>` after changing models/migrations.
+  `--parallel` is slower here, while CI keeps using `--parallel`). The test DB is
+  isolated per checkout, so parallel worktrees/sessions don't corrupt each other.
+  Use `tools/test_local.sh --fresh <target>` after changing models/migrations.
 - **Lint (ruff):** `uv run ruff check .`
 - **Type check:** `uv run mypy .`
 - **Generate test data:** `uv run python tools/generate_testdata.py`

--- a/airone/auth/view.py
+++ b/airone/auth/view.py
@@ -22,6 +22,27 @@ def logout(request: HttpRequest) -> HttpResponse:
 
 
 class PagodaLoginView(django_auth_views.LoginView):
+    def get_context_data(self, **kwargs: object) -> dict[str, object]:
+        # Read settings per request instead of baking them into the URLconf at
+        # import time, so runtime changes (and per-test overrides) are honored
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "title": settings.AIRONE["TITLE"],
+                "subtitle": settings.AIRONE["SUBTITLE"],
+                "note_desc": settings.AIRONE["NOTE_DESC"],
+                "note_link": settings.AIRONE["NOTE_LINK"],
+                "sso_desc": settings.AIRONE["SSO_DESC"],
+                "idp": list(getattr(settings, "SOCIAL_AUTH_SAML_ENABLED_IDPS").keys())[0]
+                if hasattr(settings, "SOCIAL_AUTH_SAML_ENABLED_IDPS")
+                else None,
+                "password_reset_disabled": settings.AIRONE["PASSWORD_RESET_DISABLED"],
+                "check_term_service": settings.AIRONE["CHECK_TERM_SERVICE"],
+                "terms_of_service_url": settings.AIRONE["TERMS_OF_SERVICE_URL"],
+            }
+        )
+        return context
+
     def form_valid(self, form: AuthenticationForm) -> Union[HttpResponse, JsonResponse]:
         response = super().form_valid(form)
 

--- a/airone/lib/test.py
+++ b/airone/lib/test.py
@@ -1,7 +1,7 @@
+import atexit
 import functools
 import inspect
 import io
-import logging
 import os
 import sys
 from typing import Callable, List, cast
@@ -43,6 +43,11 @@ class AironeTestCase(TestCase):
 
     TZ_INFO = ZoneInfo(settings.TIME_ZONE)
 
+    # Elasticsearch index names that have already been created in this process.
+    # Creating an index costs ~10x more than wiping its documents, so each index is
+    # created once per process and only documents are deleted between tests.
+    _es_prepared_indices: set[str] = set()
+
     def setUp(self) -> None:
         OVERRIDE_ES_CONFIG = settings.ES_CONFIG.copy()
         # Attach prefix "test-" to distinguish index name for test with configured one.
@@ -65,6 +70,8 @@ class AironeTestCase(TestCase):
             AIRONE=OVERRIDE_AIRONE,
             AIRONE_FLAGS=OVERRIDE_AIRONE_FLAGS,
             MEDIA_ROOT=MEDIA_ROOT,
+            # PBKDF2 costs ~150ms per hashing; tests don't need password strength
+            PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"],
         )
         self._settings.enable()
         self.modify_settings(
@@ -73,17 +80,19 @@ class AironeTestCase(TestCase):
 
         # Before starting test, clear all documents in the Elasticsearch of test index
         self._es = ESS()
-        self._es.recreate_index()
+        if self._es._index not in AironeTestCase._es_prepared_indices:
+            self._es.recreate_index()
+            AironeTestCase._es_prepared_indices.add(self._es._index)
+            # The index is reused by all tests in this process; drop it on process exit
+            atexit.register(self._es.indices.delete, index=self._es._index, ignore_unavailable=True)
+        else:
+            # Make documents indexed by the previous test searchable, then wipe them all
+            self._es.indices.refresh(index=self._es._index)
+            self._es.delete_by_query(
+                index=self._es._index, query={"match_all": {}}, conflicts="proceed", refresh=True
+            )
 
     def tearDown(self) -> None:
-        # Clean up Elasticsearch test index
-        if hasattr(self, "_es") and self._es:
-            try:
-                self._es.indices.delete(index=self._es._index, ignore_unavailable=True)
-            except Exception as e:
-                # Don't fail the test due to cleanup errors
-                logging.warning(f"Failed to cleanup ES index {self._es._index}: {e}")
-
         for fname in os.listdir(settings.MEDIA_ROOT):
             os.unlink(os.path.join(settings.MEDIA_ROOT, fname))
 

--- a/airone/tests/test_auth.py
+++ b/airone/tests/test_auth.py
@@ -4,15 +4,20 @@ from airone.auth.social_auth import create_user
 from airone.lib.test import AironeViewTest
 from user.models import User
 
-settings.AIRONE["TITLE"] = "TITLE"
-settings.AIRONE["SUBTITLE"] = "SUBTITLE"
-settings.AIRONE["NOTE_DESC"] = "NOTE_DESC"
-settings.AIRONE["NOTE_LINK"] = "NOTE_LINK"
-settings.AIRONE["SSO_DESC"] = "SSO_DESC"
-settings.AIRONE["PASSWORD_RESET_DISABLED"] = True
-
 
 class ViewTest(AironeViewTest):
+    def setUp(self):
+        # AironeTestCase.setUp swaps settings.AIRONE for a per-test copy, so
+        # mutating it here (instead of at import time) cannot leak into tests
+        # of other modules that run in the same process
+        super().setUp()
+        settings.AIRONE["TITLE"] = "TITLE"
+        settings.AIRONE["SUBTITLE"] = "SUBTITLE"
+        settings.AIRONE["NOTE_DESC"] = "NOTE_DESC"
+        settings.AIRONE["NOTE_LINK"] = "NOTE_LINK"
+        settings.AIRONE["SSO_DESC"] = "SSO_DESC"
+        settings.AIRONE["PASSWORD_RESET_DISABLED"] = True
+
     def test_login_extra_context(self):
         resp = self.client.get("/auth/login/")
         self.assertEqual(resp.context["title"], "TITLE")

--- a/airone/tests/test_plugin_task.py
+++ b/airone/tests/test_plugin_task.py
@@ -13,6 +13,37 @@ from airone.lib.plugin_task import (
 from job.models import Job
 
 
+class PluginTaskRegistrySandboxMixin:
+    """Snapshot and restore process-global plugin task state.
+
+    The registry and Job._METHOD_TABLE hold handlers registered at process
+    startup; leaving them reset/cleared after these tests breaks job
+    dispatching for tests of other modules that run in the same process.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self._registry_snapshot = (
+            dict(PluginTaskRegistry._registry),
+            dict(PluginTaskRegistry._operation_id_map),
+            dict(PluginTaskRegistry._reverse_map),
+            PluginTaskRegistry._initialized,
+        )
+        self._method_table_snapshot = dict(Job._METHOD_TABLE)
+        self.addCleanup(self._restore_plugin_task_registry)
+        PluginTaskRegistry.reset()
+
+    def _restore_plugin_task_registry(self):
+        registry, operation_id_map, reverse_map, initialized = self._registry_snapshot
+        PluginTaskRegistry.reset()
+        PluginTaskRegistry._registry.update(registry)
+        PluginTaskRegistry._operation_id_map.update(operation_id_map)
+        PluginTaskRegistry._reverse_map.update(reverse_map)
+        PluginTaskRegistry._initialized = initialized
+        Job._METHOD_TABLE.clear()
+        Job._METHOD_TABLE.update(self._method_table_snapshot)
+
+
 class TestPluginTaskConfig(TestCase):
     """PluginTaskConfig tests"""
 
@@ -71,16 +102,8 @@ class TestPluginTaskConfig(TestCase):
             )
 
 
-class TestPluginTaskRegistry(TestCase):
+class TestPluginTaskRegistry(PluginTaskRegistrySandboxMixin, TestCase):
     """PluginTaskRegistry tests"""
-
-    def setUp(self):
-        """Reset registry before each test"""
-        PluginTaskRegistry.reset()
-
-    def tearDown(self):
-        """Reset registry after each test"""
-        PluginTaskRegistry.reset()
 
     def test_duplicate_registration_raises_error(self):
         """Raise error when registering same plugin twice"""
@@ -301,16 +324,8 @@ class TestPluginTaskRegistry(TestCase):
         self.assertEqual(tasks[5001], ("test_plugin.tasks", "task_b"))
 
 
-class TestJobMethodTable(TestCase):
+class TestJobMethodTable(PluginTaskRegistrySandboxMixin, TestCase):
     """Job.method_table() plugin task extension tests"""
-
-    def setUp(self):
-        """Reset registry before each test"""
-        PluginTaskRegistry.reset()
-
-    def tearDown(self):
-        """Reset registry after each test"""
-        PluginTaskRegistry.reset()
 
     @override_settings(
         PLUGIN_OPERATION_ID_CONFIG={

--- a/airone/urls.py
+++ b/airone/urls.py
@@ -28,22 +28,9 @@ urlpatterns = [
     re_path(r"^auth/sso/", include("social_django.urls", namespace="social")),
     re_path(
         r"^auth/login/",
-        auth_view.PagodaLoginView.as_view(
-            redirect_authenticated_user=True,
-            extra_context={
-                "title": settings.AIRONE["TITLE"],
-                "subtitle": settings.AIRONE["SUBTITLE"],
-                "note_desc": settings.AIRONE["NOTE_DESC"],
-                "note_link": settings.AIRONE["NOTE_LINK"],
-                "sso_desc": settings.AIRONE["SSO_DESC"],
-                "idp": list(getattr(settings, "SOCIAL_AUTH_SAML_ENABLED_IDPS").keys())[0]
-                if hasattr(settings, "SOCIAL_AUTH_SAML_ENABLED_IDPS")
-                else None,
-                "password_reset_disabled": settings.AIRONE["PASSWORD_RESET_DISABLED"],
-                "check_term_service": settings.AIRONE["CHECK_TERM_SERVICE"],
-                "terms_of_service_url": settings.AIRONE["TERMS_OF_SERVICE_URL"],
-            },
-        ),
+        # Login-page context is built per request in PagodaLoginView so that
+        # settings are not frozen into the URLconf at import time
+        auth_view.PagodaLoginView.as_view(redirect_authenticated_user=True),
         name="login",
     ),
     re_path(r"^auth/logout/", auth_view.logout, name="logout"),

--- a/api_v1/tests/test_api.py
+++ b/api_v1/tests/test_api.py
@@ -53,7 +53,7 @@ class APITest(AironeViewTest):
                 Entry.objects.create(name="r-%d" % index, schema=ref_entity, created_user=admin)
             )
 
-        params = self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY.copy()
+        params = copy.deepcopy(self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY)
         for param in params:
             if param["type"] & AttrType.OBJECT:
                 param["ref"] = ref_entity
@@ -62,7 +62,7 @@ class APITest(AironeViewTest):
             **{
                 "user": admin,
                 "name": "Entity",
-                "attrs": self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY,
+                "attrs": params,
             }
         )
         params = {
@@ -1395,7 +1395,7 @@ class APITest(AironeViewTest):
         # Initialize Entity, Entries and TriggerConditoin
         ref_entity = Entity.objects.create(name="Referred Entity", created_user=user)
         ref_entry = Entry.objects.create(name="ref0", schema=ref_entity, created_user=user)
-        params = self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY.copy()
+        params = copy.deepcopy(self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY)
         for param in params:
             if param["type"] & AttrType.OBJECT:
                 param["ref"] = ref_entity
@@ -1500,7 +1500,7 @@ class APITest(AironeViewTest):
                 Entry.objects.create(name="r-%d" % index, schema=ref_entity, created_user=admin)
             )
 
-        params = self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY.copy()
+        params = copy.deepcopy(self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY)
         for param in params:
             if param["type"] & AttrType.OBJECT:
                 param["ref"] = ref_entity
@@ -1508,7 +1508,7 @@ class APITest(AironeViewTest):
             **{
                 "user": admin,
                 "name": "Entity",
-                "attrs": self.ALL_TYPED_ATTR_PARAMS_FOR_CREATING_ENTITY,
+                "attrs": params,
             }
         )
         params = {

--- a/entity/api_v2/serializers.py
+++ b/entity/api_v2/serializers.py
@@ -264,6 +264,8 @@ class EntityAttrCreateSerializer(serializers.ModelSerializer[EntityAttr]):
             "name_prefix",
             "name_postfix",
         ]
+        # Pin int32 bounds explicitly; DB-derived bounds are absent on 64-bit SQLite
+        extra_kwargs = {"index": {"min_value": -(2**31), "max_value": 2**31 - 1}}
 
     def validate_type(self, type: Optional[int]) -> Optional[int]:
         if type is not None and type not in AttrTypeValue.values():
@@ -396,7 +398,12 @@ class EntityAttrUpdateSerializer(serializers.ModelSerializer[EntityAttr]):
             "name_prefix",
             "name_postfix",
         ]
-        extra_kwargs = {"name": {"required": False}, "type": {"required": False}}
+        extra_kwargs = {
+            "name": {"required": False},
+            "type": {"required": False},
+            # Pin int32 bounds explicitly; DB-derived bounds are absent on 64-bit SQLite
+            "index": {"min_value": -(2**31), "max_value": 2**31 - 1},
+        }
 
     def validate_id(self, id: int) -> int:
         # Handle case when serializer is used directly (e.g., in tests)

--- a/entry/tests/test_api_v2.py
+++ b/entry/tests/test_api_v2.py
@@ -1810,7 +1810,7 @@ class ViewTest(BaseViewTest):
             "ChangingName",
             model_sg,
             values={
-                "lb": item_lb.id,
+                "LB": item_lb.id,
                 "domain": "test.example.com",
                 "port": "10000",
                 "number": 1,

--- a/entry/tests/test_view.py
+++ b/entry/tests/test_view.py
@@ -2432,7 +2432,7 @@ class ViewTest(BaseViewTest):
             "ChangingName",
             model_sg,
             values={
-                "lb": item_lb.id,
+                "LB": item_lb.id,
                 "domain": "test.example.com",
                 "port": "10000",
             },

--- a/tools/test_local.sh
+++ b/tools/test_local.sh
@@ -9,6 +9,12 @@
 #   - Tests here are I/O-bound against MySQL/ES; running with --parallel is
 #     SLOWER than serial on local Docker setups, so this script runs serially.
 #
+# The test database is isolated per checkout (airone_<hash of checkout path>)
+# unless AIRONE_MYSQL_MASTER_URL is already set. Without this, multiple
+# worktrees or agent sessions share "test_airone" and a --keepdb schema from
+# another branch fails with errors like "Field 'x' doesn't have a default
+# value".
+#
 # usage:
 #   tools/test_local.sh entity                       # one app
 #   tools/test_local.sh entity.tests.test_api_v2     # one file
@@ -20,9 +26,9 @@ set -ue
 BASE_DIR=$(cd "$(dirname "$0")/.." && pwd)
 cd "${BASE_DIR}"
 
-KEEPDB="--keepdb"
+FRESH=0
 if [ "${1:-}" = "--fresh" ]; then
-  KEEPDB=""
+  FRESH=1
   shift
 fi
 
@@ -32,6 +38,12 @@ if [ $# -eq 0 ]; then
   exit 1
 fi
 
+if [ -z "${AIRONE_MYSQL_MASTER_URL:-}" ]; then
+  DB_SUFFIX=$(echo "${BASE_DIR}" | shasum | cut -c1-8)
+  export AIRONE_MYSQL_MASTER_URL="mysql://airone:password@127.0.0.1:3306/airone_${DB_SUFFIX}?charset=utf8mb4"
+  echo ">>> test database: test_airone_${DB_SUFFIX} (isolated per checkout)"
+fi
+
 # The repository does not track migration files; generate them like CI does
 # so that the test database can be (re)built when needed.
 if ! ls entity/migrations/0*.py >/dev/null 2>&1; then
@@ -39,4 +51,9 @@ if ! ls entity/migrations/0*.py >/dev/null 2>&1; then
   uv run python manage.py makemigrations
 fi
 
-exec uv run python manage.py test "$@" ${KEEPDB}
+if [ "${FRESH}" = "1" ]; then
+  # Recreate the test DB from current migrations, then drop it as usual
+  exec uv run python manage.py test "$@" --noinput
+fi
+
+exec uv run python manage.py test "$@" --keepdb

--- a/tools/test_local.sh
+++ b/tools/test_local.sh
@@ -8,15 +8,24 @@
 #     first run. Pass --fresh when migrations or models have changed.
 #   - Tests here are I/O-bound against MySQL/ES; running with --parallel is
 #     SLOWER than serial on local Docker setups, so this script runs serially.
+#   - --sqlite runs against an in-memory SQLite database instead of MySQL.
+#     SQL round-trips dominate test time locally (~2.4ms/query through the
+#     Docker VM), so this is by far the fastest mode: entity 99s -> 14s,
+#     whole backend suite ~19min -> ~4min. Migrations run in memory each
+#     time (a few seconds); --keepdb and DB isolation become unnecessary.
+#     Use it for development iteration; run the final check against MySQL
+#     (default mode) or rely on CI, since collation and integer-range
+#     behavior differ slightly between backends.
 #
-# The test database is isolated per checkout (airone_<hash of checkout path>)
-# unless AIRONE_MYSQL_MASTER_URL is already set. Without this, multiple
+# The MySQL test database is isolated per checkout (airone_<hash of checkout
+# path>) unless AIRONE_MYSQL_MASTER_URL is already set. Without this, multiple
 # worktrees or agent sessions share "test_airone" and a --keepdb schema from
 # another branch fails with errors like "Field 'x' doesn't have a default
 # value".
 #
 # usage:
-#   tools/test_local.sh entity                       # one app
+#   tools/test_local.sh entity                       # one app (MySQL)
+#   tools/test_local.sh --sqlite entity              # fastest: in-memory SQLite
 #   tools/test_local.sh entity.tests.test_api_v2     # one file
 #   tools/test_local.sh --fresh entity               # recreate the test DB
 #   tools/test_local.sh entity entry                 # multiple targets
@@ -27,21 +36,19 @@ BASE_DIR=$(cd "$(dirname "$0")/.." && pwd)
 cd "${BASE_DIR}"
 
 FRESH=0
-if [ "${1:-}" = "--fresh" ]; then
-  FRESH=1
-  shift
-fi
+SQLITE=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --fresh) FRESH=1; shift ;;
+    --sqlite) SQLITE=1; shift ;;
+    *) break ;;
+  esac
+done
 
 if [ $# -eq 0 ]; then
-  echo "usage: $0 [--fresh] <test target>..."
-  echo "  e.g. $0 entity entry.tests.test_api_v2"
+  echo "usage: $0 [--fresh] [--sqlite] <test target>..."
+  echo "  e.g. $0 --sqlite entity entry.tests.test_api_v2"
   exit 1
-fi
-
-if [ -z "${AIRONE_MYSQL_MASTER_URL:-}" ]; then
-  DB_SUFFIX=$(echo "${BASE_DIR}" | shasum | cut -c1-8)
-  export AIRONE_MYSQL_MASTER_URL="mysql://airone:password@127.0.0.1:3306/airone_${DB_SUFFIX}?charset=utf8mb4"
-  echo ">>> test database: test_airone_${DB_SUFFIX} (isolated per checkout)"
 fi
 
 # The repository does not track migration files; generate them like CI does
@@ -49,6 +56,19 @@ fi
 if ! ls entity/migrations/0*.py >/dev/null 2>&1; then
   echo ">>> generating migrations (first run)"
   uv run python manage.py makemigrations
+fi
+
+if [ "${SQLITE}" = "1" ]; then
+  # In-memory database: always fresh, nothing to keep or isolate
+  export AIRONE_MYSQL_MASTER_URL="sqlite://:memory:"
+  echo ">>> test database: in-memory SQLite"
+  exec uv run python manage.py test "$@"
+fi
+
+if [ -z "${AIRONE_MYSQL_MASTER_URL:-}" ]; then
+  DB_SUFFIX=$(echo "${BASE_DIR}" | shasum | cut -c1-8)
+  export AIRONE_MYSQL_MASTER_URL="mysql://airone:password@127.0.0.1:3306/airone_${DB_SUFFIX}?charset=utf8mb4"
+  echo ">>> test database: test_airone_${DB_SUFFIX} (isolated per checkout)"
 fi
 
 if [ "${FRESH}" = "1" ]; then

--- a/tools/test_local.sh
+++ b/tools/test_local.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Fast local test runner. CI is not affected by this script; it keeps using
+# `manage.py test <target> --parallel` (see .github/workflows/build-core.yml).
+#
+# Local measurements (entity module, macOS + Docker MySQL/ES, 2026-07):
+#   - Test DB creation costs ~28s per run; --keepdb removes it after the
+#     first run. Pass --fresh when migrations or models have changed.
+#   - Tests here are I/O-bound against MySQL/ES; running with --parallel is
+#     SLOWER than serial on local Docker setups, so this script runs serially.
+#
+# usage:
+#   tools/test_local.sh entity                       # one app
+#   tools/test_local.sh entity.tests.test_api_v2     # one file
+#   tools/test_local.sh --fresh entity               # recreate the test DB
+#   tools/test_local.sh entity entry                 # multiple targets
+
+set -ue
+
+BASE_DIR=$(cd "$(dirname "$0")/.." && pwd)
+cd "${BASE_DIR}"
+
+KEEPDB="--keepdb"
+if [ "${1:-}" = "--fresh" ]; then
+  KEEPDB=""
+  shift
+fi
+
+if [ $# -eq 0 ]; then
+  echo "usage: $0 [--fresh] <test target>..."
+  echo "  e.g. $0 entity entry.tests.test_api_v2"
+  exit 1
+fi
+
+# The repository does not track migration files; generate them like CI does
+# so that the test database can be (re)built when needed.
+if ! ls entity/migrations/0*.py >/dev/null 2>&1; then
+  echo ">>> generating migrations (first run)"
+  uv run python manage.py makemigrations
+fi
+
+exec uv run python manage.py test "$@" ${KEEPDB}


### PR DESCRIPTION
The full UT/IT's is so high cost; requires MySQL, ES connections, frequent resets. Its too heavy to use coding agents like GitHub Copiot, Claude Code, Codex etc. It allows another quick ways to do that, sqlite based, with keepdb.