### PR TITLE
fix pagenation

### DIFF
--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -83,7 +83,7 @@ logger = logging.getLogger(__name__)
 
 class EntryPermission(BasePermission):
     def has_object_permission(self, request: Request, view: Any, obj: Any) -> bool:
-        user = cast(User, request.user)
+        user = cast("User", request.user)
 
         permisson = {
             "retrieve": ACLType.Readable,
@@ -144,7 +144,7 @@ class EntryAPI(PluginOverrideMixin, viewsets.ModelViewSet):
         if response is not None:
             return response
 
-        user = cast(User, request.user)
+        user = cast("User", request.user)
 
         serializer = EntryUpdateSerializer(
             instance=entry, data=request.data, context={"_user": user}
@@ -390,7 +390,7 @@ class AdvancedSearchAPI(generics.GenericAPIView):
     def post(self, request: Request) -> Response:
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        user = cast(User, request.user)
+        user = cast("User", request.user)
 
         hint_entry = serializer.validated_data.get("hint_entry")
         if hint_entry and (hint_entry.get("filter_key") is not None or hint_entry.get("keyword")):

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -4,7 +4,7 @@ import re
 from collections import Counter
 from copy import deepcopy
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from django.db.models import Prefetch, Q, QuerySet
 from drf_spectacular.types import OpenApiTypes
@@ -31,6 +31,7 @@ from airone.lib.drf import (
 )
 from airone.lib.elasticsearch import (
     ENTRY_NAME_SORT_TARGET,
+    AdvancedSearchResultRecord,
     AdvancedSearchResults,
     AttrHint,
     EntryHint,
@@ -82,7 +83,7 @@ logger = logging.getLogger(__name__)
 
 class EntryPermission(BasePermission):
     def has_object_permission(self, request: Request, view: Any, obj: Any) -> bool:
-        user: User = request.user
+        user = cast(User, request.user)
 
         permisson = {
             "retrieve": ACLType.Readable,
@@ -143,7 +144,7 @@ class EntryAPI(PluginOverrideMixin, viewsets.ModelViewSet):
         if response is not None:
             return response
 
-        user: User = request.user
+        user = cast(User, request.user)
 
         serializer = EntryUpdateSerializer(
             instance=entry, data=request.data, context={"_user": user}
@@ -389,6 +390,7 @@ class AdvancedSearchAPI(generics.GenericAPIView):
     def post(self, request: Request) -> Response:
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+        user = cast(User, request.user)
 
         hint_entry = serializer.validated_data.get("hint_entry")
         if hint_entry and (hint_entry.get("filter_key") is not None or hint_entry.get("keyword")):
@@ -448,8 +450,10 @@ class AdvancedSearchAPI(generics.GenericAPIView):
                 else:
                     entity = Entity.objects.filter(name=hint_entity, is_active=True).first()
 
-            if entity and request.user.has_permission(entity, ACLType.Readable):
+            if entity and user.has_permission(entity, ACLType.Readable):
                 hint_entity_ids.append(entity.id)
+
+        search_entity_ids = [str(entity_id) for entity_id in hint_entity_ids]
 
         # Validate sort parameter.
         sort_input = serializer.validated_data.get("sort")
@@ -483,8 +487,8 @@ class AdvancedSearchAPI(generics.GenericAPIView):
 
         if not join_attrs:
             resp = AdvancedSearchService.search_entries(
-                request.user,
-                hint_entity_ids,
+                user,
+                search_entity_ids,
                 hint_attrs,
                 entry_limit,
                 None,  # don't use in APIv2
@@ -500,19 +504,19 @@ class AdvancedSearchAPI(generics.GenericAPIView):
                 sort_target_attr_type=sort_target_attr_type,
             )
             total_count = deepcopy(resp.ret_count)
-            resp = AdvancedSearchService.apply_join_attrs(request.user, resp, join_attrs)
+            resp = AdvancedSearchService.apply_join_attrs(user, resp, join_attrs)
         else:
             # Join filters are applied after the initial ES search. Continue
             # scanning candidates until the requested page is full.
-            joined_values = []
+            joined_values: list[AdvancedSearchResultRecord] = []
             candidate_offset = 0
             target_end = entry_offset + entry_limit
             total_count = 0
             exhausted = False
             while len(joined_values) < target_end:
                 candidate_resp = AdvancedSearchService.search_entries(
-                    request.user,
-                    hint_entity_ids,
+                    user,
+                    search_entity_ids,
                     hint_attrs,
                     entry_limit,
                     None,
@@ -532,7 +536,7 @@ class AdvancedSearchAPI(generics.GenericAPIView):
                     exhausted = True
                     break
                 joined_resp = AdvancedSearchService.apply_join_attrs(
-                    request.user, candidate_resp, join_attrs
+                    user, candidate_resp, join_attrs
                 )
                 joined_values.extend(joined_resp.ret_values)
                 candidate_count = len(candidate_resp.ret_values)

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -31,6 +31,7 @@ from airone.lib.drf import (
 )
 from airone.lib.elasticsearch import (
     ENTRY_NAME_SORT_TARGET,
+    AdvancedSearchResults,
     AttrHint,
     EntryHint,
     FilterKey,
@@ -480,32 +481,73 @@ class AdvancedSearchAPI(generics.GenericAPIView):
                     return Response("sort target attribute type is not sortable", status=400)
                 sort_target_attr_type = attr_type
 
-        resp = AdvancedSearchService.search_entries(
-            request.user,
-            hint_entity_ids,
-            hint_attrs,
-            entry_limit,
-            None,  # don't use in APIv2
-            hint_referral,
-            is_output_all,
-            offset=entry_offset,
-            hint_entry=hint_entry,
-            allow_missing_attributes=True,  # For APIv2, allow entries missing attributes
-            exclude_referrals=exclude_referrals,
-            include_referrals=include_referrals,
-            sort_target_attrname=sort_target_attrname,
-            sort_order=sort_order,
-            sort_target_attr_type=sort_target_attr_type,
-        )
+        if not join_attrs:
+            resp = AdvancedSearchService.search_entries(
+                request.user,
+                hint_entity_ids,
+                hint_attrs,
+                entry_limit,
+                None,  # don't use in APIv2
+                hint_referral,
+                is_output_all,
+                offset=entry_offset,
+                hint_entry=hint_entry,
+                allow_missing_attributes=True,
+                exclude_referrals=exclude_referrals,
+                include_referrals=include_referrals,
+                sort_target_attrname=sort_target_attrname,
+                sort_order=sort_order,
+                sort_target_attr_type=sort_target_attr_type,
+            )
+            total_count = deepcopy(resp.ret_count)
+            resp = AdvancedSearchService.apply_join_attrs(request.user, resp, join_attrs)
+        else:
+            # Join filters are applied after the initial ES search. Continue
+            # scanning candidates until the requested page is full.
+            joined_values = []
+            candidate_offset = 0
+            target_end = entry_offset + entry_limit
+            total_count = 0
+            exhausted = False
+            while len(joined_values) < target_end:
+                candidate_resp = AdvancedSearchService.search_entries(
+                    request.user,
+                    hint_entity_ids,
+                    hint_attrs,
+                    entry_limit,
+                    None,
+                    hint_referral,
+                    is_output_all,
+                    offset=candidate_offset,
+                    hint_entry=hint_entry,
+                    allow_missing_attributes=True,
+                    exclude_referrals=exclude_referrals,
+                    include_referrals=include_referrals,
+                    sort_target_attrname=sort_target_attrname,
+                    sort_order=sort_order,
+                    sort_target_attr_type=sort_target_attr_type,
+                )
+                total_count = candidate_resp.ret_count
+                if not candidate_resp.ret_values:
+                    exhausted = True
+                    break
+                joined_resp = AdvancedSearchService.apply_join_attrs(
+                    request.user, candidate_resp, join_attrs
+                )
+                joined_values.extend(joined_resp.ret_values)
+                candidate_count = len(candidate_resp.ret_values)
+                candidate_offset += candidate_count
+                if candidate_count < entry_limit:
+                    exhausted = True
+                    break
 
-        # save total population number
-        total_count = deepcopy(resp.ret_count)
-
-        resp = AdvancedSearchService.apply_join_attrs(
-            request.user,
-            resp,
-            join_attrs,
-        )
+            if exhausted:
+                total_count = len(joined_values)
+            page_values = joined_values[entry_offset : entry_offset + entry_limit]
+            resp = AdvancedSearchResults(
+                ret_count=len(page_values),
+                ret_values=page_values,
+            )
 
         # convert field values to fit entry retrieve API data type, as a workaround.
         # FIXME should be replaced with DRF serializer etc

--- a/entry/tests/test_api_v2_advanced_search_with_join_attr.py
+++ b/entry/tests/test_api_v2_advanced_search_with_join_attr.py
@@ -288,6 +288,63 @@ class ViewTest(BaseViewTest):
             ],
         )
 
+    def test_join_attr_keeps_fetching_until_page_is_full(self):
+        """Join filtering must fill a 100-row page from later ES candidate pages."""
+        non_matching_refs = [
+            self.add_entry(
+                self.user,
+                f"non-matching-ref-{i:03d}",
+                self.ref_entity,
+                values={"val": ""},
+            )
+            for i in range(10)
+        ]
+        matching_refs = [
+            self.add_entry(
+                self.user,
+                f"matching-ref-{i:03d}",
+                self.ref_entity,
+                values={"val": "matched"},
+            )
+            for i in range(100)
+        ]
+
+        for i, ref_entry in enumerate(non_matching_refs + matching_refs):
+            self.add_entry(
+                self.user,
+                f"entry-{i:03d}",
+                self.entity,
+                values={"ref": ref_entry.id},
+            )
+
+        params = {
+            "entities": [self.entity.id],
+            "attrinfo": [{"name": "ref"}],
+            "entry_limit": 100,
+            "join_attrs": [
+                {
+                    "name": "ref",
+                    "attrinfo": [
+                        {"name": "val", "keyword": "matched"},
+                    ],
+                }
+            ],
+        }
+        resp = self.client.post(
+            "/entry/api/v2/advanced_search/", json.dumps(params), "application/json"
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["count"], 100)
+        self.assertEqual(resp.json()["total_count"], 100)
+        self.assertEqual(len(resp.json()["values"]), 100)
+        self.assertTrue(
+            all(
+                result["attrs"]["ref.val"]["value"] == {"as_string": "matched"}
+                for result in resp.json()["values"]
+            )
+        )
+
     def test_join_attr_add_attribute_case(self):
         # Added new attribute
         new_attr = EntityAttr.objects.create(

--- a/frontend/src/pages/AdvancedSearchResultsPage.tsx
+++ b/frontend/src/pages/AdvancedSearchResultsPage.tsx
@@ -376,7 +376,7 @@ export const AdvancedSearchResultsPage: FC = () => {
         </Box>
       </PageHeader>
 
-      {joinAttrs.length === 0 && searchResults.isInProcessing ? (
+      {searchResults.isInProcessing ? (
         <Loading />
       ) : (
         <Box>


### PR DESCRIPTION
issue: https://github.com/dmm-com/airone/issues/3631

## Summary

Fix advanced search pagination when join filters are applied.

## Changes

- Continue fetching Elasticsearch result pages until 100 records remain after join filtering.
- Preserve the existing SQL/Python join implementation.
- Return the correct result count when fewer than 100 records match.
- Show a loading indicator while join-filtered results are being processed.
- Add a regression test covering cases where the first page does not contain enough matching records.

## Notes

No Elasticsearch query, schema, or document structure changes are included.