### PR TITLE
add timestamp

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from typing import Any, cast
 
 import yaml
@@ -324,7 +325,8 @@ def export_search_result(request: HttpRequest, recv_data: dict[str, Any]) -> Htt
     # create a job to export search result and run it
     job = Job.new_export_search_result(
         user,
-        text="search_results.%s" % recv_data["export_style"],
+        text="search_results_%s.%s"
+        % (datetime.now().strftime("%Y_%m_%d_%H_%M"), recv_data["export_style"]),
         params=recv_data,
     )
     job.run()

--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -1928,7 +1928,8 @@ class AdvancedSearchResultExportSerializer(serializers.Serializer):
         # create a job to export search result and run it
         job = Job.new_export_search_result_v2(
             user=user,
-            text="search_results.%s" % self.validated_data["export_style"],
+            text="search_results_%s.%s"
+            % (datetime.now().strftime("%Y_%m_%d_%H_%M"), self.validated_data["export_style"]),
             params=self.validated_data,
         )
         job.run()


### PR DESCRIPTION
issue: https://github.com/dmm-com/airone/issues/3638

Add timestamps to search result export filenames

Search result export files now include a timestamp in the format `YYYY_MM_DD_HH_mm`, making exported files easier to identify and distinguish.