### PR TITLE
feat: add agent-driven N+1 detection workflow

### DIFF
--- a/.claude/skills/pagoda-n-plus-one/SKILL.md
+++ b/.claude/skills/pagoda-n-plus-one/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: pagoda-n-plus-one
+description: Detect, diagnose, repair, and verify Django N+1 queries in Pagoda/AirOne. Use when asked to find N+1 queries, reduce query growth, investigate repeated SQL, optimize Django or DRF relation loading, add query-count regression coverage, or produce a performance-remediation report.
+---
+
+# Pagoda N+1 Autofix
+
+Turn a suspected N+1 into a reproduced query-growth regression, a bounded fix, and a reviewable
+before/after report. Treat detector output as a candidate signal, not proof by itself.
+
+## Run the detector
+
+Choose the smallest API test module that exercises a list or nested serializer. Run without
+parallelism so each request remains attributable:
+
+```bash
+AIRONE_NPLUSONE_REPORT=.artifacts/nplusone-before.json \
+uv run python manage.py test <test-label> --parallel=1 \
+  --testrunner=airone.lib.nplusone.NPlusOneDiscoverRunner
+```
+
+The runner inspects each HTTP request, groups repeated SELECT shapes, and records source locations
+and repair hints. Default threshold is 5 identical shapes. Set `AIRONE_NPLUSONE_MIN_REPEATS` only
+when a smaller fixture cannot expose query growth. Never lower it below 2.
+
+If the selected test has too few parent rows, add a focused regression test that requests a small
+fixture and a larger fixture. Compare query counts or candidate occurrences and prove growth before
+editing production code.
+
+## Diagnose before editing
+
+For every candidate:
+
+1. Open the reported source and the queryset that supplies its objects.
+2. Confirm query count grows with parent or child rows. Ignore constant repeated queries unless they
+   are still materially expensive.
+3. Identify the exact relation, filtering, ordering, permission, and active-row semantics.
+4. Record the before counts from both fixture sizes and preserve the detector JSON.
+
+Prefer one proven candidate per fix. Do not refactor unrelated query code merely because it appears
+near the reported line.
+
+## Repair the query shape
+
+- Use `select_related` for one-valued foreign-key or one-to-one relations.
+- Use `prefetch_related` for many-valued relations when the unfiltered related manager is correct.
+- Use `Prefetch` with a filtered/ordered queryset and `to_attr` when serializer semantics differ
+  from the default manager. Consume `to_attr` directly; calling the related manager again discards
+  the prefetch benefit.
+- Replace per-row `.get()`, `.exists()`, or `.count()` with bulk queries, annotations, or id-keyed
+  maps when relation prefetching does not model the lookup.
+- Keep ACL and active-row filters unchanged. Avoid loading an unbounded relation solely to save a
+  small number of queries.
+
+Add a regression test whose larger fixture would fail with the original implementation. Prefer a
+growth assertion over one brittle absolute query count, allowing only a small constant delta for
+authentication and permission work.
+
+## Verify and self-review
+
+Run the focused test in hard-gate mode, then the affected app tests and static checks:
+
+```bash
+AIRONE_NPLUSONE_MODE=fail AIRONE_NPLUSONE_REPORT=.artifacts/nplusone-after.json \
+uv run python manage.py test <test-label> --parallel=1 \
+  --testrunner=airone.lib.nplusone.NPlusOneDiscoverRunner
+uv run python manage.py test <affected-app>
+uv run ruff check <changed-python-files>
+uv run mypy <changed-modules> --config-file=pyproject.toml
+```
+
+Review the diff for preserved ordering, filters, ACL behavior, pagination, response shape, database
+alias behavior, and memory amplification. Re-run the before/after fixture comparison after the fix;
+a green detector alone is insufficient if the request is no longer exercising the relation.
+
+## Produce the remediation report
+
+Render the machine-readable evidence and then add the diff summary, regression test, self-review
+result, and any residual candidates:
+
+```bash
+python .claude/skills/pagoda-n-plus-one/scripts/render_report.py \
+  --before .artifacts/nplusone-before.json \
+  --after .artifacts/nplusone-after.json \
+  --output .artifacts/nplusone-remediation.md
+```
+
+Report exact commands and counts. Mark uncertain candidates as unverified rather than claiming they
+were fixed.

