### PR TITLE
add unprocessed mark

### DIFF
--- a/frontend/src/pages/EntryDetailsPage.tsx
+++ b/frontend/src/pages/EntryDetailsPage.tsx
@@ -128,7 +128,12 @@ const EntryDetailsContent: FC<Props> = ({
     <FlexBox>
       <EntryBreadcrumbs entry={entry} />
 
-      <PageHeader title={entry.name ?? ""} description="アイテム詳細">
+      <PageHeader
+        title={entry.name ?? ""}
+        description="アイテム詳細"
+        targetId={entryId}
+        hasOngoingProcess={entry.hasOngoingChanges}
+      >
         <ChipBox>
           <Stack direction="row" spacing={1}>
             {[

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "GPLv2",
       "dependencies": {
+        "@dmm-com/airone-apiclient-typescript-fetch": "^0.29.5",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -69,7 +70,7 @@
         "zod": "^3.24.2"
       },
       "optionalDependencies": {
-        "@dmm-com/airone-apiclient-typescript-fetch": "^0.29.3"
+        "@dmm-com/airone-apiclient-typescript-fetch": "^0.29.5"
       },
       "peerDependencies": {
         "@mui/material": "^6.0.0",
@@ -2159,9 +2160,9 @@
       }
     },
     "node_modules/@dmm-com/airone-apiclient-typescript-fetch": {
-      "version": "0.29.3",
-      "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.29.3/be676cb7a3093fbd2437bd6f47d8d821e3de4aa2",
-      "integrity": "sha512-nsmmy8ArwTnYSxkhoLm9OJ+kyMxNVSPm9TRfG7VM+XINMfvKVqr1EBWY7NAJUlek2j+6xt5kspR9WWauQGj+cA==",
+      "version": "0.29.5",
+      "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.29.5/45e47da3f85463bcbecd45db99fcc50fa074cf6d",
+      "integrity": "sha512-drXL2Jvlp5/GTmS3pAiI3B7AgTylsB6yRkedEQfai1tI14OjLZxoaTaEgidimA6MyjfHBykar/w2BKnv7m9NZw==",
       "license": "ISC",
       "optional": true
     },
@@ -15231,9 +15232,9 @@
       "dev": true
     },
     "@dmm-com/airone-apiclient-typescript-fetch": {
-      "version": "0.29.3",
-      "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.29.3/be676cb7a3093fbd2437bd6f47d8d821e3de4aa2",
-      "integrity": "sha512-nsmmy8ArwTnYSxkhoLm9OJ+kyMxNVSPm9TRfG7VM+XINMfvKVqr1EBWY7NAJUlek2j+6xt5kspR9WWauQGj+cA==",
+      "version": "0.29.5",
+      "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.29.5/45e47da3f85463bcbecd45db99fcc50fa074cf6d",
+      "integrity": "sha512-drXL2Jvlp5/GTmS3pAiI3B7AgTylsB6yRkedEQfai1tI14OjLZxoaTaEgidimA6MyjfHBykar/w2BKnv7m9NZw==",
       "optional": true
     },
     "@dnd-kit/accessibility": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "react-dom": "^19.2.0"
   },
   "optionalDependencies": {
-    "@dmm-com/airone-apiclient-typescript-fetch": "^0.29.3"
+    "@dmm-com/airone-apiclient-typescript-fetch": "^0.29.5"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Overview

Updated the frontend to display a reload indicator when an Entry has ongoing changes.

## Changes

- Added support for `has_ongoing_changes` in the Entry API response
- Displayed the existing reload icon on the Entry detail page when an update is in progress
- Connected `hasOngoingChanges` from `EntryRetrieve` to `PageHeader`
- Updated the generated TypeScript API client type definitions

## Behavior

The reload icon is displayed while an Entry update job is pending or being processed, including when the worker is stopped. The icon disappears after the update is completed.