### PR TITLE
delete v1 rerun

### DIFF
--- a/api_v1/job/urls.py
+++ b/api_v1/job/urls.py
@@ -4,6 +4,5 @@ from . import views
 
 urlpatterns = [
     re_path(r"^$", views.JobAPI.as_view()),
-    re_path(r"^run/(\d+)$", views.SpecificJobAPI.as_view()),
     re_path(r"^search$", views.SearchJob.as_view()),
 ]

--- a/api_v1/job/views.py
+++ b/api_v1/job/views.py
@@ -86,6 +86,7 @@ class JobAPI(APIView):
 
         return Response("Success to cancel job")
 
+
 class SearchJobResponse(BaseModel):
     class Job(BaseModel):
         id: int

--- a/api_v1/job/views.py
+++ b/api_v1/job/views.py
@@ -86,34 +86,6 @@ class JobAPI(APIView):
 
         return Response("Success to cancel job")
 
-
-class SpecificJobAPI(APIView):
-    def post(self, request: Request, job_id: int, format: str | None = None) -> Response:
-        job = Job.objects.filter(id=job_id).first()
-        if not job:
-            return Response(
-                "Failed to find Job(id=%s)" % job_id, status=status.HTTP_400_BAD_REQUEST
-            )
-
-        # check job status before starting processing
-        if job.status == JobStatus.DONE:
-            return Response("Target job has already been done")
-        elif job.status == JobStatus.PROCESSING:
-            return Response("Target job is under processing", status=status.HTTP_400_BAD_REQUEST)
-
-        # check job target status
-        if not job.target or not job.target.is_active:
-            return Response(
-                "Job target has already been deleted",
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        # Run job on an Application node
-        job.run(will_delay=False)
-
-        return Response("Success to run command")
-
-
 class SearchJobResponse(BaseModel):
     class Job(BaseModel):
         id: int

--- a/api_v1/tests/job/test_api.py
+++ b/api_v1/tests/job/test_api.py
@@ -2,8 +2,7 @@ import json
 from datetime import timedelta
 
 from airone.lib.test import AironeViewTest
-from airone.lib.types import AttrType
-from entity.models import Entity, EntityAttr
+from entity.models import Entity
 from entry.models import Entry
 from job.models import Job, JobOperation, JobStatus
 from job.settings import CONFIG
@@ -84,109 +83,6 @@ class APITest(AironeViewTest):
         resp = self.client.get("/api/v1/job/")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.json()["result"]), 0)
-
-    def test_rerun_jobs(self):
-        user = self.guest_login()
-
-        entity = Entity.objects.create(name="entity", created_user=user)
-        attr = EntityAttr.objects.create(
-            name="attr",
-            created_user=user,
-            type=AttrType.STRING,
-            parent_entity=entity,
-        )
-
-        # make a job to create an entry
-        entry = Entry.objects.create(name="entry", schema=entity, created_user=user)
-        job = Job.new_create(
-            user,
-            entry,
-            params={
-                "attrs": [
-                    {
-                        "id": str(attr.id),
-                        "value": [{"data": "hoge", "index": 0}],
-                        "referral_key": [],
-                    }
-                ]
-            },
-        )
-
-        # send request to run job
-        resp = self.client.post("/api/v1/job/run/%d" % job.id)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.content, b'"Success to run command"')
-
-        job = Job.objects.get(id=job.id)
-        self.assertEqual(job.status, JobStatus.DONE)
-        self.assertEqual(entry.attrs.count(), 1)
-
-        attrv = entry.attrs.first().get_latest_value()
-        self.assertEqual(attrv.value, "hoge")
-
-        # send request to run job with finished job-id
-        resp = self.client.post("/api/v1/job/run/%d" % job.id)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.content, b'"Target job has already been done"')
-
-        # send request to run job with invalid job-id
-        resp = self.client.post("/api/v1/job/run/%d" % 9999)
-        self.assertEqual(resp.status_code, 400)
-
-        # make and send a job to update entry
-        job = Job.new_edit(
-            user,
-            entry,
-            params={
-                "attrs": [
-                    {
-                        "id": str(entry.attrs.first().id),
-                        "value": [{"data": "fuga", "index": 0}],
-                        "referral_key": [],
-                    }
-                ]
-            },
-        )
-        resp = self.client.post("/api/v1/job/run/%d" % job.id)
-
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.content, b'"Success to run command"')
-        self.assertEqual(Job.objects.get(id=job.id).status, JobStatus.DONE)
-        self.assertEqual(entry.attrs.first().get_latest_value().value, "fuga")
-
-        # make and send a job to copy entry
-        job = Job.new_do_copy(user, entry, params={"new_name": "new_entry"})
-        resp = self.client.post("/api/v1/job/run/%d" % job.id)
-
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.content, b'"Success to run command"')
-        self.assertEqual(Job.objects.get(id=job.id).status, JobStatus.DONE)
-
-        # checks it's success to clone entry
-        new_entry = Entry.objects.get(name="new_entry", schema=entity)
-        self.assertEqual(new_entry.attrs.first().get_latest_value().value, "fuga")
-
-        # make and send a job to delete entry
-        job = Job.new_delete(user, entry)
-        resp = self.client.post("/api/v1/job/run/%d" % job.id)
-
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.content, b'"Success to run command"')
-        self.assertFalse(Entry.objects.get(id=entry.id).is_active)
-
-    def test_rerun_deleted_job(self):
-        user = self.guest_login()
-
-        entity = Entity.objects.create(name="entity", created_user=user)
-        entry = Entry.objects.create(name="entry", created_user=user, schema=entity)
-        job = Job.new_create(user, entry)
-
-        # delete target entry
-        entry.delete()
-
-        resp = self.client.post("/api/v1/job/run/%d" % job.id)
-        self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.content, b'"Job target has already been deleted"')
 
     def test_get_search_job(self):
         user = self.guest_login()