--- a/.claude/skills/pagoda-n-plus-one/agents/openai.yaml
+++ b/.claude/skills/pagoda-n-plus-one/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Pagoda N+1 Autofix"
+  short_description: "Detect, fix, and verify Django N+1 queries"
+  default_prompt: "Use $pagoda-n-plus-one to detect and repair N+1 queries in this Pagoda change."

--- a/.claude/skills/pagoda-n-plus-one/scripts/render_report.py
+++ b/.claude/skills/pagoda-n-plus-one/scripts/render_report.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Render before/after N+1 detector JSON as a compact Markdown report."""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _candidate_rows(label: str, report: dict[str, Any]) -> list[str]:
+    rows: list[str] = []
+    for request in report["requests"]:
+        for candidate in request["candidates"]:
+            location = candidate.get("location")
+            source = (
+                f"{location['path']}:{location['line']}" if location else "unknown source"
+            )
+            rows.append(
+                f"| {label} | `{request['method']} {request['path']}` | "
+                f"{candidate['occurrences']} | `{source}` | {candidate['hint']} |"
+            )
+    return rows
+
+
+def render(before: dict[str, Any], after: dict[str, Any]) -> str:
+    before_summary = before["summary"]
+    after_summary = after["summary"]
+    rows = _candidate_rows("Before", before) + _candidate_rows("After", after)
+    if not rows:
+        rows = ["| - | - | 0 | - | - |"]
+    return "\n".join(
+        [
+            "# N+1 remediation report",
+            "",
+            "## Detector summary",
+            "",
+            "| Run | Requests inspected | Requests with candidates | Candidates |",
+            "| --- | ---: | ---: | ---: |",
+            f"| Before | {before_summary['requests_inspected']} | "
+            f"{before_summary['requests_with_candidates']} | {before_summary['candidates']} |",
+            f"| After | {after_summary['requests_inspected']} | "
+            f"{after_summary['requests_with_candidates']} | {after_summary['candidates']} |",
+            "",
+            "## Candidate evidence",
+            "",
+            "| Run | Request | Repetitions | Source | Suggested repair |",
+            "| --- | --- | ---: | --- | --- |",
+            *rows,
+            "",
+            "## Human review",
+            "",
+            "- Fix and query-shape explanation: TODO",
+            "- Regression test and before/after growth: TODO",
+            "- Semantics and ACL review: TODO",
+            "- Residual risks or candidates: TODO",
+            "",
+        ]
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--before", type=Path, required=True)
+    parser.add_argument("--after", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(render(_load(args.before), _load(args.after)), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/pagoda-n-plus-one/scripts/render_report.py
+++ b/.claude/skills/pagoda-n-plus-one/scripts/render_report.py
@@ -16,9 +16,7 @@ def _candidate_rows(label: str, report: dict[str, Any]) -> list[str]:
     for request in report["requests"]:
         for candidate in request["candidates"]:
             location = candidate.get("location")
-            source = (
-                f"{location['path']}:{location['line']}" if location else "unknown source"
-            )
+            source = f"{location['path']}:{location['line']}" if location else "unknown source"
             rows.append(
                 f"| {label} | `{request['method']} {request['path']}` | "
                 f"{candidate['occurrences']} | `{source}` | {candidate['hint']} |"

--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,7 @@ static_root
 node_modules
 static/js/ui.js*
 coverage
+.artifacts/
 frontend/dist
 *.tgz
 

--- a/airone/lib/nplusone.py
+++ b/airone/lib/nplusone.py
@@ -1,0 +1,279 @@
+"""Opt-in N+1 query detection for Django tests.
+
+The test runner installs middleware that inspects SQL executed by each HTTP
+request. It reports repeated SELECT shapes with a source location and a repair
+hint, while excluding fixture setup and other queries outside the request.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import traceback
+import unittest
+from collections import defaultdict
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import ExitStack, contextmanager
+from contextvars import ContextVar
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+from django.conf import settings
+from django.db import connections
+from django.http import HttpRequest, HttpResponse
+from django.test import override_settings
+from django.test.runner import DiscoverRunner
+
+_CURRENT_TEST: ContextVar[str] = ContextVar("nplusone_current_test", default="unknown")
+_NUMBER = re.compile(r"(?<![\w.])-?\d+(?:\.\d+)?")
+_QUOTED_VALUE = re.compile(r"'(?:''|[^'])*'|\"(?:\"\"|[^\"])*\"")
+_WHITESPACE = re.compile(r"\s+")
+_SELECT = re.compile(r"^\s*(?:/\*.*?\*/\s*)*SELECT\b", re.IGNORECASE | re.DOTALL)
+
+
+@dataclass(frozen=True)
+class SourceLocation:
+    path: str
+    line: int
+    function: str
+
+
+@dataclass(frozen=True)
+class QueryFinding:
+    fingerprint: str
+    occurrences: int
+    sample_sql: str
+    location: SourceLocation | None
+    hint: str
+
+
+@dataclass(frozen=True)
+class RequestFinding:
+    test: str
+    method: str
+    path: str
+    query_count: int
+    candidates: list[QueryFinding]
+
+
+def normalize_sql(sql: str) -> str:
+    """Return a stable query shape while preserving identifiers."""
+    normalized = _QUOTED_VALUE.sub("?", sql)
+    normalized = _NUMBER.sub("?", normalized)
+    return _WHITESPACE.sub(" ", normalized).strip()
+
+
+def _project_location(stack: Sequence[traceback.FrameSummary]) -> SourceLocation | None:
+    root = Path(settings.BASE_DIR).resolve()
+    ignored = Path(__file__).resolve()
+    for frame in reversed(stack):
+        path = Path(frame.filename).resolve()
+        if path == ignored:
+            continue
+        try:
+            relative_path = path.relative_to(root)
+        except ValueError:
+            continue
+        if relative_path.parts[0] in {".venv", "node_modules"}:
+            continue
+        return SourceLocation(str(relative_path), frame.lineno or 0, frame.name)
+    return None
+
+
+def _repair_hint(location: SourceLocation | None, fingerprint: str) -> str:
+    if location and "serializers.py" in location.path:
+        return (
+            "Move relation loading to the view queryset with select_related/prefetch_related "
+            "and consume the prefetched relation in the serializer."
+        )
+    if " COUNT(" in f" {fingerprint.upper()}":
+        return "Compute the count once or annotate it on the parent queryset."
+    return (
+        "Inspect the source loop and load related rows in bulk with select_related, "
+        "prefetch_related, Prefetch, or an id-keyed map."
+    )
+
+
+class QueryDetector:
+    """Collect repeated SELECT shapes for one unit of application work."""
+
+    def __init__(self, min_repeats: int = 5) -> None:
+        if min_repeats < 2:
+            raise ValueError("min_repeats must be at least 2")
+        self.min_repeats = min_repeats
+        self.query_count = 0
+        self._samples: dict[str, str] = {}
+        self._locations: dict[str, SourceLocation | None] = {}
+        self._counts: defaultdict[str, int] = defaultdict(int)
+
+    def observe(
+        self, sql: str, stack: Sequence[traceback.FrameSummary] | None = None
+    ) -> None:
+        self.query_count += 1
+        if not _SELECT.match(sql):
+            return
+        fingerprint = normalize_sql(sql)
+        self._counts[fingerprint] += 1
+        if fingerprint not in self._samples:
+            self._samples[fingerprint] = _WHITESPACE.sub(" ", sql).strip()
+            self._locations[fingerprint] = _project_location(
+                stack if stack is not None else traceback.extract_stack(limit=50)
+            )
+
+    def findings(self) -> list[QueryFinding]:
+        findings = [
+            QueryFinding(
+                fingerprint=fingerprint,
+                occurrences=count,
+                sample_sql=self._samples[fingerprint],
+                location=self._locations[fingerprint],
+                hint=_repair_hint(self._locations[fingerprint], fingerprint),
+            )
+            for fingerprint, count in self._counts.items()
+            if count >= self.min_repeats
+        ]
+        return sorted(findings, key=lambda finding: finding.occurrences, reverse=True)
+
+    def __call__(
+        self,
+        execute: Callable[..., Any],
+        sql: str,
+        params: Any,
+        many: bool,
+        context: dict[str, Any],
+    ) -> Any:
+        self.observe(sql)
+        return execute(sql, params, many, context)
+
+    @contextmanager
+    def capture(self) -> Iterator[None]:
+        with ExitStack() as stack:
+            for connection in connections.all():
+                stack.enter_context(connection.execute_wrapper(self))
+            yield
+
+
+class NPlusOneDetected(AssertionError):
+    pass
+
+
+class FindingReporter:
+    def __init__(self) -> None:
+        self._findings: list[RequestFinding] = []
+        self._lock = Lock()
+
+    def add(self, finding: RequestFinding) -> None:
+        with self._lock:
+            self._findings.append(finding)
+
+    @property
+    def findings(self) -> list[RequestFinding]:
+        with self._lock:
+            return list(self._findings)
+
+    def write(self, report_path: Path, min_repeats: int) -> None:
+        findings = self.findings
+        payload = {
+            "schema_version": 1,
+            "summary": {
+                "requests_inspected": len(findings),
+                "requests_with_candidates": sum(bool(item.candidates) for item in findings),
+                "candidates": sum(len(item.candidates) for item in findings),
+                "min_repeats": min_repeats,
+            },
+            "requests": [asdict(item) for item in findings],
+        }
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+_REPORTER = FindingReporter()
+
+
+def _format_candidates(finding: RequestFinding) -> str:
+    lines = [f"{finding.method} {finding.path} ({finding.test})"]
+    for candidate in finding.candidates:
+        location = (
+            f"{candidate.location.path}:{candidate.location.line}"
+            if candidate.location
+            else "unknown source"
+        )
+        lines.append(f"  {candidate.occurrences}x at {location}: {candidate.hint}")
+    return "\n".join(lines)
+
+
+class NPlusOneMiddleware:
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        min_repeats = int(os.environ.get("AIRONE_NPLUSONE_MIN_REPEATS", "5"))
+        detector = QueryDetector(min_repeats=min_repeats)
+        try:
+            with detector.capture():
+                response = self.get_response(request)
+        finally:
+            finding = RequestFinding(
+                test=_CURRENT_TEST.get(),
+                method=request.method or "UNKNOWN",
+                path=request.path,
+                query_count=detector.query_count,
+                candidates=detector.findings(),
+            )
+            _REPORTER.add(finding)
+        if finding.candidates and os.environ.get("AIRONE_NPLUSONE_MODE", "report") == "fail":
+            raise NPlusOneDetected(_format_candidates(finding))
+        return response
+
+
+class NPlusOneTextTestResult(unittest.TextTestResult):
+    def startTest(self, test: Any) -> None:
+        self._nplusone_token = _CURRENT_TEST.set(test.id())
+        super().startTest(test)
+
+    def stopTest(self, test: Any) -> None:
+        super().stopTest(test)
+        _CURRENT_TEST.reset(self._nplusone_token)
+
+
+class NPlusOneTextTestRunner(unittest.TextTestRunner):
+    resultclass = NPlusOneTextTestResult  # type: ignore[assignment]
+
+
+class NPlusOneDiscoverRunner(DiscoverRunner):
+    """Django test runner that produces an actionable N+1 JSON report."""
+
+    test_runner = NPlusOneTextTestRunner
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        if self.parallel > 1:
+            raise ValueError("N+1 detection requires --parallel=1 so reports remain attributable")
+
+    def run_suite(self, suite: Any, **kwargs: Any) -> Any:
+        global _REPORTER
+        _REPORTER = FindingReporter()
+        middleware = [
+            "airone.lib.nplusone.NPlusOneMiddleware",
+            *[
+                item
+                for item in settings.MIDDLEWARE
+                if item != "airone.lib.nplusone.NPlusOneMiddleware"
+            ],
+        ]
+        with override_settings(MIDDLEWARE=middleware):
+            result = super().run_suite(suite, **kwargs)
+
+        min_repeats = int(os.environ.get("AIRONE_NPLUSONE_MIN_REPEATS", "5"))
+        report_path = Path(
+            os.environ.get("AIRONE_NPLUSONE_REPORT", ".artifacts/nplusone-report.json")
+        )
+        _REPORTER.write(report_path, min_repeats)
+        candidates = [item for item in _REPORTER.findings if item.candidates]
+        if candidates:
+            self.log("\nN+1 candidates:\n" + "\n".join(_format_candidates(x) for x in candidates))
+        self.log(f"N+1 report: {report_path}")
+        return result

