### PR TITLE
Prevent Webpack from emitting extra UI chunks

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = {
   entry: {
@@ -8,6 +9,9 @@ module.exports = {
   output: {
     filename: "ui.js",
     path: path.resolve('static/js')
+  },
+  optimization: {
+    splitChunks: false,
   },
   resolve: {
     extensions: [".webpack.js", ".web.js", ".ts", ".tsx", ".js"],
@@ -54,5 +58,8 @@ module.exports = {
     ]
   },
   ignoreWarnings: [/Failed to parse source map/],
-  plugins: [new ForkTsCheckerWebpackPlugin()]
+  plugins: [
+    new ForkTsCheckerWebpackPlugin(),
+    new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
+  ]
 };


### PR DESCRIPTION
## Summary

Prevent the frontend Webpack build from emitting many additional `*.ui.js` and vendor chunk files under `static/js`.

## Changes

- Disable automatic chunk splitting for the frontend bundle.
- Limit the generated bundle to a single chunk, `static/js/ui.js`.

## Validation

- Webpack emitted only `static/js/ui.js` in the dedicated worktree.
- The build reports four pre-existing TypeScript errors in unrelated frontend files and exits with code 1.