--- a/job/tests/test_view.py
+++ b/job/tests/test_view.py
@@ -1,4 +1,3 @@
-
 from requests_html import HTML
 
 from airone.lib.test import AironeViewTest

--- a/job/tests/test_view.py
+++ b/job/tests/test_view.py
@@ -1,14 +1,10 @@
-import json
-from unittest.mock import Mock, patch
 
-from django.urls import reverse
 from requests_html import HTML
 
 from airone.lib.test import AironeViewTest
 from entity.models import Entity
-from entry import tasks
 from entry.models import Entry
-from job.models import Job, JobOperation, JobStatus
+from job.models import Job, JobOperation
 from job.settings import CONFIG
 
 # constants using this tests
@@ -128,40 +124,6 @@ class ViewTest(AironeViewTest):
         resp = self.client.get("/job/")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.context["jobs"]), 2)
-
-    @patch(
-        "entry.tasks.create_entry_attrs.delay",
-        Mock(side_effect=tasks.create_entry_attrs),
-    )
-    def test_rerun_job_which_is_under_processing(self):
-        # send a request to re-run creating entry which is under processing
-        user = self.guest_login()
-
-        entity = Entity.objects.create(name="entity", created_user=user)
-
-        params = {
-            "entry_name": "new_entry",
-            "attrs": [],
-        }
-
-        def side_effect():
-            # send re-run request for executing job by calling API
-            job = Job.objects.last()
-            self.assertEqual(job.status, JobStatus.PROCESSING)
-
-            # check that backend processing never run by calling API
-            resp = self.client.post("/api/v1/job/run/%d" % job.id)
-            self.assertEqual(resp.status_code, 400)
-            self.assertEqual(resp.content, b'"Target job is under processing"')
-
-        with patch.object(Entry, "register_es", Mock(side_effect=side_effect)):
-            resp = self.client.post(
-                reverse("entry:do_create", args=[entity.id]),
-                json.dumps(params),
-                "application/json",
-            )
-
-            self.assertEqual(resp.status_code, 200)
 
     def test_job_download_failure(self):
         user = self.guest_login()

--- a/templates/list_jobs.html
+++ b/templates/list_jobs.html
@@ -150,12 +150,7 @@
             {% endif %}
             </td>
 
-            <!-- set re-run button if it's under executing -->
             <td class='operations'>
-              {% if job.status != JOB.STATUS.DONE and job.status != JOB.STATUS.PROCESSING and job.status != JOB.STATUS.CANCELED %}
-              <p><button type='button' class='btn btn-info btn-sm rerun-job' value='{{ job.id }}'>Re-run</button></p>
-              {% endif %}
-
               {% if job.status != JOB.STATUS.DONE and job.status != JOB.STATUS.CANCELED %}
               <p><button type='button' class='btn btn-danger btn-sm cancel-job' value='{{ job.id }}' {% if not job.can_cancel %}disabled=True{% endif %}>Cancel</button></p>
               {% endif %}
@@ -173,20 +168,6 @@
 {% block script %}
 <script>
 $(document).ready(function() {
-
-  $('.rerun-job').on('click', function(e) {
-    $(this).prop("disabled", true);
-
-    $.ajax({
-      type: 'POST',
-      url: `/api/v1/job/run/${$(this).val()}`,
-    }).done(function(data) {
-      location.reload();
-    }).fail(function(data) {
-      MessageBox.error(data);
-    });
-  });
-
   $('.cancel-job').on('click', function(e) {
     if(window.confirm('ジョブをキャンセルしますか？')) {
       $.ajax({


### PR DESCRIPTION
issue: https://github.com/dmm-com/airone/issues/3611
## Summary

Remove the job rerun API tests and related rerun coverage from the test suite.

## Background

This change is part of the effort to remove the rerun feature from the UI.  
The rerun endpoint is not used for initial job execution, so the rerun-specific test coverage can be removed without affecting normal create/edit flows.

## Changes

- Removed rerun-related tests from `api_v1/tests/job/test_api.py`
- Removed rerun-related tests from `job/tests/test_view.py`
- Cleaned up unused imports and leftover test code after test removal
- Verified Python lint passes with `uv run ruff check .`