### PR TITLE
Added a set-type method to prevent duplicates

### DIFF
--- a/frontend/src/components/entry/AdvancedSearchJoinModal.tsx
+++ b/frontend/src/components/entry/AdvancedSearchJoinModal.tsx
@@ -31,9 +31,9 @@ export const AdvancedSearchJoinModal: FC<Props> = ({
   const currentAttrInfo: AdvancedSearchJoinAttrInfo | undefined =
     joinAttrs.find((attr) => attr.name === targetAttrname);
 
-  const [selectedAttrNames, setSelectedAttrNames] = useState<Array<string>>(
-    [...new Set(currentAttrInfo?.attrinfo.map((attr) => attr.name) ?? [])],
-  );
+  const [selectedAttrNames, setSelectedAttrNames] = useState<Array<string>>([
+    ...new Set(currentAttrInfo?.attrinfo.map((attr) => attr.name) ?? []),
+  ]);
 
   const { data: referralAttrs } = usePagodaSWR(
     ["referralAttrs", targetEntityIds, searchAllEntities, targetAttrname],

--- a/frontend/src/components/entry/AdvancedSearchJoinModal.tsx
+++ b/frontend/src/components/entry/AdvancedSearchJoinModal.tsx
@@ -32,7 +32,7 @@ export const AdvancedSearchJoinModal: FC<Props> = ({
     joinAttrs.find((attr) => attr.name === targetAttrname);
 
   const [selectedAttrNames, setSelectedAttrNames] = useState<Array<string>>(
-    currentAttrInfo?.attrinfo.map((attr) => attr.name) ?? [],
+    [...new Set(currentAttrInfo?.attrinfo.map((attr) => attr.name) ?? [])],
   );
 
   const { data: referralAttrs } = usePagodaSWR(
@@ -44,6 +44,10 @@ export const AdvancedSearchJoinModal: FC<Props> = ({
         targetAttrname,
       ),
   );
+
+  const attrNameOptions = [
+    ...new Set(referralAttrs?.map((attr) => attr.name) ?? []),
+  ];
 
   const handleUpdatePageURL = () => {
     // to prevent duplication of same name parameter
@@ -85,7 +89,7 @@ export const AdvancedSearchJoinModal: FC<Props> = ({
       onClose={handleClose}
     >
       <Autocomplete
-        options={referralAttrs?.map((x) => x.name) ?? []}
+        options={attrNameOptions}
         value={selectedAttrNames}
         onChange={(_, value: Array<string>) => {
           setSelectedAttrNames(value);


### PR DESCRIPTION
issue: https://github.com/dmm-com/airone/issues/3630
## Overview

Prevented duplicate attribute names from being displayed in the Advanced Search Join modal.

## Changes

- Removed duplicate attribute names from the autocomplete options
- Removed duplicate attribute names from the initially selected values
- Ensured each attribute name is displayed only once

## Verification

- Confirmed that duplicate attribute names are no longer shown in the autocomplete list
- Confirmed that duplicate selected chips are removed when the modal is opened