### PR TITLE
Fix advanced search export for (ARRAY_)NAMED_OBJECT_BOOLEAN attrs

### DIFF
--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -80,9 +80,11 @@ def _csv_export(
                 case AttrType.OBJECT | AttrType.GROUP | AttrType.ROLE:
                     line_data.append(str(vval["name"]))
 
-                case AttrType.NAMED_OBJECT:
+                case AttrType.NAMED_OBJECT | AttrType.NAMED_OBJECT_BOOLEAN:
                     [(k, v)] = vval.items()
-                    line_data.append("%s: %s" % (k, v["name"]))
+                    line_data.append(
+                        "%s: %s" % (k, v["name"]) if isinstance(v, dict) else "%s: " % k
+                    )
 
                 case AttrType.ARRAY_STRING:
                     line_data.append("\n".join(natsorted(vval)))
@@ -95,13 +97,20 @@ def _csv_export(
                 case AttrType.ARRAY_OBJECT | AttrType.ARRAY_GROUP | AttrType.ARRAY_ROLE:
                     line_data.append("\n".join(natsorted([x["name"] for x in vval])))
 
-                case AttrType.ARRAY_NAMED_OBJECT:
+                case AttrType.ARRAY_NAMED_OBJECT | AttrType.ARRAY_NAMED_OBJECT_BOOLEAN:
                     items = []
                     for vset in vval:
                         [(k, v)] = vset.items()
-                        items.append("%s: %s" % (k, v["name"]))
+                        items.append(
+                            "%s: %s" % (k, v["name"]) if isinstance(v, dict) else "%s: " % k
+                        )
 
                     line_data.append("\n".join(natsorted(items)))
+
+                case _:
+                    # Types without a dedicated formatter (e.g. SELECT / MULTI_SELECT)
+                    # still need a cell, otherwise the following columns get shifted.
+                    line_data.append("")
 
         if has_referral is not False:
             line_data.append(

--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -37,6 +37,9 @@ from user.models import User
 class ExportedEntryAttributeValueObject(BaseModel):
     entity: str
     name: str
+    # Only set for (ARRAY_)NAMED_OBJECT_BOOLEAN; omitted from the export otherwise
+    # because the dump is done with exclude_unset=True.
+    boolean: bool | None = None
 
 
 ExportedEntryAttributePrimitiveValue = (

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -275,12 +275,21 @@ def _yaml_export_v2(
         atype: int, value: ExportPrimitiveInput
     ) -> ExportedEntryAttributePrimitiveValue:
         match atype:
-            case AttrType.NAMED_OBJECT:
+            case AttrType.NAMED_OBJECT | AttrType.NAMED_OBJECT_BOOLEAN:
                 assert isinstance(value, dict)
                 [(key, val)] = value.items()
+                # NAMED_OBJECT_BOOLEAN carries its boolean flag beside the referral
+                # info, so export it too in order to keep the value round-trippable.
+                boolean_info = (
+                    {"boolean": val["boolean"]}
+                    if atype == AttrType.NAMED_OBJECT_BOOLEAN
+                    and isinstance(val, dict)
+                    and "boolean" in val
+                    else {}
+                )
                 entry: Entry | None = (
                     Entry.objects.filter(id=val["id"]).first()
-                    if isinstance(val.get("id"), int)
+                    if isinstance(val, dict) and isinstance(val.get("id"), int)
                     else None
                 )
                 if entry:
@@ -288,6 +297,7 @@ def _yaml_export_v2(
                         key: ExportedEntryAttributeValueObject(
                             entity=entry.schema.name,
                             name=val["name"],
+                            **boolean_info,
                         )
                     }
                 elif len(key) > 0:
@@ -895,9 +905,9 @@ def _csv_export_v2(
                 return str(vval)
             case AttrType.OBJECT | AttrType.GROUP | AttrType.ROLE:
                 return str(vval["name"])
-            case AttrType.NAMED_OBJECT:
+            case AttrType.NAMED_OBJECT | AttrType.NAMED_OBJECT_BOOLEAN:
                 [(k, v)] = vval.items()
-                return f"{k}: {v['name']}"
+                return f"{k}: {v['name']}" if isinstance(v, dict) else f"{k}: "
             case AttrType.SELECT:
                 if isinstance(vval, dict):
                     return str(vval.get("label", ""))
@@ -919,13 +929,13 @@ def _csv_export_v2(
                 from natsort import natsorted
 
                 return "\n".join(natsorted([x["name"] for x in vval]))
-            case AttrType.ARRAY_NAMED_OBJECT:
+            case AttrType.ARRAY_NAMED_OBJECT | AttrType.ARRAY_NAMED_OBJECT_BOOLEAN:
                 from natsort import natsorted
 
                 items = []
                 for vset in vval:
                     [(k, v)] = vset.items()
-                    items.append(f"{k}: {v['name']}")
+                    items.append(f"{k}: {v['name']}" if isinstance(v, dict) else f"{k}: ")
                 return "\n".join(natsorted(items))
         return ""
 

--- a/entry/tests/test_api_v2_import_export.py
+++ b/entry/tests/test_api_v2_import_export.py
@@ -2041,6 +2041,86 @@ class ViewTest(BaseViewTest):
     @patch(
         "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)
     )
+    def test_export_named_object_boolean_attrs(self):
+        # Regression test: (ARRAY_)NAMED_OBJECT_BOOLEAN values were not handled by the
+        # v2 exporters, so the YAML export aborted the Job with an AssertionError and
+        # the CSV export emitted an empty cell.
+        user = self._create_user("admin", is_superuser=True)
+
+        ref_entity = Entity.objects.create(name="ReferredEntity", created_user=user)
+        entity = Entity.objects.create(name="entity", created_user=user)
+        for name, attr_type in [
+            ("nobool", AttrType.NAMED_OBJECT_BOOLEAN),
+            ("arr_nobool", AttrType.ARRAY_NAMED_OBJECT_BOOLEAN),
+        ]:
+            entity_attr = EntityAttr.objects.create(
+                name=name,
+                type=attr_type,
+                created_user=user,
+                parent_entity=entity,
+            )
+            entity_attr.referral.add(ref_entity)
+
+        ref_entry = Entry.objects.create(name="ref", schema=ref_entity, created_user=user)
+        ref_entry.register_es()
+
+        entry = Entry.objects.create(name="entry", schema=entity, created_user=user)
+        entry.complement_attrs(user)
+        entry.attrs.get(schema__name="nobool").add_value(
+            user, {"name": "key1", "id": ref_entry, "boolean": True}
+        )
+        entry.attrs.get(schema__name="arr_nobool").add_value(
+            user, [{"name": "key2", "id": ref_entry, "boolean": True}]
+        )
+        entry.register_es()
+
+        export_params = {
+            "entities": [entity.id],
+            "attrinfo": [
+                {"name": "nobool", "filter_key": 0, "keyword": ""},
+                {"name": "arr_nobool", "filter_key": 0, "keyword": ""},
+            ],
+        }
+
+        # YAML export
+        resp = self.client.post(
+            "/entry/api/v2/advanced_search_result_export/",
+            json.dumps(dict(export_params, export_style="yaml")),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        job = Job.objects.last()
+        self.assertEqual(job.status, JobStatus.DONE)
+        resp_data = yaml.load(job.get_cache(), Loader=yaml.FullLoader)
+        attrs = {x["name"]: x["value"] for x in resp_data[0]["entries"][0]["attrs"]}
+        self.assertEqual(
+            attrs["nobool"],
+            {"key1": {"entity": "ReferredEntity", "name": "ref", "boolean": True}},
+        )
+        self.assertEqual(
+            attrs["arr_nobool"],
+            [{"key2": {"entity": "ReferredEntity", "name": "ref", "boolean": True}}],
+        )
+
+        # CSV export
+        resp = self.client.post(
+            "/entry/api/v2/advanced_search_result_export/",
+            json.dumps(dict(export_params, export_style="csv")),
+            "application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        job = Job.objects.last()
+        self.assertEqual(job.status, JobStatus.DONE)
+        self.assertEqual(
+            job.get_cache(),
+            "Name,Entity,nobool,arr_nobool\nentry,entity,key1: ref,key2: ref\n",
+        )
+
+    @patch(
+        "entry.tasks.export_search_result_v2.delay", Mock(side_effect=tasks.export_search_result_v2)
+    )
     def test_yaml_export_without_has_referral_omits_referrals_key(self):
         # Regression test for #3459: when 'has_referral' is not enabled, the YAML output
         # must NOT contain the 'referrals' key (previously emitted as 'referrals: null').


### PR DESCRIPTION
_yaml_export_v2() dispatches array values by `atype ^ AttrType._ARRAY`, but the resulting NAMED_OBJECT_BOOLEAN (_NAMED|OBJECT|BOOLEAN) does not match `case AttrType.NAMED_OBJECT`, so it fell through to the fallback branch and aborted the export Job with an AssertionError. Handle both named-object types and export the boolean flag alongside the referral info so the value stays round-trippable (the importer ignores the extra key).