--- a/airone/lib/nplusone.py
+++ b/airone/lib/nplusone.py
@@ -109,9 +109,7 @@ class QueryDetector:
         self._locations: dict[str, SourceLocation | None] = {}
         self._counts: defaultdict[str, int] = defaultdict(int)
 
-    def observe(
-        self, sql: str, stack: Sequence[traceback.FrameSummary] | None = None
-    ) -> None:
+    def observe(self, sql: str, stack: Sequence[traceback.FrameSummary] | None = None) -> None:
         self.query_count += 1
         if not _SELECT.match(sql):
             return

--- a/airone/tests/test_nplusone.py
+++ b/airone/tests/test_nplusone.py
@@ -1,0 +1,55 @@
+import traceback
+from pathlib import Path
+
+from django.conf import settings
+from django.test import SimpleTestCase
+
+from airone.lib.nplusone import QueryDetector, normalize_sql
+
+
+class NormalizeSQLTest(SimpleTestCase):
+    def test_normalizes_values_but_preserves_query_shape(self):
+        first = "SELECT * FROM user WHERE id = 1 AND name = 'alice'"
+        second = "SELECT * FROM user WHERE id = 42 AND name = 'bob'"
+
+        self.assertEqual(normalize_sql(first), normalize_sql(second))
+
+
+class QueryDetectorTest(SimpleTestCase):
+    def test_reports_repeated_select_with_actionable_location(self):
+        detector = QueryDetector(min_repeats=3)
+        stack = [traceback.FrameSummary("/tmp/outside.py", 1, "outside")]
+        for user_id in range(3):
+            detector.observe(f"SELECT username FROM user WHERE id = {user_id}", stack=stack)
+
+        findings = detector.findings()
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].occurrences, 3)
+        self.assertIn("load related rows in bulk", findings[0].hint)
+
+    def test_prefers_application_source_over_virtual_environment(self):
+        detector = QueryDetector(min_repeats=2)
+        root = Path(settings.BASE_DIR)
+        stack = [
+            traceback.FrameSummary(str(root / "group/api_v2/serializers.py"), 31, "get_members"),
+            traceback.FrameSummary(str(root / ".venv/django/db/utils.py"), 92, "execute"),
+        ]
+        detector.observe("SELECT * FROM user WHERE group_id = 1", stack=stack)
+        detector.observe("SELECT * FROM user WHERE group_id = 2", stack=stack)
+
+        finding = detector.findings()[0]
+
+        self.assertEqual(finding.location.path, "group/api_v2/serializers.py")
+        self.assertIn("prefetch_related", finding.hint)
+
+    def test_ignores_repeated_writes(self):
+        detector = QueryDetector(min_repeats=2)
+        detector.observe("INSERT INTO user (username) VALUES ('alice')", stack=[])
+        detector.observe("INSERT INTO user (username) VALUES ('bob')", stack=[])
+
+        self.assertEqual(detector.findings(), [])
+
+    def test_rejects_threshold_below_two(self):
+        with self.assertRaisesRegex(ValueError, "at least 2"):
+            QueryDetector(min_repeats=1)

