### PR TITLE
feat: replace attribute reorder arrows with drag-and-drop

### DIFF
--- a/frontend/src/components/entity/entityForm/AttributeField.tsx
+++ b/frontend/src/components/entity/entityForm/AttributeField.tsx
@@ -1,9 +1,12 @@
 import { Entity } from "@dmm-com/airone-apiclient-typescript-fetch";
+import {
+  DraggableAttributes,
+  DraggableSyntheticListeners,
+} from "@dnd-kit/core";
 import AddIcon from "@mui/icons-material/Add";
-import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
-import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import BadgeIcon from "@mui/icons-material/Badge";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import EditNoteIcon from "@mui/icons-material/EditNote";
 import GroupIcon from "@mui/icons-material/Group";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
@@ -90,14 +93,22 @@ const ATTRIBUTE_TYPE_ORDER = [
   "datetime",
 ];
 
+// Props forwarded from the sortable row wrapper so this cell can host the
+// drag handle (pointer + keyboard activation) for reordering attributes.
+interface AttributeDragHandleProps {
+  setActivatorNodeRef: (element: HTMLElement | null) => void;
+  attributes: DraggableAttributes;
+  listeners: DraggableSyntheticListeners;
+  isDragging: boolean;
+}
+
 interface Props {
   control: Control<Schema>;
   setValue: UseFormSetValue<Schema>;
-  maxIndex: number;
   referralEntities: Entity[];
   handleAppendAttribute: (index: number) => void;
   handleDeleteAttribute: (index: number) => void;
-  handleChangeOrderAttribute: (index: number, order: number) => void;
+  dragHandleProps?: AttributeDragHandleProps;
   attrId?: number;
   index?: number;
 }
