### PR TITLE
Allow mypy ratchet CLI output in Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,10 @@ extend-exclude = ["./*/migrations", "manage.py", "./node_modules"]
 [tool.ruff.lint.per-file-ignores]
 "./airone/tests/test_elasticsearch.py" = ["E501"]
 # Command-line helpers whose stdout is the interface: generate_testdata.py
-# reports progress, and devmode.py is run by tools/lite.sh as
-# `airone/lib/devmode.py --env` with its output consumed by the shell.
+# and mypy_ratchet.py report progress, and devmode.py is run by tools/lite.sh
+# as `airone/lib/devmode.py --env` with its output consumed by the shell.
 "./tools/generate_testdata.py" = ["T201"]
+"./tools/mypy_ratchet.py" = ["T201"]
 "./airone/lib/devmode.py" = ["T201"]
 # Fixtures emulating an out-of-tree custom_view directory. They are loaded by
 # file path via importlib (airone/lib/custom_view.py), so they are deliberately


### PR DESCRIPTION
## Summary
- Allow `tools/mypy_ratchet.py` to use `print` as a CLI reporting script
- Update the Ruff per-file ignore comment to include `mypy_ratchet.py`

## Verification
- `uv run ruff check --output-format=github tools/mypy_ratchet.py`
- Reproduced the `build-core.yml` staticchecks sequence in a clean temporary worktree:
  - `uv run python tools/mypy_ratchet.py --base-ref 0080eadcd8b50a89f341e0a6ea898da81b2f65fa`
  - `uv run ruff check --output-format=github .`
  - `uv run ruff format --check .`