--- a/group/api_v2/serializers.py
+++ b/group/api_v2/serializers.py
@@ -1,4 +1,4 @@
-from typing import Any, TypedDict
+from typing import Any, TypedDict, cast
 
 from django.db.models import QuerySet
 from drf_spectacular.utils import extend_schema_field
@@ -28,7 +28,7 @@ class GroupSerializer(serializers.ModelSerializer[Group]):
 
     @extend_schema_field(GroupMemberSerializer(many=True))
     def get_members(self, obj: Group) -> list[GroupMemberType]:
-        users = User.objects.filter(groups__name=obj.name, is_active=True).order_by("username")
+        users = cast(list[User], getattr(obj, "active_members"))
         return [
             {
                 "id": u.id,

--- a/group/api_v2/views.py
+++ b/group/api_v2/views.py
@@ -1,5 +1,6 @@
 from typing import Any, cast
 
+from django.db.models import Prefetch
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
 from rest_framework import filters, generics, serializers, status, viewsets
@@ -34,7 +35,13 @@ class UserPermission(BasePermission):
 
 
 class GroupAPI(viewsets.ModelViewSet[Group]):
-    queryset = Group.objects.filter(is_active=True)  # type: ignore[assignment,misc]
+    queryset = Group.objects.filter(is_active=True).prefetch_related(  # type: ignore[assignment,misc]
+        Prefetch(
+            "user_set",
+            queryset=User.objects.filter(is_active=True).order_by("username"),
+            to_attr="active_members",
+        )
+    )
     permission_classes = [IsAuthenticated & UserPermission]
     pagination_class = PageNumberPagination
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter, filters.SearchFilter]

--- a/group/tests/test_api_v2.py
+++ b/group/tests/test_api_v2.py
@@ -1,6 +1,8 @@
 import json
 
 import yaml
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from rest_framework import status
 
 from airone.lib.test import AironeViewTest
@@ -19,16 +21,55 @@ class ViewTest(AironeViewTest):
         self.admin_login()
 
         user = self._create_user("fuga")
+        first_user = self._create_user("alpha")
+        inactive_user = self._create_user("inactive")
+        inactive_user.is_active = False
+        inactive_user.save(update_fields=["is_active"])
         group = self._create_group("hoge")
         user.groups.add(group)
+        first_user.groups.add(group)
+        inactive_user.groups.add(group)
 
         resp = self.client.get("/group/api/v2/groups")
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
         self.assertEqual(len(body["results"]), 1)
         self.assertEqual(body["results"][0]["id"], group.id)
-        self.assertEqual(len(body["results"][0]["members"]), 1)
-        self.assertEqual(body["results"][0]["members"][0]["id"], user.id)
+        self.assertEqual(
+            [member["id"] for member in body["results"][0]["members"]],
+            [first_user.id, user.id],
+        )
+
+    def test_list_many_groups(self):
+        self.admin_login()
+
+        def create_groups(start: int, end: int) -> None:
+            groups = [self._create_group(f"group-{index:02}") for index in range(start, end)]
+            for index, group in enumerate(groups, start=start):
+                user = self._create_user(f"user-{index:02}")
+                user.groups.add(group)
+
+        create_groups(0, 3)
+        with CaptureQueriesContext(connection) as few_queries:
+            resp = self.client.get("/group/api/v2/groups")
+            self.assertEqual(resp.status_code, 200)
+
+        create_groups(3, 12)
+        with CaptureQueriesContext(connection) as many_queries:
+            resp = self.client.get("/group/api/v2/groups")
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(len(body["results"]), 12)
+        self.assertTrue(all(len(group["members"]) == 1 for group in body["results"]))
+        self.assertLessEqual(
+            len(many_queries) - len(few_queries),
+            2,
+            msg=(
+                f"query count scales with groups: 3 groups => {len(few_queries)}, "
+                f"12 groups => {len(many_queries)}"
+            ),
+        )
 
     def test_retrieve(self):
         self.admin_login()


### PR DESCRIPTION
N+1 is a so tough problem in the most of web applications. pagoda based on Django is as well. This agent skill allows AI Agents to auto-detect, fix the some problems with counting similar queries (like `SELECT ... FROM ... WHERE id = 1`, `SELECT ... FROM ... WHERE id = 2`, ...).