### PR TITLE
Show belonging groups and roles on the user detail screen

### DIFF
--- a/frontend/src/components/user/ChangeUserAuthModal.test.tsx
+++ b/frontend/src/components/user/ChangeUserAuthModal.test.tsx
@@ -26,6 +26,8 @@ describe("ChangeUserAuthModal", () => {
       created: "",
     },
     authenticateType: UserRetrieveAuthenticateTypeEnum.AUTH_TYPE_LOCAL,
+    groups: [],
+    roles: [],
   };
 
   test("should render a component essentially", async () => {

--- a/frontend/src/components/user/UserForm.test.tsx
+++ b/frontend/src/components/user/UserForm.test.tsx
@@ -2,7 +2,10 @@
  * @jest-environment jsdom
  */
 
-import { UserRetrieveAuthenticateTypeEnum } from "@dmm-com/airone-apiclient-typescript-fetch";
+import {
+  UserRetrieve,
+  UserRetrieveAuthenticateTypeEnum,
+} from "@dmm-com/airone-apiclient-typescript-fetch";
 import { zodResolver } from "@hookform/resolvers/zod/dist/zod";
 import { render, renderHook, screen } from "@testing-library/react";
 import { useForm } from "react-hook-form";
@@ -38,9 +41,11 @@ describe("UserForm", () => {
       created: "",
     },
     authenticateType: UserRetrieveAuthenticateTypeEnum.AUTH_TYPE_LOCAL,
+    groups: [],
+    roles: [],
   };
 
-  test("should provide user editor", function () {
+  const renderUserForm = (user: UserRetrieve, isCreateMode: boolean) => {
     const {
       result: {
         current: { control },
@@ -49,15 +54,15 @@ describe("UserForm", () => {
       useForm<Schema>({
         resolver: zodResolver(schema),
         mode: "onBlur",
-        defaultValues: userInfo,
+        defaultValues: user,
       }),
     );
 
     render(
       <UserForm
-        user={userInfo}
+        user={user}
         control={control}
-        isCreateMode={true}
+        isCreateMode={isCreateMode}
         isMyself={false}
         isSubmittable={false}
         isCoUser={false}
@@ -68,6 +73,10 @@ describe("UserForm", () => {
       />,
       { wrapper: TestWrapper },
     );
+  };
+
+  test("should provide user editor", function () {
+    renderUserForm(userInfo, true);
 
     expect(
       screen.getByPlaceholderText("ユーザ名を入力してください"),
@@ -76,5 +85,81 @@ describe("UserForm", () => {
       screen.getByPlaceholderText("パスワードを入力してください"),
     ).toHaveValue("user1");
     expect(screen.getByText("user1-")).toBeInTheDocument();
+  });
+
+  test("should not show belonging groups and roles on creating a user", function () {
+    renderUserForm(userInfo, true);
+
+    expect(screen.queryByText("所属グループ")).not.toBeInTheDocument();
+    expect(screen.queryByText("所属ロール")).not.toBeInTheDocument();
+  });
+
+  test("should show belonging groups and roles", function () {
+    renderUserForm(
+      {
+        ...userInfo,
+        groups: [
+          { id: 10, name: "child_group", isDirect: true },
+          { id: 11, name: "parent_group", isDirect: false },
+        ],
+        roles: [
+          {
+            id: 20,
+            name: "direct_role",
+            isDirect: true,
+            isAdmin: false,
+            viaGroups: [],
+          },
+          {
+            id: 21,
+            name: "group_role",
+            isDirect: false,
+            isAdmin: false,
+            viaGroups: [{ id: 10, name: "child_group" }],
+          },
+          {
+            id: 22,
+            name: "admin_role",
+            isDirect: false,
+            isAdmin: true,
+            viaGroups: [{ id: 11, name: "parent_group" }],
+          },
+        ],
+      },
+      false,
+    );
+
+    // a Chip renders its label in an inner element, so the link is its ancestor
+    const linkOf = (label: string) => screen.getByText(label).closest("a");
+
+    expect(screen.getByText("所属グループ")).toBeInTheDocument();
+    expect(linkOf("child_group")).toHaveAttribute("href", "/ui/groups/10");
+    // an inherited group is annotated so that it's distinguishable
+    expect(linkOf("parent_group (継承)")).toHaveAttribute(
+      "href",
+      "/ui/groups/11",
+    );
+
+    expect(screen.getByText("所属ロール")).toBeInTheDocument();
+    expect(linkOf("direct_role")).toHaveAttribute("href", "/ui/roles/20");
+    expect(linkOf("group_role (child_group 経由)")).toHaveAttribute(
+      "href",
+      "/ui/roles/21",
+    );
+    expect(linkOf("admin_role (管理 / parent_group 経由)")).toHaveAttribute(
+      "href",
+      "/ui/roles/22",
+    );
+  });
+
+  test("should show placeholders when the user belongs to nothing", function () {
+    renderUserForm({ ...userInfo, groups: [], roles: [] }, false);
+
+    expect(
+      screen.getByText("所属しているグループはありません"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("所属しているロールはありません"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/user/UserForm.tsx
+++ b/frontend/src/components/user/UserForm.tsx
@@ -1,12 +1,14 @@
 import {
   UserRetrieve,
   UserRetrieveAuthenticateTypeEnum,
+  UserRole,
 } from "@dmm-com/airone-apiclient-typescript-fetch";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import {
   Box,
   Button,
   Checkbox,
+  Chip,
   IconButton,
   InputAdornment,
   Paper,
@@ -34,7 +36,9 @@ import { Control, Controller, useWatch } from "react-hook-form";
 import { ChangeUserAuthModal } from "./ChangeUserAuthModal";
 import { Schema } from "./userForm/UserFormSchema";
 
+import { AironeLink } from "components/common/AironeLink";
 import { FlexBox } from "components/common/FlexBox";
+import { groupPath, rolePath } from "routes/Routes";
 import { ServerContext } from "services/ServerContext";
 import { User } from "services/ServerContext";
 
@@ -45,6 +49,18 @@ const StyledTableRow = styled(TableRow)(() => ({
   "&:last-child td, &:last-child th": {
     border: 0,
   },
+}));
+
+const ChipBox = styled(Box)(({ theme }) => ({
+  display: "flex",
+  flexWrap: "wrap",
+  gap: theme.spacing(0.5),
+  margin: theme.spacing(1),
+}));
+
+const EmptyMessage = styled(Typography)(({ theme }) => ({
+  margin: theme.spacing(1),
+  color: theme.palette.text.secondary,
 }));
 
 interface Props {
@@ -310,6 +326,80 @@ const ElemUserName: FC<Props & { isMyself: boolean; isCoUser: boolean }> = ({
   );
 };
 
+const ElemGroups: FC<ReadonlyProps> = ({ user }) => {
+  return (
+    <StyledTableRow>
+      <TableCell sx={{ width: "400px", wordBreak: "break-word" }}>
+        所属グループ
+      </TableCell>
+      <TableCell sx={{ width: "750px", p: "0px", wordBreak: "break-word" }}>
+        {user.groups.length > 0 ? (
+          <ChipBox>
+            {user.groups.map((group) => (
+              <Chip
+                key={group.id}
+                label={group.isDirect ? group.name : `${group.name} (継承)`}
+                size="small"
+                variant={group.isDirect ? "filled" : "outlined"}
+                component={AironeLink}
+                to={groupPath(group.id)}
+                clickable
+              />
+            ))}
+          </ChipBox>
+        ) : (
+          <EmptyMessage>所属しているグループはありません</EmptyMessage>
+        )}
+      </TableCell>
+    </StyledTableRow>
+  );
+};
+
+/**
+ * Builds a chip label that tells why the user belongs to the role, because a
+ * role can be granted through a group instead of being assigned directly.
+ */
+const getRoleLabel = (role: UserRole): string => {
+  const notes: string[] = [];
+  if (role.isAdmin) {
+    notes.push("管理");
+  }
+  if (!role.isDirect && role.viaGroups.length > 0) {
+    notes.push(`${role.viaGroups.map((g) => g.name).join(", ")} 経由`);
+  }
+
+  return notes.length > 0 ? `${role.name} (${notes.join(" / ")})` : role.name;
+};
+
+const ElemRoles: FC<ReadonlyProps> = ({ user }) => {
+  return (
+    <StyledTableRow>
+      <TableCell sx={{ width: "400px", wordBreak: "break-word" }}>
+        所属ロール
+      </TableCell>
+      <TableCell sx={{ width: "750px", p: "0px", wordBreak: "break-word" }}>
+        {user.roles.length > 0 ? (
+          <ChipBox>
+            {user.roles.map((role) => (
+              <Chip
+                key={role.id}
+                label={getRoleLabel(role)}
+                size="small"
+                variant={role.isDirect ? "filled" : "outlined"}
+                component={AironeLink}
+                to={rolePath(role.id)}
+                clickable
+              />
+            ))}
+          </ChipBox>
+        ) : (
+          <EmptyMessage>所属しているロールはありません</EmptyMessage>
+        )}
+      </TableCell>
+    </StyledTableRow>
+  );
+};
+
 const ElemUserPassword: FC<Props> = ({ control }) => {
   return (
     <StyledTableRow>
@@ -421,6 +511,13 @@ export const UserForm: FC<UserFormProps> = ({
               isMyself={isMyself}
               isCoUser={isCoUser}
             />
+
+            {!isCreateMode && user != null && (
+              <>
+                <ElemGroups user={user} />
+                <ElemRoles user={user} />
+              </>
+            )}
 
             {loginUser?.isSuperuser && (
               <>

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "zod": "^3.24.2"
       },
       "optionalDependencies": {
-        "@dmm-com/airone-apiclient-typescript-fetch": "^0.29.1"
+        "@dmm-com/airone-apiclient-typescript-fetch": "^0.29.3"
       },
       "peerDependencies": {
         "@mui/material": "^6.0.0",
@@ -2311,9 +2311,9 @@
       }
     },
     "node_modules/@dmm-com/airone-apiclient-typescript-fetch": {
-      "version": "0.29.1",
-      "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.29.1/13890fa187f6fbe3316c6477123b28b5ac00a3fd",
-      "integrity": "sha512-2QoHbJyz9QLONRz4ojAn6MZb7BdwqnkxtNQfHjJt9wSc/qj9H1JwlGgO4g0gpzL62MsfEIyXUEl5MazcaEsZhg==",
+      "version": "0.29.3",
+      "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.29.3/be676cb7a3093fbd2437bd6f47d8d821e3de4aa2",
+      "integrity": "sha512-nsmmy8ArwTnYSxkhoLm9OJ+kyMxNVSPm9TRfG7VM+XINMfvKVqr1EBWY7NAJUlek2j+6xt5kspR9WWauQGj+cA==",
       "license": "ISC",
       "optional": true
     },
@@ -16492,9 +16492,9 @@
       "dev": true
     },
     "@dmm-com/airone-apiclient-typescript-fetch": {
-      "version": "0.29.1",
-      "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.29.1/13890fa187f6fbe3316c6477123b28b5ac00a3fd",
-      "integrity": "sha512-2QoHbJyz9QLONRz4ojAn6MZb7BdwqnkxtNQfHjJt9wSc/qj9H1JwlGgO4g0gpzL62MsfEIyXUEl5MazcaEsZhg==",
+      "version": "0.29.3",
+      "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.29.3/be676cb7a3093fbd2437bd6f47d8d821e3de4aa2",
+      "integrity": "sha512-nsmmy8ArwTnYSxkhoLm9OJ+kyMxNVSPm9TRfG7VM+XINMfvKVqr1EBWY7NAJUlek2j+6xt5kspR9WWauQGj+cA==",
       "optional": true
     },
     "@dnd-kit/accessibility": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "react-dom": "^19.2.0"
   },
   "optionalDependencies": {
-    "@dmm-com/airone-apiclient-typescript-fetch": "^0.29.1"
+    "@dmm-com/airone-apiclient-typescript-fetch": "^0.29.3"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary

Frontend part of showing the groups and roles a user belongs to on the user detail screen (`/ui/users/<id>`).

Follow-up to #1813, which added `groups` and `roles` to the user retrieve API. This PR bumps the API client to the published `0.29.3` and consumes those fields.

## Changes

### API client bump

- `package.json` — `optionalDependencies` range `^0.29.1` -> `^0.29.3`
- `package-lock.json` — regenerated for `0.29.3`

The dependency stays in `optionalDependencies`. `npm install <pkg>@<ver>` moves it to `dependencies` on its own, which would change `npm ci` behaviour and break local development without the published package, so the range was edited in place and the lock regenerated with `npm install --package-lock-only`.

### Two new rows on `UserForm`

`ElemGroups` and `ElemRoles` are added right after the name row, so the information is visible without scrolling past the token settings.

- Each chip links to the group / role detail screen via `groupPath()` / `rolePath()`
- Directly assigned groups and roles are filled chips
- A group inherited from a hierarchical superior group is an outlined chip labelled `<name> (継承)`
- A role granted through a group is an outlined chip labelled `<name> (<group> 経由)`
- A role the user administrates is labelled `<name> (管理)`, combined as `<name> (管理 / <group> 経由)` when both apply
- A placeholder message is shown when the user belongs to nothing
- The rows are hidden while creating a user, where there is nothing to show yet

The rows are read only. Editing stays in `GroupEditPage` / `RoleEditPage`, so there is a single place that owns the membership.

Visibility is unchanged: this screen is already restricted to superusers, the user themselves, and their parent user by `UserPermission` on the backend.

### Test fixture update

`ChangeUserAuthModal.test.tsx` builds a `UserRetrieve` literal with a type annotation, so it needs the new required fields to compile against `0.29.3`. This is why the frontend change could not be included in #1813, where the client was still `0.29.1`.

## Tests

`UserForm.test.tsx`

- `should not show belonging groups and roles on creating a user`
- `should show belonging groups and roles` — chip labels and the link target of each chip, covering an inherited group, a group-granted role and an administrative role
- `should show placeholders when the user belongs to nothing`

The existing `should provide user editor` test is unchanged in behaviour; the duplicated render setup was factored into a `renderUserForm` helper.

### Verified locally

- `npx eslint frontend e2e` — 0 errors (33 pre-existing warnings)
- `npx biome format` — clean on the changed files
- `npx knip` — clean
- `npm run test` — 148 suites / 810 tests pass, coverage above every threshold (statements 76.92% / branches 56.47% / functions 60.35% / lines 76.28%)
- `webpack build --entry ./frontend/src/App.tsx --mode development` and `npm run build:lib` (including `tsc --project tsconfig.lib.json`) both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
