### PR TITLE
Add setup-pagoda-env composite action and adopt it in CI

### DIFF
--- a/.github/actions/setup-pagoda-env/action.yml
+++ b/.github/actions/setup-pagoda-env/action.yml
@@ -1,0 +1,114 @@
+name: "Setup Pagoda extension env"
+description: >-
+  Shared CI environment setup for Pagoda/AirOne extension repositories.
+  Installs uv and Python, installs the system dependencies, clones the Pagoda
+  base, optionally places the extension inside the base, runs `uv sync`, and
+  (optionally) prepares MySQL. Service containers and the actual checks stay in
+  the calling workflow (composite actions cannot declare `services:`).
+inputs:
+  airone-branch:
+    description: "Pagoda base branch to clone."
+    required: false
+    default: "master"
+  base-dir:
+    description: "Directory to clone the Pagoda base into (also the working directory for uv)."
+    required: false
+    default: "airone"
+  python-version:
+    description: "Python version to set up."
+    required: false
+    default: "3.14"
+  link-mode:
+    description: "How to place the extension inside the base: none | mv | symlink."
+    required: false
+    default: "none"
+  link-source:
+    description: "Path of the checked-out extension to place (required when link-mode is mv or symlink)."
+    required: false
+    default: ""
+  link-dest-name:
+    description: "Directory name under base-dir to place the extension as."
+    required: false
+    default: "custom_view"
+  editable-installs:
+    description: "Newline-separated paths (relative to base-dir) to `uv pip install -e`."
+    required: false
+    default: ""
+  prepare-mysql:
+    description: "Set to 'true' to run the MySQL preparation SQL (for jobs with a mysql service)."
+    required: false
+    default: "false"
+outputs:
+  base-dir:
+    description: "Resolved Pagoda base directory."
+    value: ${{ inputs.base-dir }}
+runs:
+  using: "composite"
+  steps:
+    - name: Install uv
+      shell: bash
+      run: pipx install uv
+
+    - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: "pip"
+
+    - name: Install system dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libldap2-dev libsasl2-dev libxmlsec1-dev \
+          default-mysql-client default-libmysqlclient-dev pkg-config
+
+    - name: Clone Pagoda base
+      shell: bash
+      run: |
+        echo "Cloning pagoda (${{ inputs.airone-branch }}) into ${{ inputs.base-dir }}"
+        git clone -b "${{ inputs.airone-branch }}" https://github.com/dmm-com/pagoda.git "${{ inputs.base-dir }}"
+
+    - name: Place extension into base
+      if: ${{ inputs.link-mode != 'none' }}
+      shell: bash
+      run: |
+        dest="${{ inputs.base-dir }}/${{ inputs.link-dest-name }}"
+        if [ -z "${{ inputs.link-source }}" ]; then
+          echo "link-source is required when link-mode is '${{ inputs.link-mode }}'" >&2
+          exit 1
+        fi
+        case "${{ inputs.link-mode }}" in
+          mv)
+            mv "${{ inputs.link-source }}" "$dest"
+            ;;
+          symlink)
+            ln -s "$(realpath "${{ inputs.link-source }}")" "$dest"
+            ;;
+          *)
+            echo "Unknown link-mode: ${{ inputs.link-mode }}" >&2
+            exit 1
+            ;;
+        esac
+
+    - name: Install dependencies (uv sync)
+      shell: bash
+      working-directory: ${{ inputs.base-dir }}
+      run: uv sync --extra dev
+
+    - name: Editable installs
+      if: ${{ inputs.editable-installs != '' }}
+      shell: bash
+      working-directory: ${{ inputs.base-dir }}
+      run: |
+        while IFS= read -r pkg; do
+          [ -z "$pkg" ] && continue
+          echo "uv pip install -e $pkg"
+          uv pip install -e "$pkg"
+        done <<< "${{ inputs.editable-installs }}"
+
+    - name: Prepare MySQL
+      if: ${{ inputs.prepare-mysql == 'true' }}
+      shell: bash
+      run: |
+        mysql -protocol=tcp -uroot -h127.0.0.1 -ppassword -e "SET GLOBAL character_set_server=utf8; SET GLOBAL collation_server=utf8_general_ci; SET GLOBAL default_storage_engine=InnoDB;"
+        mysql -protocol=tcp -uroot -h127.0.0.1 -ppassword -e "GRANT ALL ON *.* to airone@'%'"

--- a/.github/actions/setup-pagoda-env/action.yml
+++ b/.github/actions/setup-pagoda-env/action.yml
@@ -56,7 +56,10 @@ runs:
         # Python version is centralized here (base side) so every extension
         # repository stays in sync. Bump it in this one place.
         python-version: "3.14"
-        cache: "pip"
+        # No pip cache: dependencies are installed via uv (its own cache), and
+        # `cache: pip` requires a requirements/pyproject file in the workspace,
+        # which fails in jobs that clone the Pagoda base into a subdir without
+        # checking out a Python project at the workspace root.
 
     - name: Install system dependencies
       shell: bash

--- a/.github/actions/setup-pagoda-env/action.yml
+++ b/.github/actions/setup-pagoda-env/action.yml
@@ -14,10 +14,6 @@ inputs:
     description: "Directory to clone the Pagoda base into (also the working directory for uv)."
     required: false
     default: "airone"
-  python-version:
-    description: "Python version to set up."
-    required: false
-    default: "3.14"
   link-mode:
     description: "How to place the extension inside the base: none | mv | symlink."
     required: false
