### PR TITLE
Fix MySQL option spacing in clear_and_initdb

### DIFF
--- a/tools/clear_and_initdb.sh
+++ b/tools/clear_and_initdb.sh
@@ -59,10 +59,10 @@ main() {
 
   if [ ${IS_BAREMETAL} = "true" ]
   then
-    MYSQL_COMMAND="mysql --skip-ssl　-u${db_user} -p${db_pass} -h${db_host}"
-    MYSQL_ROOT_COMMAND="mysql --skip-ssl　-uroot ${root_pass_opt} -h${db_host}"
+    MYSQL_COMMAND="mysql --skip-ssl -u${db_user} -p${db_pass} -h${db_host}"
+    MYSQL_ROOT_COMMAND="mysql --skip-ssl -uroot ${root_pass_opt} -h${db_host}"
   else
-    MYSQL_COMMAND="sudo docker exec -i mysql mysql --skip-ssl　-uroot ${root_pass_opt}"
+    MYSQL_COMMAND="sudo docker exec -i mysql mysql --skip-ssl -uroot ${root_pass_opt}"
     MYSQL_ROOT_COMMAND="${MYSQL_COMMAND}"
   fi
 


### PR DESCRIPTION
## Summary
- Replace full-width spaces between `--skip-ssl` and MySQL user options with normal spaces in `tools/clear_and_initdb.sh`
- Prevent `mysql: unknown option '--skip-ssl　-uroot'` during DB initialization

## Verification
- `bash -n tools/clear_and_initdb.sh`