@@ -105,11 +116,10 @@ interface Props {
 export const AttributeField: FC<Props> = ({
   control,
   setValue,
-  maxIndex,
   referralEntities,
   handleAppendAttribute,
   handleDeleteAttribute,
-  handleChangeOrderAttribute,
+  dragHandleProps,
   attrId,
   index,
 }) => {
@@ -186,6 +196,31 @@ export const AttributeField: FC<Props> = ({
 
   return index != null ? (
     <>
+      {/* Drag handle to reorder attributes (pointer & keyboard) */}
+      <TableCell>
+        <Box display="flex" alignItems="center" justifyContent="center">
+          <Tooltip title="ドラッグして並び替え">
+            {/* span keeps the tooltip working while the button is disabled */}
+            <span>
+              <IconButton
+                ref={dragHandleProps?.setActivatorNodeRef}
+                disabled={!isWritable || dragHandleProps == null}
+                aria-label={`${index + 1} 番目の属性をドラッグして並び替え`}
+                data-testid="attr-drag-handle"
+                sx={{
+                  cursor: dragHandleProps?.isDragging ? "grabbing" : "grab",
+                  touchAction: "none",
+                }}
+                {...(dragHandleProps?.attributes ?? {})}
+                {...(dragHandleProps?.listeners ?? {})}
+              >
+                <DragIndicatorIcon />
+              </IconButton>
+            </span>
+          </Tooltip>
+        </Box>
+      </TableCell>
+
       {/* Attribute Name */}
       <TableCell>
         <Controller
@@ -378,27 +413,6 @@ export const AttributeField: FC<Props> = ({
             );
           }}
         />
-      </TableCell>
-
-      {/* Change Attribute order to be shown at Item detail page */}
-      <TableCell>
-        <Box display="flex" flexDirection="column">
-          <IconButton
-            aria-label={`${index + 1} 番目の属性を上へ移動`}
-            disabled={index === 0 || !isWritable}
-            onClick={() => handleChangeOrderAttribute(index, 1)}
-          >
-            <ArrowUpwardIcon />
-          </IconButton>
-
-          <IconButton
-            aria-label={`${index + 1} 番目の属性を下へ移動`}
-            disabled={index === maxIndex || !isWritable}
-            onClick={() => handleChangeOrderAttribute(index, -1)}
-          >
-            <ArrowDownwardIcon />
-          </IconButton>
-        </Box>
       </TableCell>
 
       {/* Delete target Attribute */}

--- a/frontend/src/components/entity/entityForm/AttributesFields.test.tsx
+++ b/frontend/src/components/entity/entityForm/AttributesFields.test.tsx
@@ -14,10 +14,35 @@ import { useForm } from "react-hook-form";
 
 import { schema } from "../../entry/entryForm/EntryFormSchema";
 
-import { AttributesFields } from "./AttributesFields";
+import { AttributesFields, getReorderIndices } from "./AttributesFields";
 import { Schema } from "./EntityFormSchema";
 
 import { TestWrapper } from "TestWrapper";
+import { AttributeTypes } from "services/Constants";
+
+describe("getReorderIndices", () => {
+  const ids = ["a", "b", "c", "d"];
+
+  test("returns source and destination indices for a valid move", () => {
+    expect(getReorderIndices(ids, "a", "c")).toEqual({
+      oldIndex: 0,
+      newIndex: 2,
+    });
+    expect(getReorderIndices(ids, "d", "a")).toEqual({
+      oldIndex: 3,
+      newIndex: 0,
+    });
+  });
+
+  test("returns null when dropped onto itself (no-op)", () => {
+    expect(getReorderIndices(ids, "b", "b")).toBeNull();
+  });
+
+  test("returns null when an id is unknown", () => {
+    expect(getReorderIndices(ids, "a", "z")).toBeNull();
+    expect(getReorderIndices(ids, "z", "a")).toBeNull();
+  });
+});
 
 describe("AttributesFields", () => {
   const defaultValues: Schema = {
@@ -32,7 +57,7 @@ describe("AttributesFields", () => {
     attrs: [],
   };
 
-  test("should provide attributes fields editor", async () => {
+  const renderFields = (values: Schema = defaultValues) => {
     const {
       result: {
         current: { control, getValues, setValue },
@@ -41,7 +66,7 @@ describe("AttributesFields", () => {
       useForm<Schema>({
         resolver: zodResolver(schema),
         mode: "onBlur",
-        defaultValues,
+        defaultValues: values,
       }),
     );
 
@@ -54,14 +79,27 @@ describe("AttributesFields", () => {
       { wrapper: TestWrapper },
     );
 
+    return { getValues };
+  };
+
+  test("provides drag-and-drop reordering instead of up/down arrows", async () => {
+    const { getValues } = renderFields();
+
     expect(screen.queryAllByPlaceholderText("属性名")).toHaveLength(0);
 
-    // add first attribute
+    // add first attribute (only the empty-state add button exists initially)
     await act(async () => {
       screen.getByRole("button").click();
     });
 
     expect(screen.queryAllByPlaceholderText("属性名")).toHaveLength(1);
+
+    // a drag handle is rendered for reordering
+    expect(screen.getAllByTestId("attr-drag-handle")).toHaveLength(1);
+
+    // the legacy up/down arrow controls are gone
+    expect(screen.queryByTestId("ArrowUpwardIcon")).toBeNull();
+    expect(screen.queryByTestId("ArrowDownwardIcon")).toBeNull();
 
     // edit first attribute
     await act(async () => {
@@ -73,22 +111,43 @@ describe("AttributesFields", () => {
     expect(screen.getByPlaceholderText("属性名")).toHaveValue("attr1");
     expect(getValues("attrs.0.name")).toEqual("attr1");
 
-    // add second attribute
+    // add a second attribute via the row's add button
     await act(async () => {
-      // now there is 1 attribute, and each webhook has 5 buttons (note, up, down, delete, add)
-      // click the add button of the first webhook
-      screen.getAllByRole("button")[4].click();
+      fireEvent.click(screen.getAllByTestId("AddIcon")[0]);
     });
 
-    expect(screen.queryAllByPlaceholderText("属性名")).toHaveLength(1);
+    expect(screen.getAllByTestId("attr-drag-handle")).toHaveLength(2);
 
-    // delete first attribute
+    // delete the first attribute via its delete button
     await act(async () => {
-      // now there is 1 attribute, and each webhook has 5 buttons (up, down, delete, config)
-      // click the delete button of the first webhook
-      screen.getAllByRole("button")[1].click();
+      fireEvent.click(screen.getAllByTestId("DeleteOutlineIcon")[0]);
     });
 
-    expect(screen.queryAllByPlaceholderText("属性名")).toHaveLength(1);
+    expect(screen.getAllByTestId("attr-drag-handle")).toHaveLength(1);
+  });
+
+  test("disables the drag handle for a non-writable attribute", () => {
+    renderFields({
+      ...defaultValues,
+      attrs: [
+        {
+          name: "readonly-attr",
+          type: AttributeTypes.string.type,
+          isMandatory: false,
+          isDeleteInChain: false,
+          isSummarized: false,
+          isWritable: false,
+          referral: [],
+          note: "",
+          nameOrder: "0",
+          namePrefix: "",
+          namePostfix: "",
+          displayAttr: "",
+        },
+      ],
+    });
+
+    const handle = screen.getByTestId("attr-drag-handle");
+    expect(handle).toBeDisabled();
   });
 });

--- a/frontend/src/components/entity/entityForm/AttributesFields.tsx
+++ b/frontend/src/components/entity/entityForm/AttributesFields.tsx
@@ -1,5 +1,22 @@
 import { Entity } from "@dmm-com/airone-apiclient-typescript-fetch";
 import {
+  DndContext,
+  DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
   Table,
   TableBody,
   TableCell,
@@ -9,7 +26,12 @@ import {
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { FC, useState } from "react";
-import { Control, useFieldArray } from "react-hook-form";
+import {
+  Control,
+  FieldArrayWithId,
+  useFieldArray,
+  useWatch,
+} from "react-hook-form";
 import { UseFormSetValue } from "react-hook-form/dist/types/form";
 
 import { AttributeField } from "./AttributeField";
@@ -38,14 +60,105 @@ const StyledTableBody = styled(TableBody)({
   },
 });
 
-const HighlightedTableRow = styled(TableRow)(({}) => ({
+const highlightedRowSx = {
   "@keyframes highlighted": {
     from: {
       backgroundColor: "#6B8998",
     },
   },
   animation: "highlighted 1s ease 0s 1",
-}));
+};
+
+/**
+ * Compute the source/destination indices of a drag-and-drop reorder.
+ *
+ * Returns null when the drop is a no-op (dropped on itself or an unknown id),
+ * so callers can skip mutating the field array.
+ */
+export const getReorderIndices = (
+  ids: string[],
+  activeId: string,
+  overId: string,
+): { oldIndex: number; newIndex: number } | null => {
+  if (activeId === overId) {
+    return null;
+  }
+  const oldIndex = ids.indexOf(activeId);
+  const newIndex = ids.indexOf(overId);
+  if (oldIndex < 0 || newIndex < 0) {
+    return null;
+  }
+  return { oldIndex, newIndex };
+};
+
+interface SortableAttributeRowProps {
+  field: FieldArrayWithId<Schema, "attrs", "key">;
+  index: number;
+  isHighlighted: boolean;
+  control: Control<Schema>;
+  setValue: UseFormSetValue<Schema>;
+  referralEntities: Entity[];
+  handleAppendAttribute: (index: number) => void;
+  handleDeleteAttribute: (index: number) => void;
+}
+
+const SortableAttributeRow: FC<SortableAttributeRowProps> = ({
+  field,
+  index,
+  isHighlighted,
+  control,
+  setValue,
+  referralEntities,
+  handleAppendAttribute,
+  handleDeleteAttribute,
+}) => {
+  const isWritable = useWatch({
+    control,
+    name: `attrs.${index}.isWritable`,
+  });
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: field.key, disabled: !isWritable });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    ...(isDragging
+      ? { position: "relative" as const, zIndex: 1, opacity: 0.7 }
+      : {}),
+  };
+
+  return (
+    <TableRow
+      ref={setNodeRef}
+      style={style}
+      sx={isHighlighted ? highlightedRowSx : undefined}
+    >
+      <AttributeField
+        referralEntities={referralEntities}
+        handleAppendAttribute={handleAppendAttribute}
+        handleDeleteAttribute={handleDeleteAttribute}
+        control={control}
+        setValue={setValue}
+        attrId={field.id}
+        index={index}
+        dragHandleProps={{
+          setActivatorNodeRef,
+          attributes,
+          listeners,
+          isDragging,
+        }}
+      />
+    </TableRow>
+  );
+};
 
 interface Props {
   control: Control<Schema>;
@@ -58,7 +171,7 @@ export const AttributesFields: FC<Props> = ({
   setValue,
   referralEntities,
 }) => {
-  const { fields, insert, remove, swap } = useFieldArray({
+  const { fields, insert, remove, move } = useFieldArray({
     control,
     name: "attrs",
     keyName: "key", // NOTE: attr has 'id' field conflicts default key name
@@ -66,6 +179,15 @@ export const AttributesFields: FC<Props> = ({
 
   const [latestChangedIndex, setLatestChangedIndex] = useState<number | null>(
     null,
+  );
+
+  const sensors = useSensors(
+    // Require a small drag distance so clicks on nested inputs are not swallowed
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    // Keep keyboard-based reordering available for accessibility
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
   );
 
   const handleAppendAttribute = (index: number) => {
@@ -90,10 +212,21 @@ export const AttributesFields: FC<Props> = ({
     remove(index);
   };
 
-  const handleChangeOrderAttribute = (index: number, order: number) => {
-    const newIndex = index - order;
-    swap(newIndex, index);
-    setLatestChangedIndex(newIndex);
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over == null) {
+      return;
+    }
+    const indices = getReorderIndices(
+      fields.map((field) => field.key),
+      String(active.id),
+      String(over.id),
+    );
+    if (indices == null) {
+      return;
+    }
+    move(indices.oldIndex, indices.newIndex);
+    setLatestChangedIndex(indices.newIndex);
   };
 
   return (
@@ -102,55 +235,57 @@ export const AttributesFields: FC<Props> = ({
         属性情報
       </Typography>
 
-      <Table id="table_attribute_list">
-        <TableHead>
-          <HeaderTableRow>
-            <HeaderTableCell width="300px">属性名</HeaderTableCell>
-            <HeaderTableCell width="300px">型</HeaderTableCell>
-            <HeaderTableCell width="200px">デフォルト値</HeaderTableCell>
-            <HeaderTableCell width="100px">並び替え</HeaderTableCell>
-            <HeaderTableCell width="100px">削除</HeaderTableCell>
-            <HeaderTableCell width="100px">追加</HeaderTableCell>
-            <HeaderTableCell width="100px">詳細</HeaderTableCell>
-          </HeaderTableRow>
-        </TableHead>
-        <StyledTableBody>
-          <>
-            {fields.map((field, index) => {
-              const StyledTableRow =
-                index === latestChangedIndex ? HighlightedTableRow : TableRow;
-              return (
-                <StyledTableRow key={field.key}>
-                  <AttributeField
-                    referralEntities={referralEntities}
-                    handleAppendAttribute={handleAppendAttribute}
-                    handleDeleteAttribute={handleDeleteAttribute}
-                    handleChangeOrderAttribute={handleChangeOrderAttribute}
-                    control={control}
-                    setValue={setValue}
-                    maxIndex={fields.length - 1}
-                    attrId={field.id}
-                    index={index}
-                  />
-                </StyledTableRow>
-              );
-            })}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        modifiers={[restrictToVerticalAxis]}
+        onDragEnd={handleDragEnd}
+      >
+        <Table id="table_attribute_list">
+          <TableHead>
+            <HeaderTableRow>
+              <HeaderTableCell width="100px">並び替え</HeaderTableCell>
+              <HeaderTableCell width="300px">属性名</HeaderTableCell>
+              <HeaderTableCell width="300px">型</HeaderTableCell>
+              <HeaderTableCell width="200px">デフォルト値</HeaderTableCell>
+              <HeaderTableCell width="100px">削除</HeaderTableCell>
+              <HeaderTableCell width="100px">追加</HeaderTableCell>
+              <HeaderTableCell width="100px">詳細</HeaderTableCell>
+            </HeaderTableRow>
+          </TableHead>
+          <StyledTableBody>
+            <SortableContext
+              items={fields.map((field) => field.key)}
+              strategy={verticalListSortingStrategy}
+            >
+              {fields.map((field, index) => (
+                <SortableAttributeRow
+                  key={field.key}
+                  field={field}
+                  index={index}
+                  isHighlighted={index === latestChangedIndex}
+                  referralEntities={referralEntities}
+                  handleAppendAttribute={handleAppendAttribute}
+                  handleDeleteAttribute={handleDeleteAttribute}
+                  control={control}
+                  setValue={setValue}
+                />
+              ))}
+            </SortableContext>
             {fields.length === 0 && (
               <TableRow>
                 <AttributeField
                   referralEntities={referralEntities}
                   handleAppendAttribute={handleAppendAttribute}
                   handleDeleteAttribute={handleDeleteAttribute}
-                  handleChangeOrderAttribute={handleChangeOrderAttribute}
                   control={control}
                   setValue={setValue}
-                  maxIndex={0}
                 />
               </TableRow>
             )}
-          </>
-        </StyledTableBody>
-      </Table>
+          </StyledTableBody>
+        </Table>
+      </DndContext>
     </>
   );
 };

--- a/frontend/src/pages/__snapshots__/EntityEditPage.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/EntityEditPage.test.tsx.snap
@@ -530,6 +530,13 @@ exports[`EditEntityPage should match snapshot 1`] = `
                 <th
                   class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-8816du-MuiTableCell-root"
                   scope="col"
+                  width="100px"
+                >
+                  並び替え
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-8816du-MuiTableCell-root"
+                  scope="col"
                   width="300px"
                 >
                   属性名
@@ -547,13 +554,6 @@ exports[`EditEntityPage should match snapshot 1`] = `
                   width="200px"
                 >
                   デフォルト値
-                </th>
-                <th
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-8816du-MuiTableCell-root"
-                  scope="col"
-                  width="100px"
-                >
-                  並び替え
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-8816du-MuiTableCell-root"
@@ -627,6 +627,23 @@ exports[`EditEntityPage should match snapshot 1`] = `
               </tr>
             </tbody>
           </table>
+          <div
+            id="DndDescribedBy-0"
+            style="display: none;"
+          >
+            
+    To pick up a draggable item, press the space bar.
+    While dragging, use the arrow keys to move the item.
+    Press space again to drop the item in its new position, or press escape to cancel.
+  
+          </div>
+          <div
+            aria-atomic="true"
+            aria-live="assertive"
+            id="DndLiveRegion-0"
+            role="status"
+            style="position: fixed; top: 0px; left: 0px; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%); white-space: nowrap;"
+          />
           <h4
             class="MuiTypography-root MuiTypography-h4 MuiTypography-alignCenter css-1ulnhey-MuiTypography-root"
             style="--Typography-textAlign: center;"
@@ -1378,6 +1395,13 @@ exports[`EditEntityPage should match snapshot 1`] = `
               <th
                 class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-8816du-MuiTableCell-root"
                 scope="col"
+                width="100px"
+              >
+                並び替え
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-8816du-MuiTableCell-root"
+                scope="col"
                 width="300px"
               >
                 属性名
@@ -1395,13 +1419,6 @@ exports[`EditEntityPage should match snapshot 1`] = `
                 width="200px"
               >
                 デフォルト値
-              </th>
-              <th
-                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-8816du-MuiTableCell-root"
-                scope="col"
-                width="100px"
-              >
-                並び替え
               </th>
               <th
                 class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-8816du-MuiTableCell-root"
@@ -1475,6 +1492,23 @@ exports[`EditEntityPage should match snapshot 1`] = `
             </tr>
           </tbody>
         </table>
+        <div
+          id="DndDescribedBy-0"
+          style="display: none;"
+        >
+          
+    To pick up a draggable item, press the space bar.
+    While dragging, use the arrow keys to move the item.
+    Press space again to drop the item in its new position, or press escape to cancel.
+  
+        </div>
+        <div
+          aria-atomic="true"
+          aria-live="assertive"
+          id="DndLiveRegion-0"
+          role="status"
+          style="position: fixed; top: 0px; left: 0px; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%); white-space: nowrap;"
+        />
         <h4
           class="MuiTypography-root MuiTypography-h4 MuiTypography-alignCenter css-1ulnhey-MuiTypography-root"
           style="--Typography-textAlign: center;"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,10 @@
       "hasInstallScript": true,
       "license": "GPLv2",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "react-router": "^7.15.1",
         "swr": "^2.4.0"
       },
@@ -2312,6 +2316,73 @@
       "integrity": "sha512-2QoHbJyz9QLONRz4ojAn6MZb7BdwqnkxtNQfHjJt9wSc/qj9H1JwlGgO4g0gpzL62MsfEIyXUEl5MazcaEsZhg==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -14088,9 +14159,7 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -16427,6 +16496,50 @@
       "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.29.1/13890fa187f6fbe3316c6477123b28b5ac00a3fd",
       "integrity": "sha512-2QoHbJyz9QLONRz4ojAn6MZb7BdwqnkxtNQfHjJt9wSc/qj9H1JwlGgO4g0gpzL62MsfEIyXUEl5MazcaEsZhg==",
       "optional": true
+    },
+    "@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "requires": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "requires": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "requires": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
     },
     "@emnapi/core": {
       "version": "1.8.1",
@@ -24797,9 +24910,7 @@
     "tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,10 @@
     "@dmm-com/airone-apiclient-typescript-fetch": "^0.29.1"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "react-router": "^7.15.1",
     "swr": "^2.4.0"
   }


### PR DESCRIPTION
Migrate the entity attribute list reordering UX from up/down arrow buttons to drag-and-drop using @dnd-kit. Each row now exposes a grab handle in a dedicated column; rows can be reordered by pointer drag or keyboard (Space to lift, arrows to move, Space to drop), preserving accessibility.