@@ -51,7 +47,9 @@ runs:
 
     - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
-        python-version: ${{ inputs.python-version }}
+        # Python version is centralized here (base side) so every extension
+        # repository stays in sync. Bump it in this one place.
+        python-version: "3.14"
         cache: "pip"
 
     - name: Install system dependencies

--- a/.github/actions/setup-pagoda-env/action.yml
+++ b/.github/actions/setup-pagoda-env/action.yml
@@ -14,6 +14,12 @@ inputs:
     description: "Directory to clone the Pagoda base into (also the working directory for uv)."
     required: false
     default: "airone"
+  clone:
+    description: >-
+      Set to 'false' when the calling repository IS the Pagoda base (e.g. pagoda's
+      own CI): the clone step is skipped and base-dir is used as-is.
+    required: false
+    default: "true"
   link-mode:
     description: "How to place the extension inside the base: none | mv | symlink."
     required: false
@@ -61,6 +67,7 @@ runs:
           default-mysql-client default-libmysqlclient-dev pkg-config
 
     - name: Clone Pagoda base
+      if: ${{ inputs.clone == 'true' }}
       shell: bash
       run: |
         echo "Cloning pagoda (${{ inputs.airone-branch }}) into ${{ inputs.base-dir }}"

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -14,24 +14,13 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        python-version: ["3.14"]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Install uv
-        run: pipx install uv
-      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+      - name: Set up Pagoda env
+        uses: ./.github/actions/setup-pagoda-env
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - name: apt-get
-        run: |
-          sudo apt-get update
-          sudo apt-get install libldap2-dev libsasl2-dev libxmlsec1-dev libmysqlclient-dev pkg-config
-      - name: uv sync
-        run: |
-          uv sync --extra dev
+          clone: "false"
+          base-dir: .
       - name: staticchecks
         run: |
           mv custom_view_sample custom_view
@@ -82,7 +71,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.14"]
         target: ${{ fromJson(needs.setup_python.outputs.targets) }}
     services:
       rabbitmq:
@@ -118,23 +106,12 @@ jobs:
           --health-retries=3
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Install uv
-        run: pipx install uv
-      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+      - name: Set up Pagoda env
+        uses: ./.github/actions/setup-pagoda-env
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - name: Install additional dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libldap2-dev libsasl2-dev libxmlsec1-dev default-mysql-client default-libmysqlclient-dev
-      - name: Prepare MySQL
-        run: |
-          mysql -protocol=tcp -uroot -h127.0.0.1 -ppassword -e "SET GLOBAL character_set_server=utf8; SET GLOBAL collation_server=utf8_general_ci; SET GLOBAL default_storage_engine=InnoDB;"
-          mysql -protocol=tcp -uroot -h127.0.0.1 -ppassword -e "GRANT ALL ON *.* to airone@'%'"
-      - name: uv sync
-        run: |
-          uv sync --extra dev
+          clone: "false"
+          base-dir: .
+          prepare-mysql: "true"
       - name: test
         run: |
           mv custom_view_sample custom_view

--- a/.github/workflows/release-apiv2-client.yml
+++ b/.github/workflows/release-apiv2-client.yml
@@ -23,19 +23,11 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Install uv
-        run: pipx install uv
-      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+      - name: Set up Pagoda env
+        uses: ./.github/actions/setup-pagoda-env
         with:
-          python-version: "3.14"
-          cache: "pip"
-      - name: apt-get
-        run: |
-          sudo apt-get update
-          sudo apt-get install libldap2-dev libsasl2-dev libxmlsec1-dev libmysqlclient-dev pkg-config
-      - name: uv sync
-        run: |
-          uv sync --extra dev
+          clone: "false"
+          base-dir: .
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22


### PR DESCRIPTION
## Summary

Introduce a shared composite action for the CI environment setup that is
duplicated across pagoda and its downstream extension repositories, and adopt
it in pagoda's own workflows.

- **New**: `.github/actions/setup-pagoda-env` composite action. It installs uv
  and Python, installs the system dependencies (apt), optionally clones the
  Pagoda base, optionally places an extension into it, runs `uv sync`, and
  optionally prepares MySQL. Service containers and the actual checks stay in
  the calling workflow (composite actions cannot declare `services:`).
- **Python version is centralized** in the action (single source of truth), so
  callers no longer pass it and the matrix `python-version` is dropped.
- **`clone` input** lets pagoda's own CI reuse the action without cloning
  itself (`clone: false`, `base-dir: .`).
- **Adopted in pagoda's own workflows**: `build-core.yml` (lint/test) and
  `release-apiv2-client.yml` now reference the action via a local `./` path,
  replacing the duplicated uv/python/apt/uv-sync/mysql-prep blocks.

## Why

The same environment-setup block was duplicated across pagoda's own workflows
and every extension repo (twc, airone.custom.racktables, airone.react.custom,
airone-playwright). Centralizing it removes multi-repo drift (Python version,
action pins, apt packages, service setup).

## Downstream

Extension repositories will reference this action as
`dmm-com/pagoda/.github/actions/setup-pagoda-env@<sha>` (the org requires a
full-length commit SHA). Their PRs currently pin a fork commit for pre-merge
verification and will be repointed to the merged SHA once this lands.

## Notes

- `services:` cannot live in a composite action, so each caller keeps its own
  service-container block (identical across repos).
- No pip cache on setup-python: dependencies are installed via uv (its own
  cache), and `cache: pip` requires a dependency file in the workspace which
  fails in jobs that clone the base into a subdirectory.