### PR TITLE
Cache CI setup deps in setup-pagoda-env (uv, apt) and speed up uv install

### DIFF
--- a/.github/actions/setup-pagoda-env/action.yml
+++ b/.github/actions/setup-pagoda-env/action.yml
@@ -56,10 +56,10 @@ runs:
         # Python version is centralized here (base side) so every extension
         # repository stays in sync. Bump it in this one place.
         python-version: "3.14"
-        # No pip cache: dependencies are installed via uv (its own cache), and
-        # `cache: pip` requires a requirements/pyproject file in the workspace,
-        # which fails in jobs that clone the Pagoda base into a subdir without
-        # checking out a Python project at the workspace root.
+        # No pip cache: dependencies are installed via uv, whose download/build
+        # cache is persisted by the "Cache uv downloads" step below. `cache: pip`
+        # would also require a requirements/pyproject file at the workspace root,
+        # which is absent in jobs that clone the Pagoda base into a subdir.
 
     - name: Install system dependencies
       shell: bash
@@ -97,6 +97,21 @@ runs:
             exit 1
             ;;
         esac
+
+    # Cache uv's global download/build cache so `uv sync` reuses wheels and
+    # built artifacts across runs instead of re-downloading every dependency.
+    # This runs after the Pagoda base is cloned/placed, so the lockfile exists
+    # and can key the cache precisely. The uv.lock hash fully determines the
+    # dependency set, so the key is intentionally branch-agnostic: base branches
+    # resolving to the same lockfile share one cache. restore-keys falls back to
+    # the latest same-OS/Python cache as a warm base when the lockfile changes.
+    - name: Cache uv downloads
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/uv
+        key: uv-${{ runner.os }}-py3.14-${{ hashFiles(format('{0}/uv.lock', inputs.base-dir)) }}
+        restore-keys: |
+          uv-${{ runner.os }}-py3.14-
 
     - name: Install dependencies (uv sync)
       shell: bash

--- a/.github/actions/setup-pagoda-env/action.yml
+++ b/.github/actions/setup-pagoda-env/action.yml
@@ -47,9 +47,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    # Install uv from a prebuilt binary (fast) instead of `pipx install uv`,
+    # which builds/installs via pip. The uv download cache is persisted
+    # separately by the "Cache uv downloads" step below, so enable-cache is
+    # left off here (its lockfile does not exist yet at this point anyway).
     - name: Install uv
-      shell: bash
-      run: pipx install uv
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
     - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
@@ -61,13 +64,33 @@ runs:
         # would also require a requirements/pyproject file at the workspace root,
         # which is absent in jobs that clone the Pagoda base into a subdir.
 
+    # Resolve the apt package list once so both the cache key and the install
+    # step reference the same set (bumping a package invalidates the cache).
+    - name: Resolve apt package list
+      id: apt
+      shell: bash
+      run: |
+        pkgs="libldap2-dev libsasl2-dev libxmlsec1-dev default-mysql-client default-libmysqlclient-dev pkg-config"
+        echo "APT_PACKAGES=$pkgs" >> "$GITHUB_ENV"
+        echo "hash=$(printf '%s' "$pkgs" | sha256sum | cut -c1-16)" >> "$GITHUB_OUTPUT"
+
+    # Cache the downloaded .deb archives. apt is pointed at a runner-owned
+    # directory (~/apt-cache) via Dir::Cache::archives instead of the default
+    # root-owned /var/cache/apt/archives, so actions/cache can read/write it
+    # without permission workarounds. On a hit, `apt-get install` uses the
+    # cached .debs and skips the download (apt-get update + dpkg still run).
+    - name: Cache apt archives
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/apt-cache
+        key: apt-${{ runner.os }}-${{ steps.apt.outputs.hash }}
+
     - name: Install system dependencies
       shell: bash
       run: |
+        mkdir -p ~/apt-cache/partial
         sudo apt-get update
-        sudo apt-get install -y \
-          libldap2-dev libsasl2-dev libxmlsec1-dev \
-          default-mysql-client default-libmysqlclient-dev pkg-config
+        sudo apt-get install -y -o Dir::Cache::archives="$HOME/apt-cache" $APT_PACKAGES
 
     - name: Clone Pagoda base
       if: ${{ inputs.clone == 'true' }}


### PR DESCRIPTION
## Summary

Reduce the per-job setup time of the `setup-pagoda-env` composite action,
which every Pagoda extension repo (custom_view, twc, ...) runs — often
across many matrix jobs. Three changes:

- **Cache uv downloads** — persist uv's global download/build cache
  (`~/.cache/uv`) with `actions/cache` so `uv sync` reuses wheels and built
  artifacts instead of re-downloading everything each run. The step runs
  after the Pagoda base is cloned so the lockfile exists and keys the cache
  precisely. The key is `(OS, Python, uv.lock hash)` only — intentionally
  branch-agnostic, since the lockfile hash fully determines the dependency
  set, so base branches resolving to the same lockfile share one cache.

- **Faster uv install** — install uv via `astral-sh/setup-uv` (prebuilt
  binary) instead of `pipx install uv`, which builds/installs through pip.

- **Cache apt archives** — cache the downloaded `.deb` files. apt is pointed
  at a runner-owned directory (`~/apt-cache`) via `Dir::Cache::archives`
  rather than the root-owned `/var/cache/apt/archives`, so `actions/cache`
  can read/write it without permission workarounds. On a hit, `apt-get
  install` reuses the `.debs` and skips the download. The package list is
  resolved once and hashed into the cache key.

## Notes

- Effects apply from the **second run onward** (first run only populates the
  caches).
- New `uses:` (`astral-sh/setup-uv`, `actions/cache`) are pinned to
  full-length commit SHAs per org policy.
- Follow-up: after merge, bump the pinned
  `setup-pagoda-env@<SHA>` reference in the extension repos (custom_view,
  twc) to the merged SHA so they pick up the caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)