### PR TITLE
Fix: TypeError when boolean is passed to attrinfo.keyword in entry search API

### DIFF
--- a/api_v1/entry/views.py
+++ b/api_v1/entry/views.py
@@ -48,6 +48,8 @@ class EntrySearchAPIRequest(BaseModel):
     @field_validator("attrinfo")
     def validate_attrinfo_keyword_length(cls, v: list[Any]) -> list[Any]:
         for item in v:
+            if isinstance(item["keyword"], bool):
+                item["keyword"] = str(item["keyword"])
             if isinstance(item, dict) and "keyword" in item and item["keyword"]:
                 if len(item["keyword"]) > CONFIG_ENTRY.MAX_QUERY_SIZE:
                     raise ValueError("Keyword length exceeds maximum allowed size")

--- a/api_v1/entry/views.py
+++ b/api_v1/entry/views.py
@@ -48,9 +48,9 @@ class EntrySearchAPIRequest(BaseModel):
     @field_validator("attrinfo")
     def validate_attrinfo_keyword_length(cls, v: list[Any]) -> list[Any]:
         for item in v:
-            if isinstance(item["keyword"], bool):
-                item["keyword"] = str(item["keyword"])
-            if isinstance(item, dict) and "keyword" in item and item["keyword"]:
+            if isinstance(item, dict) and "keyword" in item and item["keyword"] is not None:
+                if isinstance(item["keyword"], bool):
+                    item["keyword"] = str(item["keyword"])
                 if len(item["keyword"]) > CONFIG_ENTRY.MAX_QUERY_SIZE:
                     raise ValueError("Keyword length exceeds maximum allowed size")
         return v

--- a/api_v1/tests/entry/test_api.py
+++ b/api_v1/tests/entry/test_api.py
@@ -519,3 +519,43 @@ class APITest(AironeViewTest):
             self.assertEqual(
                 resp.json()["result"]["ret_values"][0]["attrs"]["boolean"]["value"], value
             )
+
+    def test_search_with_boolean_keyword(self):
+        user = self.guest_login()
+
+        test_entity = self.create_entity(
+            user,
+            "TestEntity",
+            attrs=[
+                {
+                    "name": "text_attr",
+                    "type": AttrType.STRING,
+                }
+            ],
+        )
+
+        for keyword_value, matching_value, unmatching_value in [
+            (True, "True", "False"),
+            (False, "False", "True"),
+        ]:
+            entry = self.add_entry(
+                user, "Entry-%s" % keyword_value, test_entity, values={"text_attr": matching_value}
+            )
+            self.add_entry(
+                user,
+                "UnmatchedEntry-%s" % keyword_value,
+                test_entity,
+                values={"text_attr": unmatching_value},
+            )
+
+            params = {
+                "entities": [test_entity.id],
+                "attrinfo": [{"name": "text_attr", "keyword": keyword_value}],
+            }
+            resp = self.client.post("/api/v1/entry/search", json.dumps(params), "application/json")
+            self.assertEqual(resp.status_code, 200)
+
+            ret_values = resp.json()["result"]["ret_values"]
+            self.assertEqual(len(ret_values), 1)
+            self.assertEqual(ret_values[0]["entry"]["id"], entry.id)
+            self.assertEqual(ret_values[0]["attrs"]["text_attr"]["value"], matching_value)

--- a/api_v1/tests/entry/test_api.py
+++ b/api_v1/tests/entry/test_api.py
@@ -523,21 +523,21 @@ class APITest(AironeViewTest):
     def test_search_with_boolean_keyword(self):
         user = self.guest_login()
 
-        test_entity = self.create_entity(
-            user,
-            "TestEntity",
-            attrs=[
-                {
-                    "name": "text_attr",
-                    "type": AttrType.STRING,
-                }
-            ],
-        )
-
         for keyword_value, matching_value, unmatching_value in [
             (True, "True", "False"),
             (False, "False", "True"),
         ]:
+            test_entity = self.create_entity(
+                user,
+                "TestEntity-%s" % keyword_value,
+                attrs=[
+                    {
+                        "name": "text_attr",
+                        "type": AttrType.STRING,
+                    }
+                ],
+            )
+
             entry = self.add_entry(
                 user, "Entry-%s" % keyword_value, test_entity, values={"text_attr": matching_value}
             )


### PR DESCRIPTION
EntrySearchAPIRequest.validate_attrinfo_keyword_length in api_v1/entry/views.py called len(item["keyword"]) directly. When a client sent a JSON boolean (e.g. "keyword": true or "keyword": false) instead of a string, this raised TypeError: object of type 'bool' has no len() for true, and for false it bypassed the length check entirely but then failed downstream when AttrHint(keyword=False) was constructed, since pydantic v2 does not coerce bool to str, resulting in a generic "The type of parameter 'attrinfo' is incorrect" response.

The validator now converts a boolean keyword value to its string representation (True/False) before the length check, so both truthy and falsy boolean inputs are handled consistently and no longer raise an unhandled exception or an incorrect error response.

issue: https://github.com/dmm-com/airone/issues/3606