### PR TITLE
Fix N+1 queries and redundant COUNT in job list API

### DIFF
--- a/job/api_v2/views.py
+++ b/job/api_v2/views.py
@@ -284,15 +284,26 @@ class JobListAPI(viewsets.ModelViewSet[Job]):
         if target_id:
             query &= Q(target=target_id)
 
-        return Job.objects.filter(query).select_related("target").order_by("-created_at")
+        return (
+            Job.objects.filter(query)
+            .select_related("user", "target")
+            .order_by("-id")
+        )
+
+    def paginate_queryset(self, queryset: Any) -> Any:
+        page = super().paginate_queryset(queryset)
+        self._paginated_page = page
+        return page
 
     def get_serializer_context(self) -> dict[str, Any]:
         context: dict[str, Any] = dict(super().get_serializer_context())
 
         # prefetch target entries, then pass it via context manually to avoid N+1 in serializer
-        qs = self.paginate_queryset(self.get_queryset().values("target__id", "target__objtype"))
+        page: list[Job] = getattr(self, "_paginated_page", None) or []
         target_ids = [
-            int(r["target__id"]) for r in (qs or []) if r["target__objtype"] == ACLObjType.Entry
+            obj.target.id
+            for obj in page
+            if obj.target is not None and obj.target.objtype == ACLObjType.Entry
         ]
         entries = (
             Entry.objects.filter(id__in=target_ids)

--- a/job/api_v2/views.py
+++ b/job/api_v2/views.py
@@ -284,11 +284,7 @@ class JobListAPI(viewsets.ModelViewSet[Job]):
         if target_id:
             query &= Q(target=target_id)
 
-        return (
-            Job.objects.filter(query)
-            .select_related("user", "target")
-            .order_by("-id")
-        )
+        return Job.objects.filter(query).select_related("user", "target").order_by("-id")
 
     def paginate_queryset(self, queryset: Any) -> Any:
         page = super().paginate_queryset(queryset)

--- a/job/models.py
+++ b/job/models.py
@@ -228,9 +228,10 @@ class Job(models.Model):
         else:
             return False
 
-    def is_timeout(self) -> bool:
-        # Sync updated_at time information with the data which is stored in database
-        self.refresh_from_db(fields=["updated_at"])
+    def is_timeout(self, with_refresh: bool = True) -> bool:
+        if with_refresh:
+            # Sync updated_at time information with the data which is stored in database
+            self.refresh_from_db(fields=["updated_at"])
 
         task_expiry = self.updated_at + timedelta(seconds=self._get_job_timeout())
 
@@ -250,7 +251,7 @@ class Job(models.Model):
             JobStatus.WARNING,
         ]
 
-        return self.status in finished_status or self.is_timeout()
+        return self.status in finished_status or self.is_timeout(with_refresh=with_refresh)
 
     def is_canceled(self) -> bool:
         # Sync status flag information with the data which is stored in database


### PR DESCRIPTION
## Summary
- Investigated why `/job/api/v2/jobs` was extremely slow against a production-scale
  DB (job_job table with ~5.4M rows) and fixed the root causes
- `Job.is_timeout()` ignored `with_refresh=False` and always called
  `refresh_from_db()`, causing one extra query per unfinished job in the list
- `JobListAPI.get_serializer_context()` re-ran `get_queryset()` +
  `paginate_queryset()` just to prefetch target entries, executing the
  pagination COUNT query twice per request; now reuses the already-paginated
  page (target is already `select_related()`) instead
- Added `select_related("user")` to avoid a per-row query from the `user`
  SlugRelatedField
- Changed `order_by("-created_at")` to `order_by("-id")`: `created_at` had no
  usable index and the ORDER BY was causing a full table scan + filesort;
  `id` is the PRIMARY KEY, so the existing index already satisfies the
  ordering, confirmed via `EXPLAIN ANALYZE` (no new index needed)

## Note
- The pagination `COUNT(*)` itself is still a full scan because the filter's
  OR conditions on `operation` are low-selectivity, and deep pages remain
  slow due to inherent OFFSET pagination cost. Both are left out of scope
  since real usage rarely reaches deep pages or needs an exact count beyond
  display purposes; keyset pagination or an async counter table would be the
  next step if that changes

## Test plan
- `uv run python manage.py test job.tests.test_api_v2`
- `uv run ruff check job/models.py job/api_v2/views.py`
- `uv run mypy job/models.py job/api_v2/views.py --config-file=pyproject.toml`
- Verified response time against a production-scale DB for
  `/job/api/v2/jobs?all_users=true&limit=30&offset=0` (14s → ~4.4s)
