### PR TITLE
Show attribute descriptions as tooltips on item detail page

### DIFF
--- a/frontend/src/components/entry/EntryAttributes.test.tsx
+++ b/frontend/src/components/entry/EntryAttributes.test.tsx
@@ -57,4 +57,31 @@ describe("EntryAttributes", () => {
     expect(within(bodyRowGroup).queryByText("value1")).toBeInTheDocument();
     expect(within(bodyRowGroup).queryByText("value2")).not.toBeInTheDocument();
   });
+
+  test("should show note icon only for attributes with a note", async () => {
+    await act(async () => {
+      render(
+        <EntryAttributes
+          attributes={attributes}
+          attrNotes={{ 1: "description of string1" }}
+        />,
+        {
+          wrapper: TestWrapper,
+        },
+      );
+    });
+
+    expect(screen.getByLabelText("string1の説明")).toBeInTheDocument();
+    expect(screen.queryByLabelText("string2の説明")).not.toBeInTheDocument();
+  });
+
+  test("should not show note icons when attrNotes is not given", async () => {
+    await act(async () => {
+      render(<EntryAttributes attributes={attributes} />, {
+        wrapper: TestWrapper,
+      });
+    });
+
+    expect(screen.queryByLabelText("string1の説明")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/entry/EntryAttributes.tsx
+++ b/frontend/src/components/entry/EntryAttributes.tsx
@@ -2,7 +2,9 @@ import {
   EntryAttributeType,
   TriggerParent,
 } from "@dmm-com/airone-apiclient-typescript-fetch";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import {
+  Box,
   Link,
   Paper,
   Table,
@@ -23,6 +25,8 @@ import { triggersPath } from "routes/Routes";
 interface Props {
   attributes: Array<EntryAttributeType>;
   triggers?: TriggerParent[];
+  /** Description of each attribute (EntityAttr.note), keyed by EntityAttr id */
+  attrNotes?: Record<number, string>;
 }
 
 const StyledTableRow = styled(TableRow)<{ highlighted?: boolean }>(
@@ -58,7 +62,26 @@ const AttrValueTableCell = styled(TableCell)(() => ({
   wordBreak: "break-word",
 }));
 
-export const EntryAttributes: FC<Props> = ({ attributes, triggers }) => {
+const AttrNameBox = styled(Box)(() => ({
+  display: "flex",
+  alignItems: "center",
+  gap: "4px",
+}));
+
+const AttrNoteIcon = styled(HelpOutlineIcon)(({ theme }) => ({
+  fontSize: "16px",
+  color: theme.palette.text.disabled,
+  cursor: "help",
+  "&:hover": {
+    color: theme.palette.text.secondary,
+  },
+}));
+
+export const EntryAttributes: FC<Props> = ({
+  attributes,
+  triggers,
+  attrNotes = {},
+}) => {
   const triggeredAttrIds = useMemo(
     () =>
       new Set(triggers?.flatMap((t) => t.actions.map((a) => a.attr.id)) ?? []),
@@ -81,16 +104,28 @@ export const EntryAttributes: FC<Props> = ({ attributes, triggers }) => {
               highlighted={triggeredAttrIds.has(attr.schema.id)}
             >
               <AttrNameTableCell>
-                {triggeredAttrIds.has(attr.schema.id) ? (
-                  <Tooltip
-                    title="この属性には Trigger が設定されています"
-                    placement="top"
-                  >
-                    <Link href={triggersPath()}>{attr.schema.name}</Link>
-                  </Tooltip>
-                ) : (
-                  attr.schema.name
-                )}
+                <AttrNameBox>
+                  {triggeredAttrIds.has(attr.schema.id) ? (
+                    <Tooltip
+                      title="この属性には Trigger が設定されています"
+                      placement="top"
+                    >
+                      <Link href={triggersPath()}>{attr.schema.name}</Link>
+                    </Tooltip>
+                  ) : (
+                    attr.schema.name
+                  )}
+                  {attrNotes[attr.schema.id] && (
+                    <Tooltip
+                      title={attrNotes[attr.schema.id]}
+                      placement="top"
+                      arrow
+                      enterTouchDelay={0}
+                    >
+                      <AttrNoteIcon aria-label={`${attr.schema.name}の説明`} />
+                    </Tooltip>
+                  )}
+                </AttrNameBox>
               </AttrNameTableCell>
               <AttrValueTableCell>
                 {attr.isReadable ? (

--- a/frontend/src/pages/EntryDetailsPage.test.tsx
+++ b/frontend/src/pages/EntryDetailsPage.test.tsx
@@ -44,6 +44,22 @@ const server = setupServer(
       ],
     });
   }),
+  // getEntity
+  http.get("http://localhost/entity/api/v2/2/", () => {
+    return HttpResponse.json({
+      id: 2,
+      name: "test entity",
+      note: "",
+      is_toplevel: false,
+      attrs: [],
+      webhooks: [],
+      isolation_rules: [],
+      is_public: true,
+      has_ongoing_changes: false,
+      permission: 8,
+      delete_chain_exclude_entities: [],
+    });
+  }),
   // getTrigger
   http.get("http://localhost/trigger/api/v2/", () => {
     return HttpResponse.json({

--- a/frontend/src/pages/EntryDetailsPage.tsx
+++ b/frontend/src/pages/EntryDetailsPage.tsx
@@ -3,7 +3,7 @@ import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import { Box, Chip, IconButton, Stack, Typography } from "@mui/material";
 import Grid from "@mui/material/Grid2";
 import { styled } from "@mui/material/styles";
-import { FC, Suspense, useEffect, useState } from "react";
+import { FC, Suspense, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 
 import { Loading } from "components/common/Loading";
@@ -92,6 +92,20 @@ const EntryDetailsContent: FC<Props> = ({
     aironeApiClient.getTriggers(),
   );
 
+  const { data: entity } = usePagodaSWR(["entity", entityId], () =>
+    aironeApiClient.getEntity(entityId),
+  );
+
+  const attrNotes = useMemo(
+    () =>
+      Object.fromEntries(
+        (entity?.attrs ?? [])
+          .filter((attr) => attr.note !== "")
+          .map((attr) => [attr.id, attr.note]),
+      ),
+    [entity],
+  );
+
   useEffect(() => {
     if (entry.schema?.id != entityId) {
       navigate(entryDetailsPath(entry.schema?.id ?? 0, entryId), {
@@ -174,6 +188,7 @@ const EntryDetailsContent: FC<Props> = ({
                     (attr) => !excludeAttrs.includes(attr.schema.name),
                   )}
                   triggers={triggers?.results}
+                  attrNotes={attrNotes}
                 />
               ),
             },


### PR DESCRIPTION
Show usable attribute description on the item details page to explain what the attribute means to users.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/4d21a93b-ebb6-4c1b-9562-394d85f4bde9" />
