### PR TITLE
Fix import not updating (ARRAY_)NAMED_OBJECT_BOOLEAN attribute values

### DIFF
--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -1288,6 +1288,37 @@ class EntryImportEntitySerializer(serializers.Serializer):
                         return ref_entry.id if ref_entry else 0
                 return None
 
+            def _named_object(
+                val: dict[str, Any],
+                refs: list[Entity],
+                is_boolean: bool,
+            ) -> dict[str, Any]:
+                """Convert a named-object value of `{<name>: <referral>}` shape.
+
+                For (ARRAY_)NAMED_OBJECT_BOOLEAN, the exported boolean flag lives
+                either inside the referral (`{name: .., entity: .., boolean: ..}`,
+                the yaml export shape) or beside the name key
+                (`{<name>: <entry name>, boolean: ..}`). Accept both and carry the
+                flag over, otherwise it is dropped here and the attribute value is
+                never recognized as updated.
+                """
+                items = dict(val)
+                boolean: bool | None = None
+                if is_boolean and isinstance(items.get("boolean"), bool):
+                    boolean = items.pop("boolean")
+                if not items:
+                    return {}
+
+                name, referral = next(iter(items.items()))
+                if is_boolean and boolean is None and isinstance(referral, dict):
+                    boolean = referral.get("boolean")
+
+                converted = {"name": name, "id": _object(referral, refs)}
+                if is_boolean:
+                    converted["boolean"] = bool(boolean)
+
+                return converted
+
             def _group(val: str) -> int | None:
                 if val:
                     ref_group: Group | None = Group.objects.filter(name=val).first()
@@ -1300,6 +1331,10 @@ class EntryImportEntitySerializer(serializers.Serializer):
                     return ref_role.id if ref_role else 0
                 return None
 
+            attr_type = entity_attrs[attr_data["name"]]["type"]
+            # _NAMED types also carry the BOOLEAN bit when they hold a boolean flag
+            is_boolean_named = bool(attr_type & AttrType._NAMED and attr_type & AttrType.BOOLEAN)
+
             if entity_attrs[attr_data["name"]]["type"] & AttrType._ARRAY:
                 if not isinstance(attr_data["value"], list):
                     return
@@ -1308,13 +1343,11 @@ class EntryImportEntitySerializer(serializers.Serializer):
                         if entity_attrs[attr_data["name"]]["type"] & AttrType._NAMED:
                             if not isinstance(child_value, dict):
                                 return
-                            attr_data["value"][i] = {
-                                "name": list(child_value.keys())[0],
-                                "id": _object(
-                                    list(child_value.values())[0],
-                                    entity_attrs[attr_data["name"]]["refs"],
-                                ),
-                            }
+                            attr_data["value"][i] = _named_object(
+                                child_value,
+                                entity_attrs[attr_data["name"]]["refs"],
+                                is_boolean_named,
+                            )
                         else:
                             attr_data["value"][i] = _object(
                                 child_value, entity_attrs[attr_data["name"]]["refs"]
@@ -1329,16 +1362,10 @@ class EntryImportEntitySerializer(serializers.Serializer):
                     if entity_attrs[attr_data["name"]]["type"] & AttrType._NAMED:
                         if not isinstance(attr_data["value"], dict):
                             return
-                        attr_data["value"] = (
-                            {
-                                "name": list(attr_data["value"].keys())[0],
-                                "id": _object(
-                                    list(attr_data["value"].values())[0],
-                                    entity_attrs[attr_data["name"]]["refs"],
-                                ),
-                            }
-                            if len(attr_data["value"].keys()) > 0
-                            else {}
+                        attr_data["value"] = _named_object(
+                            attr_data["value"],
+                            entity_attrs[attr_data["name"]]["refs"],
+                            is_boolean_named,
                         )
                     else:
                         attr_data["value"] = _object(

--- a/entry/models.py
+++ b/entry/models.py
@@ -876,7 +876,7 @@ class Attribute(ACLBase):
 
                 return bool(last_value.datetime != recv_value)
 
-            case AttrType.NAMED_OBJECT:
+            case AttrType.NAMED_OBJECT | AttrType.NAMED_OBJECT_BOOLEAN:
                 # the case that specified value is empty or invalid
                 if not recv_value:
                     # Value would be changed as empty when there is valid value
@@ -887,6 +887,12 @@ class Attribute(ACLBase):
 
                 if last_value.value != recv_value["name"]:
                     return True
+
+                # NAMED_OBJECT_BOOLEAN holds a boolean flag beside the referral, so a
+                # change of the flag alone is an update as well.
+                if self.schema.type == AttrType.NAMED_OBJECT_BOOLEAN:
+                    if last_value.boolean != bool(recv_value.get("boolean", False)):
+                        return True
 
                 # formalize recv_value['id'] type
                 if isinstance(recv_value["id"], Entry):

--- a/entry/tests/test_api_v2_import_export.py
+++ b/entry/tests/test_api_v2_import_export.py
@@ -613,6 +613,91 @@ class ViewTest(BaseViewTest):
 
     @patch("entry.tasks.notify_update_entry.delay", Mock(side_effect=tasks.notify_update_entry))
     @patch("entry.tasks.import_entries_v2.delay", Mock(side_effect=tasks.import_entries_v2))
+    def test_import_update_named_object_boolean_attrs(self):
+        # Regression test: the boolean flag of (ARRAY_)NAMED_OBJECT_BOOLEAN was dropped
+        # while converting import data, so the value was never treated as updated.
+        user = self.user
+
+        ref_entity = Entity.objects.create(name="BoolRefEntity", created_user=user)
+        ref_entry = Entry.objects.create(name="ref", schema=ref_entity, created_user=user)
+        ref_entry.register_es()
+
+        entity = Entity.objects.create(name="BoolEntity", created_user=user)
+        for name, attr_type in [
+            ("nobool", AttrType.NAMED_OBJECT_BOOLEAN),
+            ("arr_nobool", AttrType.ARRAY_NAMED_OBJECT_BOOLEAN),
+        ]:
+            entity_attr = EntityAttr.objects.create(
+                name=name,
+                type=attr_type,
+                created_user=user,
+                parent_entity=entity,
+            )
+            entity_attr.referral.add(ref_entity)
+
+        entry = Entry.objects.create(name="item", schema=entity, created_user=user)
+        entry.complement_attrs(user)
+        entry.attrs.get(schema__name="nobool").add_value(
+            user, {"name": "key1", "id": ref_entry, "boolean": False}
+        )
+        entry.attrs.get(schema__name="arr_nobool").add_value(
+            user, [{"name": "key2", "id": ref_entry, "boolean": False}]
+        )
+
+        def _latest_booleans():
+            single = entry.attrs.get(schema__name="nobool").get_latest_value()
+            array = entry.attrs.get(schema__name="arr_nobool").get_latest_value()
+            return (single.boolean, [x.boolean for x in array.data_array.all()])
+
+        def _import(query, value_single, value_array):
+            resp = self.client.post(
+                "/entry/api/v2/import/%s" % query,
+                yaml.dump(
+                    [
+                        {
+                            "entity": "BoolEntity",
+                            "entries": [
+                                {
+                                    "name": "item",
+                                    "attrs": [
+                                        {"name": "nobool", "value": value_single},
+                                        {"name": "arr_nobool", "value": value_array},
+                                    ],
+                                }
+                            ],
+                        }
+                    ]
+                ),
+                "application/yaml",
+            )
+            self.assertEqual(resp.status_code, 200)
+            job = Job.objects.filter(operation=JobOperation.IMPORT_ENTRY_V2).last()
+            self.assertEqual(job.status, JobStatus.DONE)
+
+        self.assertEqual(_latest_booleans(), (False, [False]))
+
+        # the flag is nested in the referral, as the yaml export emits it
+        referral = {"entity": "BoolRefEntity", "name": "ref", "boolean": True}
+        _import("", {"key1": referral}, [{"key2": referral}])
+        self.assertEqual(_latest_booleans(), (True, [True]))
+
+        # the flag is a sibling of the name key, as AttributeValue.get_value() emits it
+        _import(
+            "?force=true",
+            {"key1": "ref", "boolean": False},
+            [{"key2": "ref", "boolean": False}],
+        )
+        self.assertEqual(_latest_booleans(), (False, [False]))
+
+        # the referral itself must survive both import shapes
+        array = entry.attrs.get(schema__name="arr_nobool").get_latest_value()
+        self.assertEqual(
+            [(x.value, x.referral.id) for x in array.data_array.all()],
+            [("key2", ref_entry.id)],
+        )
+
+    @patch("entry.tasks.notify_update_entry.delay", Mock(side_effect=tasks.notify_update_entry))
+    @patch("entry.tasks.import_entries_v2.delay", Mock(side_effect=tasks.import_entries_v2))
     @patch("entry.tasks.export_entries_v2.delay", Mock(side_effect=tasks.export_entries_v2))
     def test_import_update_entry_with_id(self):
         """


### PR DESCRIPTION
Importing an item never changed the boolean flag of a named-object-boolean attribute, for two independent reasons:

- EntryImportEntitySerializer converted named-object values into {"name": .., "id": ..} and dropped the boolean flag, so the value handed to add_value() always carried the default False. Add a _named_object() helper that keeps the flag, accepting both shapes it can be exported in: nested in the referral ({name, entity, boolean}, yaml export) and beside the name key ({<name>: <entry name>, boolean}, AttributeValue.get_value()).

- Attribute.is_updated() had no branch for the non-array NAMED_OBJECT_BOOLEAN, so a change of the flag alone fell through the match and was reported as "not updated". Handle it next to NAMED_OBJECT and compare the flag. The array variant already compared it, so it is fixed by the serializer change alone.