### PR TITLE
feat: add typed job parameter contracts with fail-closed Job validation

### DIFF
--- a/airone/lib/plugin_task.py
+++ b/airone/lib/plugin_task.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, TypeAlias
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from pydantic import BaseModel
 
 from airone.lib.log import Logger
 
@@ -42,6 +43,7 @@ class PluginTaskConfig:
         cancelable_operations: List of operations that can be canceled (default: empty)
         parallelizable_operations: List of operations that can run in parallel
         downloadable_operations: List of operations that can be downloaded (default: empty)
+        parameter_models: Optional mapping of operation names to Pydantic payload models
 
     Note:
         The key in tasks is the operation name, and the value is a tuple of (offset, function name).
@@ -55,6 +57,7 @@ class PluginTaskConfig:
     cancelable_operations: list[str] = field(default_factory=list)
     parallelizable_operations: list[str] = field(default_factory=list)
     downloadable_operations: list[str] = field(default_factory=list)
+    parameter_models: dict[str, type[BaseModel]] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Validation after initialization"""
@@ -87,6 +90,18 @@ class PluginTaskConfig:
         self.cancelable_operations = self.cancelable_operations or []
         self.parallelizable_operations = self.parallelizable_operations or []
         self.downloadable_operations = self.downloadable_operations or []
+        unknown_parameter_models = set(self.parameter_models) - set(self.tasks)
+        if unknown_parameter_models:
+            raise ValueError(
+                f"Parameter models reference unknown operations for plugin '{self.plugin_id}': "
+                f"{sorted(unknown_parameter_models)}"
+            )
+        for op_name, contract in self.parameter_models.items():
+            if not isinstance(contract, type) or not issubclass(contract, BaseModel):
+                raise TypeError(
+                    f"Parameter model for operation '{op_name}' in plugin "
+                    f"'{self.plugin_id}' must be a Pydantic model class"
+                )
 
 
 class PluginTaskRegistry:
@@ -118,6 +133,7 @@ class PluginTaskRegistry:
     _registry: dict[str, PluginTaskConfig] = {}
     _operation_id_map: dict[tuple[str, str], int] = {}  # (plugin_id, op_name) -> operation_id
     _reverse_map: dict[int, tuple[str, str]] = {}  # operation_id -> (plugin_id, op_name)
+    _registered_parameter_operation_ids: set[int] = set()
     _initialized = False
 
     @classmethod
@@ -227,6 +243,14 @@ class PluginTaskRegistry:
             )
             raise ImproperlyConfigured(error_message)
 
+        from job.params import register_job_params
+
+        for (plugin_id, op_name), operation_id in cls._operation_id_map.items():
+            contract = cls._registry[plugin_id].parameter_models.get(op_name)
+            if contract is not None:
+                register_job_params(operation_id, contract)
+                cls._registered_parameter_operation_ids.add(operation_id)
+
         cls._initialized = True
         logger.info(f"Plugin operation_id validation completed ({len(used_ids)} IDs)")
 
@@ -307,6 +331,11 @@ class PluginTaskRegistry:
     @classmethod
     def reset(cls) -> None:
         """Reset registry (for testing)"""
+        from job.params import unregister_job_params
+
+        for operation_id in cls._registered_parameter_operation_ids:
+            unregister_job_params(operation_id)
+        cls._registered_parameter_operation_ids.clear()
         cls._registry.clear()
         cls._operation_id_map.clear()
         cls._reverse_map.clear()

--- a/airone/tests/test_plugin_task.py
+++ b/airone/tests/test_plugin_task.py
@@ -5,12 +5,19 @@ from types import ModuleType
 
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from airone.lib.plugin_task import (
     PluginTaskConfig,
     PluginTaskRegistry,
 )
 from job.models import Job
+from job.params import (
+    get_job_params_contract,
+    register_job_params,
+    unregister_job_params,
+    validate_job_params,
+)
 
 
 class PluginTaskRegistrySandboxMixin:
@@ -27,6 +34,7 @@ class PluginTaskRegistrySandboxMixin:
             dict(PluginTaskRegistry._registry),
             dict(PluginTaskRegistry._operation_id_map),
             dict(PluginTaskRegistry._reverse_map),
+            set(PluginTaskRegistry._registered_parameter_operation_ids),
             PluginTaskRegistry._initialized,
         )
         self._method_table_snapshot = dict(Job._METHOD_TABLE)
@@ -34,11 +42,17 @@ class PluginTaskRegistrySandboxMixin:
         PluginTaskRegistry.reset()
 
     def _restore_plugin_task_registry(self):
-        registry, operation_id_map, reverse_map, initialized = self._registry_snapshot
+        registry, operation_id_map, reverse_map, parameter_operation_ids, initialized = (
+            self._registry_snapshot
+        )
         PluginTaskRegistry.reset()
         PluginTaskRegistry._registry.update(registry)
         PluginTaskRegistry._operation_id_map.update(operation_id_map)
         PluginTaskRegistry._reverse_map.update(reverse_map)
+        for (plugin_id, op_name), operation_id in operation_id_map.items():
+            if operation_id in parameter_operation_ids:
+                register_job_params(operation_id, registry[plugin_id].parameter_models[op_name])
+        PluginTaskRegistry._registered_parameter_operation_ids.update(parameter_operation_ids)
         PluginTaskRegistry._initialized = initialized
         Job._METHOD_TABLE.clear()
         Job._METHOD_TABLE.update(self._method_table_snapshot)
@@ -158,6 +172,54 @@ class TestPluginTaskRegistry(PluginTaskRegistrySandboxMixin, TestCase):
 
         PluginTaskRegistry.validate_all()
         self.assertTrue(True)
+
+    @override_settings(
+        PLUGIN_OPERATION_ID_CONFIG={
+            "test_plugin": (5000, 5099),
+        }
+    )
+    def test_validate_all_registers_operation_parameter_model(self):
+        class OperationParams(BaseModel):
+            model_config = ConfigDict(strict=True, extra="forbid")
+            count: int
+
+        config = PluginTaskConfig(
+            plugin_id="test_plugin",
+            module_path="test_plugin.tasks",
+            tasks={"operation_a": (0, "task_a")},
+            parameter_models={"operation_a": OperationParams},
+        )
+        PluginTaskRegistry.register(config)
+
+        PluginTaskRegistry.validate_all()
+
+        self.assertIs(get_job_params_contract(5000), OperationParams)
+        self.assertEqual(validate_job_params(5000, {"count": 1}).count, 1)
+        with self.assertRaises(ValidationError):
+            validate_job_params(5000, {"count": "1"})
+
+    @override_settings(
+        PLUGIN_OPERATION_ID_CONFIG={
+            "test_plugin": (5000, 5099),
+        }
+    )
+    def test_reset_preserves_manually_registered_parameter_model(self):
+        class ManualParams(BaseModel):
+            value: str
+
+        config = PluginTaskConfig(
+            plugin_id="test_plugin",
+            module_path="test_plugin.tasks",
+            tasks={"operation_a": (0, "task_a")},
+        )
+        PluginTaskRegistry.register(config)
+        PluginTaskRegistry.validate_all()
+        register_job_params(5000, ManualParams)
+        self.addCleanup(unregister_job_params, 5000)
+
+        PluginTaskRegistry.reset()
+
+        self.assertIs(get_job_params_contract(5000), ManualParams)
 
     def test_validate_all_unregistered_plugin_raises_error(self):
         """Plugin configured in settings but not registered"""

--- a/api_v1/tests/job/test_api.py
+++ b/api_v1/tests/job/test_api.py
@@ -33,7 +33,10 @@ class APITest(AironeViewTest):
         entry = Entry.objects.create(name="entry", created_user=user, schema=entity)
 
         # create three jobs
-        jobs = [Job.new_create(user, entry) for _ in range(0, 3)]
+        jobs = [
+            Job.new_create(user, entry, params={"entry_name": entry.name, "attrs": []})
+            for _ in range(0, 3)
+        ]
 
         resp = self.client.get("/api/v1/job/")
         self.assertEqual(resp.status_code, 200)
@@ -140,7 +143,7 @@ class APITest(AironeViewTest):
         self.assertEqual(resp.content, b'"Target job cannot be canceled"')
 
         # send request with proper parameter
-        job = Job.new_create(user, entry)
+        job = Job.new_create(user, entry, params={"entry_name": entry.name, "attrs": []})
         self.assertEqual(job.status, JobStatus.PREPARING)
 
         resp = self.client.delete(
@@ -162,7 +165,7 @@ class APITest(AironeViewTest):
         Job.new_register_referrals(user, entry)
 
         # create an unhidden job
-        Job.new_create(user, entry)
+        Job.new_create(user, entry, params={"entry_name": entry.name, "attrs": []})
 
         resp = self.client.get("/api/v1/job/")
         self.assertEqual(resp.status_code, 200)

--- a/custom_view_sample/lib/task.py
+++ b/custom_view_sample/lib/task.py
@@ -1,5 +1,7 @@
 import enum
 
+from job.params import EmptyParams, register_job_params
+
 
 @enum.unique
 class JobOperationCustom(enum.IntEnum):
@@ -15,3 +17,5 @@ CUSTOM_DOWNLOADABLE_OPERATIONS: list[JobOperationCustom] = []
 CUSTOM_TASKS: dict[JobOperationCustom, str] = {
     JobOperationCustom.UPDATE_CUSTOM_ATTRIBUTE: "update_custom_attribute",
 }
+
+register_job_params(JobOperationCustom.UPDATE_CUSTOM_ATTRIBUTE, EmptyParams)

--- a/custom_view_sample/views/CustomEntity.py
+++ b/custom_view_sample/views/CustomEntity.py
@@ -15,13 +15,10 @@ def list_entry(request: HttpRequest, entity: Entity, context: dict[str, Any]) ->
 
 
 def after_create_entry(recv_data: dict[str, Any], user: User, entry: Entry) -> None:
-    job = Job.new_create(
+    job = Job.new_custom_job(
         user=user,
+        operation=JobOperationCustom.UPDATE_CUSTOM_ATTRIBUTE,
         target=entry,
-    )
-
-    operation = JobOperationCustom.UPDATE_CUSTOM_ATTRIBUTE
-    job.update(
-        operation=operation,
+        params={},
     )
     job.run()

--- a/dashboard/tests/test_view.py
+++ b/dashboard/tests/test_view.py
@@ -1438,7 +1438,7 @@ class ViewTest(AironeViewTest):
         }
 
         # create a job to export search result
-        job = Job.new_export(user, params=export_params)
+        job = Job.new_export_search_result(user, params=export_params)
 
         # A request with same parameter which is under execution will be denied
         resp = self.client.post(

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -20,7 +20,7 @@ from entry.admin import AttrResource, AttrValueResource, EntryResource
 from entry.models import AttributeValue, Entry
 from entry.services import AdvancedSearchService
 from entry.settings import CONFIG as CONFIG_ENTRY
-from job.models import Job, JobStatus
+from job.models import Job, JobOperation, JobStatus
 from user.models import User
 
 from .settings import CONFIG
@@ -319,7 +319,11 @@ def export_search_result(request: HttpRequest, recv_data: dict[str, Any]) -> Htt
     user = cast(User, request.user)
     # check whether same job is sent
     job_status_not_finished: list[JobStatus] = [JobStatus.PREPARING, JobStatus.PROCESSING]
-    if Job.get_job_with_params(user, recv_data).filter(status__in=job_status_not_finished).exists():
+    if (
+        Job.get_job_with_params(user, JobOperation.EXPORT_SEARCH_RESULT, recv_data)
+        .filter(status__in=job_status_not_finished)
+        .exists()
+    ):
         return HttpResponse("Same export processing is under execution", status=400)
 
     # create a job to export search result and run it

--- a/entity/api_v2/views.py
+++ b/entity/api_v2/views.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 from typing import Any, List, cast
 
@@ -206,9 +207,10 @@ class EntityAPI(viewsets.ModelViewSet[Entity]):
 
         serializer = EntityCreateSerializer(data=request.data, context={"_user": user})
         serializer.is_valid(raise_exception=True)
+        job_params = copy.deepcopy(serializer.validated_data)
         entity = serializer.create(serializer.validated_data)
 
-        job = Job.new_create_entity_v2(user, entity, params=request.data)
+        job = Job.new_create_entity_v2(user, entity, params=job_params)
         job.run()
 
         return Response(status=status.HTTP_202_ACCEPTED)
@@ -222,9 +224,10 @@ class EntityAPI(viewsets.ModelViewSet[Entity]):
             instance=entity, data=request.data, context={"_user": user}
         )
         serializer.is_valid(raise_exception=True)
+        job_params = copy.deepcopy(serializer.validated_data)
         serializer.update(entity, serializer.validated_data)
 
-        job = Job.new_edit_entity_v2(user, entity, params=request.data)
+        job = Job.new_edit_entity_v2(user, entity, params=job_params)
         job.run()
 
         return Response(status=status.HTTP_202_ACCEPTED)
@@ -485,7 +488,7 @@ class EntityImportPreviewAPI(generics.GenericAPIView[Entity]):
         )
         serializer.is_valid(raise_exception=True)
 
-        job = Job.new_import_entity_preview(user, request.data)
+        job = Job.new_import_entity_preview(user, serializer.validated_data)
         job.run()
 
         return Response({"job_id": job.id}, status=status.HTTP_202_ACCEPTED)

--- a/entry/api_v2/serializers.py
+++ b/entry/api_v2/serializers.py
@@ -28,7 +28,7 @@ from entity.models import Entity, EntityAttr
 from entry.models import AliasEntry, Attribute, AttributeValue, Entry
 from entry.settings import CONFIG as CONFIG_ENTRY
 from group.models import Group
-from job.models import Job, JobStatus
+from job.models import Job, JobOperation, JobStatus
 from role.models import Role
 from user.api_v2.serializers import UserBaseSerializer
 from user.models import User
@@ -1919,7 +1919,11 @@ class AdvancedSearchResultExportSerializer(serializers.Serializer):
 
         job_status_not_finished: list[JobStatus] = [JobStatus.PREPARING, JobStatus.PROCESSING]
         if (
-            Job.get_job_with_params(user, self.validated_data)
+            Job.get_job_with_params(
+                user,
+                JobOperation.EXPORT_SEARCH_RESULT_V2,
+                self.validated_data,
+            )
             .filter(status__in=job_status_not_finished)
             .exists()
         ):

--- a/entry/api_v2/views.py
+++ b/entry/api_v2/views.py
@@ -713,7 +713,11 @@ class EntryExportAPI(generics.GenericAPIView):
         # check whether same job is sent
         job_status_not_finished = [JobStatus.PREPARING, JobStatus.PROCESSING]
         if (
-            Job.get_job_with_params(request.user, job_params.dict())
+            Job.get_job_with_params(
+                request.user,
+                JobOperation.EXPORT_ENTRY_V2,
+                job_params.model_dump(mode="json"),
+            )
             .filter(status__in=job_status_not_finished)
             .exists()
         ):
@@ -730,11 +734,9 @@ class EntryExportAPI(generics.GenericAPIView):
         # create a job to export search result and run it
         job = Job.new_export_v2(
             request.user,
-            **{
-                "text": "entry_%s.%s" % (entity.name, str(job_params.export_format)),
-                "target": entity,
-                "params": job_params.dict(),
-            },
+            target=entity,
+            text="entry_%s.%s" % (entity.name, str(job_params.export_format)),
+            params=job_params.model_dump(mode="json"),
         )
         job.run()
 
@@ -862,6 +864,7 @@ class EntryImportAPI(generics.GenericAPIView):
         user: User = request.user
         serializer = EntryImportSerializer(data=import_datas)
         serializer.is_valid(raise_exception=True)
+        import_datas = serializer.validated_data
         entities = self.get_queryset()
 
         # limit import job to deny accidental frequent import for same entity

--- a/entry/tests/test_api_v2_import_export.py
+++ b/entry/tests/test_api_v2_import_export.py
@@ -2486,7 +2486,7 @@ class ViewTest(BaseViewTest):
         }
 
         # create a job to export search result
-        job = Job.new_export(user, params=export_params)
+        job = Job.new_export_search_result_v2(user, params=export_params)
 
         # A request with same parameter which is under execution will be denied
         resp = self.client.post(

--- a/entry/views.py
+++ b/entry/views.py
@@ -27,7 +27,7 @@ from entity.models import Entity
 from entry.models import Attribute, AttributeValue, Entry
 from entry.utils import get_sort_order
 from group.models import Group
-from job.models import Job, JobStatus
+from job.models import Job, JobOperation, JobStatus
 from role.models import Role
 from user.models import User
 
@@ -479,7 +479,7 @@ def export(request: HttpRequest, entity_id: int, recv_data: dict[str, Any]) -> H
     # check whether same job is sent
     job_status_not_finished = [JobStatus.PREPARING, JobStatus.PROCESSING]
     if (
-        Job.get_job_with_params(request.user, job_params)
+        Job.get_job_with_params(request.user, JobOperation.EXPORT_ENTRY, job_params)
         .filter(status__in=job_status_not_finished)
         .exists()
     ):
@@ -492,11 +492,9 @@ def export(request: HttpRequest, entity_id: int, recv_data: dict[str, Any]) -> H
     # create a job to export search result and run it
     job = Job.new_export(
         request.user,
-        **{
-            "text": "entry_%s.%s" % (entity.name, job_params["export_format"]),
-            "target": entity,
-            "params": job_params,
-        },
+        target=entity,
+        text="entry_%s.%s" % (entity.name, job_params["export_format"]),
+        params=job_params,
     )
     job.run()
 

--- a/job/models.py
+++ b/job/models.py
@@ -20,6 +20,13 @@ from airone.lib.plugin_task import PluginTaskRegistry
 from airone.lib.types import BaseIntEnum
 from entity.models import Entity
 from entry.models import Entry
+from job.params import (
+    CORE_JOB_PARAMS,
+    assert_core_registry_complete,
+    get_job_params_contract,
+    parse_job_params,
+    serialize_job_params,
+)
 from job.settings import CONFIG as JOB_CONFIG
 from user.models import User
 
@@ -92,6 +99,11 @@ class JobOperation(BaseIntEnum):
     BULK_EDIT_ENTRY = 31
     IMPORT_ENTITY_PREVIEW = 32
     IMPORT_ENTRY_PREVIEW = 33
+
+
+# Core operation additions must never silently fall through to the untyped
+# external-plugin compatibility path, even outside the test suite.
+assert_core_registry_complete()
 
 
 @enum.unique
@@ -215,6 +227,31 @@ class Job(models.Model):
     # When this has another job, this job have to wait until it would be finished.
     dependent_job = models.ForeignKey("Job", null=True, on_delete=models.SET_NULL)
 
+    def get_typed_params(self, expected_type: type[Any] | None = None) -> Any:
+        """Return validated job parameters, parsing persisted JSON only once."""
+
+        try:
+            contract = get_job_params_contract(self.operation)
+        except ValueError:
+            if expected_type is not None:
+                raise TypeError(
+                    f"Job operation {self.operation} has no registered parameter contract"
+                ) from None
+            cache_key = (self.operation, self.params)
+            if getattr(self, "_typed_params_cache_key", None) != cache_key:
+                self._typed_params_cache = json.loads(self.params)
+                self._typed_params_cache_key = cache_key
+            return self._typed_params_cache
+        if expected_type is not None and contract is not expected_type:
+            raise TypeError(
+                f"Job operation {self.operation} uses {contract!r}, not {expected_type!r}"
+            )
+        cache_key = (self.operation, self.params)
+        if getattr(self, "_typed_params_cache_key", None) != cache_key:
+            self._typed_params_cache = parse_job_params(self.operation, self.params)
+            self._typed_params_cache_key = cache_key
+        return self._typed_params_cache
+
     def may_schedule(self) -> bool:
         # Operations that can run in parallel exclude checking for dependent jobs
         if self.operation in self.PARALLELIZABLE_OPERATIONS:
@@ -264,9 +301,24 @@ class Job(models.Model):
 
         return self.status == JobStatus.CANCELED
 
+    def _validate_params_for_processing(self) -> bool:
+        try:
+            self.get_typed_params()
+        except (ValueError, TypeError):
+            Logger.error(f"Job(id={self.id}, operation={self.operation}) has invalid parameters")
+            self.update(JobStatus.ERROR)
+            return False
+        return True
+
     def proceed_if_ready(self) -> bool:
         # In this case, job is finished (might be canceled or proceeded same job by other process)
         if self.is_finished() or self.status == JobStatus.PROCESSING:
+            return False
+
+        # All tracked task implementations use this readiness boundary. The
+        # PROCESSING transition below repeats the check as a backstop for
+        # external tasks that omit it.
+        if not self._validate_params_for_processing():
             return False
 
         # This checks whether dependent job is and it hasn't finished yet.
@@ -284,6 +336,9 @@ class Job(models.Model):
     ) -> None:
         update_fields = ["updated_at"]
 
+        if status == JobStatus.PROCESSING and not self._validate_params_for_processing():
+            raise ValueError(f"Job(id={self.id}) cannot process invalid parameters")
+
         if status is not None and status in [s.value for s in JobStatus]:
             update_fields.append("status")
             self.status = status
@@ -297,7 +352,10 @@ class Job(models.Model):
             self.target = target
 
         if operation is not None and operation in self.method_table():
-            update_fields.append("operation")
+            # An operation change changes the meaning of params. Validate before
+            # persisting it so custom/plugin jobs cannot bypass their contract.
+            self.params = self._serialize_params(operation, json.loads(self.params))
+            update_fields.extend(["operation", "params"])
             self.operation = operation
 
         self.save(update_fields=update_fields)
@@ -369,11 +427,7 @@ class Job(models.Model):
         if dependent_job is None and depend_on is not None:
             dependent_job = depend_on
 
-        params_str = (
-            json.dumps(params, default=_support_time_default, sort_keys=True)
-            if params is not None
-            else "{}"
-        )
+        params_str = kls._serialize_params(operation, {} if params is None else params)
 
         job_params: JobParams = {
             "user": user,
@@ -389,6 +443,41 @@ class Job(models.Model):
             job_params["target"] = target
 
         return kls.objects.create(**job_params)
+
+    @staticmethod
+    def _serialize_params(operation: int, params: Any) -> str:
+        """Validate core/registered params; retain legacy external compatibility."""
+
+        try:
+            get_job_params_contract(operation)
+        except ValueError:
+            # Unregistered external operations predate typed contracts. Keep
+            # them usable until their plugin registers a contract.
+            return json.dumps(
+                params,
+                default=_support_time_default,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        return serialize_job_params(operation, params)
+
+    @classmethod
+    def new_custom_job(
+        kls,
+        user: User,
+        operation: int,
+        *,
+        params: Any,
+        target: ACLBase | None = None,
+        text: str = "",
+        depend_on: "Job | None" = None,
+    ) -> "Job":
+        """Public creation API for custom/plugin operations."""
+
+        if int(operation) in CORE_JOB_PARAMS:
+            raise ValueError("Use the operation-specific factory for core jobs")
+        return kls._create_new_job(user, target, operation, text, params, depend_on)
 
     @classmethod
     def get_task_module(kls, component: str) -> ModuleType:
@@ -435,13 +524,26 @@ class Job(models.Model):
         kls._METHOD_TABLE[operation] = method
 
     @classmethod
-    def get_job_with_params(kls, user: User, params: JobParams) -> models.QuerySet["Job"]:
+    def get_job_with_params(
+        kls, user: User, operation: int, params: JobParams | list[Any]
+    ) -> models.QuerySet["Job"]:
+        canonical_params = kls._serialize_params(operation, params)
+        legacy_params = json.dumps(params, default=_support_time_default, sort_keys=True)
         return kls.objects.filter(
-            user=user, params=json.dumps(params, default=_support_time_default, sort_keys=True)
+            user=user,
+            operation=operation,
+            params__in={canonical_params, legacy_params},
         )
 
     @classmethod
-    def new_create(kls, user: User, target: Entry, text: str = "", params: JobParams = {}) -> "Job":
+    def new_create(
+        kls, user: User, target: Entry, text: str = "", params: JobParams | None = None
+    ) -> "Job":
+        if params is None:
+            # Preserve the historical custom-view staging pattern:
+            # Job.new_create(...).update(operation=<custom>). The synthesized
+            # payload is also safe if the core task is accidentally dispatched.
+            params = {"entry_name": target.name, "attrs": []}
         return kls._create_new_job(
             user=user,
             target=target,
@@ -451,7 +553,9 @@ class Job(models.Model):
         )
 
     @classmethod
-    def new_edit(kls, user: User, target: Entry, text: str = "", params: JobParams = {}) -> "Job":
+    def new_edit(
+        kls, user: User, target: Entry, text: str = "", params: JobParams | None = None
+    ) -> "Job":
         return kls._create_new_job(
             user=user,
             target=target,
@@ -467,7 +571,9 @@ class Job(models.Model):
         )
 
     @classmethod
-    def new_copy(kls, user: User, target: Entry, text: str = "", params: JobParams = {}) -> "Job":
+    def new_copy(
+        kls, user: User, target: Entry, text: str = "", params: JobParams | None = None
+    ) -> "Job":
         return kls._create_new_job(
             user=user,
             target=target,
@@ -478,7 +584,7 @@ class Job(models.Model):
 
     @classmethod
     def new_do_copy(
-        kls, user: User, target: Entry, text: str = "", params: JobParams = {}
+        kls, user: User, target: Entry, text: str = "", params: JobParams | None = None
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -490,7 +596,7 @@ class Job(models.Model):
 
     @classmethod
     def new_import(
-        kls, user: User, entity: Entity, text: str = "", params: JobParams = {}
+        kls, user: User, entity: Entity, text: str = "", params: JobParams | None = None
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -502,7 +608,7 @@ class Job(models.Model):
 
     @classmethod
     def new_import_v2(
-        kls, user: User, entity: Entity, text: str = "", params: JobParams = {}
+        kls, user: User, entity: Entity, text: str = "", params: JobParams | None = None
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -536,7 +642,11 @@ class Job(models.Model):
 
     @classmethod
     def new_export(
-        kls, user: User, target: ACLBase | None = None, text: str = "", params: JobParams = {}
+        kls,
+        user: User,
+        target: ACLBase | None = None,
+        text: str = "",
+        params: JobParams | None = None,
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -548,7 +658,11 @@ class Job(models.Model):
 
     @classmethod
     def new_export_v2(
-        kls, user: User, target: ACLBase | None = None, text: str = "", params: JobParams = {}
+        kls,
+        user: User,
+        target: ACLBase | None = None,
+        text: str = "",
+        params: JobParams | None = None,
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -560,7 +674,7 @@ class Job(models.Model):
 
     @classmethod
     def new_restore(
-        kls, user: User, target: Entry, text: str = "", params: JobParams = {}
+        kls, user: User, target: Entry, text: str = "", params: JobParams | None = None
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -572,7 +686,11 @@ class Job(models.Model):
 
     @classmethod
     def new_export_search_result(
-        kls, user: User, target: ACLBase | None = None, text: str = "", params: JobParams = {}
+        kls,
+        user: User,
+        target: ACLBase | None = None,
+        text: str = "",
+        params: JobParams | None = None,
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -584,7 +702,11 @@ class Job(models.Model):
 
     @classmethod
     def new_export_search_result_v2(
-        kls, user: User, target: ACLBase | None = None, text: str = "", params: JobParams = {}
+        kls,
+        user: User,
+        target: ACLBase | None = None,
+        text: str = "",
+        params: JobParams | None = None,
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -600,7 +722,7 @@ class Job(models.Model):
         user: User,
         target: ACLBase | None,
         operation_value: int = JobOperation.REGISTER_REFERRALS,
-        params: JobParams = {},
+        params: JobParams | None = None,
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -612,7 +734,7 @@ class Job(models.Model):
 
     @classmethod
     def new_create_entity(
-        kls, user: User, target: Entity, text: str = "", params: JobParams = {}
+        kls, user: User, target: Entity, text: str = "", params: JobParams | None = None
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -624,7 +746,7 @@ class Job(models.Model):
 
     @classmethod
     def new_edit_entity(
-        kls, user: User, target: Entity, text: str = "", params: JobParams = {}
+        kls, user: User, target: Entity, text: str = "", params: JobParams | None = None
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -642,7 +764,7 @@ class Job(models.Model):
 
     @classmethod
     def new_update_documents(
-        kls, target: ACLBase | None, text: str = "", params: JobParams = {}
+        kls, target: ACLBase | None, text: str = "", params: JobParams | None = None
     ) -> "Job":
         user = auto_complement.get_auto_complement_user(None)
         if not user:
@@ -678,7 +800,7 @@ class Job(models.Model):
         kls,
         user: User,
         target_entry: Entry,
-        recv_attrs: list[Any] | dict[str, Any] = {},
+        recv_attrs: list[Any] | dict[str, Any] | None = None,
         dependent_job: "Job | None" = None,
     ) -> "Job":
         return kls._create_new_job(
@@ -686,13 +808,13 @@ class Job(models.Model):
             target=target_entry,
             operation=JobOperation.MAY_INVOKE_TRIGGER,
             text="",
-            params=recv_attrs,
+            params=[] if recv_attrs is None else recv_attrs,
             depend_on=dependent_job,
         )
 
     @classmethod
     def new_create_entity_v2(
-        kls, user: User, target: Entity, text: str = "", params: JobParams = {}
+        kls, user: User, target: Entity, text: str = "", params: JobParams | None = None
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -704,7 +826,7 @@ class Job(models.Model):
 
     @classmethod
     def new_edit_entity_v2(
-        kls, user: User, target: Entity, text: str = "", params: JobParams = {}
+        kls, user: User, target: Entity, text: str = "", params: JobParams | None = None
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -716,7 +838,7 @@ class Job(models.Model):
 
     @classmethod
     def new_delete_entity_v2(
-        kls, user: User, target: Entity, text: str = "", params: JobParams = {}
+        kls, user: User, target: Entity, text: str = "", params: JobParams | None = None
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -728,7 +850,7 @@ class Job(models.Model):
 
     @classmethod
     def new_create_entry_v2(
-        kls, user: User, target: Entry | None, text: str = "", params: JobParams = {}
+        kls, user: User, target: Entry | None, text: str = "", params: JobParams | None = None
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -740,7 +862,7 @@ class Job(models.Model):
 
     @classmethod
     def new_edit_entry_v2(
-        kls, user: User, target: Entry, text: str = "", params: JobParams = {}
+        kls, user: User, target: Entry, text: str = "", params: JobParams | None = None
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -752,7 +874,7 @@ class Job(models.Model):
 
     @classmethod
     def new_delete_entry_v2(
-        kls, user: User, target: Entry, text: str = "", params: JobParams = {}
+        kls, user: User, target: Entry, text: str = "", params: JobParams | None = None
     ) -> "Job":
         return kls._create_new_job(
             user=user,
@@ -789,7 +911,9 @@ class Job(models.Model):
         )
 
     @classmethod
-    def new_bulk_edit_entry_v2(kls, user: User, target: Entity, params: JobParams = {}) -> "Job":
+    def new_bulk_edit_entry_v2(
+        kls, user: User, target: Entity, params: JobParams | None = None
+    ) -> "Job":
         return kls._create_new_job(
             user=user, target=target, operation=JobOperation.BULK_EDIT_ENTRY, text="", params=params
         )

--- a/job/params.py
+++ b/job/params.py
@@ -1,0 +1,615 @@
+"""Typed and fail-closed parameter contracts for core jobs.
+
+The module deliberately does not import :mod:`job.models` at import time.  Job
+creation uses these contracts from ``job.models``, so importing the enum here
+would create a cycle.  Core operation ids are checked against the enum by
+``assert_core_registry_complete`` and by the test suite.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Generic, Literal, TypeAlias, TypeVar
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    TypeAdapter,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
+
+from airone.lib.types import AttrType
+
+
+class JobParamsModel(BaseModel):
+    """Base contract for object-root job parameters."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True, validate_default=True)
+
+
+RootValue = TypeVar("RootValue")
+
+
+class JobParamsRootModel(RootModel[RootValue], Generic[RootValue]):
+    """Base contract for non-object roots with the same strictness guarantees."""
+
+    model_config = ConfigDict(strict=True, frozen=True, validate_default=True)
+
+
+class EmptyParams(JobParamsModel):
+    pass
+
+
+class AttributeValue(JobParamsModel):
+    """Attribute input whose value depends on its entity attribute definition."""
+
+    id: int
+    value: Any = None
+
+
+class LegacyIndexedValue(JobParamsModel):
+    data: Any = None
+    index: int = 0
+
+    @field_validator("index", mode="before")
+    @classmethod
+    def coerce_legacy_index(cls, value: Any) -> Any:
+        if isinstance(value, str) and value.isdecimal():
+            return int(value)
+        return value
+
+
+class LegacyCreateAttributeValue(JobParamsModel):
+    id: str
+    entity_attr_id: str | None = None
+    type: str | int | None = None
+    value: list[LegacyIndexedValue]
+    referral_key: list[LegacyIndexedValue] = Field(default_factory=list)
+
+
+class LegacyEditAttributeValue(LegacyCreateAttributeValue):
+    entity_attr_id: str
+
+
+class LegacyCreateEntryParams(JobParamsModel):
+    entry_name: str
+    attrs: list[LegacyCreateAttributeValue]
+
+
+class LegacyEditEntryParams(JobParamsModel):
+    entry_name: str
+    attrs: list[LegacyEditAttributeValue]
+
+
+class CopyEntryParams(JobParamsModel):
+    new_name_list: list[str] = Field(default_factory=list)
+    post_data: dict[str, Any] = Field(default_factory=dict)
+
+
+class DoCopyEntryParams(JobParamsModel):
+    new_name_list: list[str] = Field(default_factory=list)
+    new_name: str
+    post_data: dict[str, Any] = Field(default_factory=dict)
+
+
+class ImportedAttribute(JobParamsModel):
+    name: str
+    value: Any = None
+
+
+class ImportedEntry(JobParamsModel):
+    id: int | None = None
+    name: str
+    attrs: list[ImportedAttribute] = Field(default_factory=list)
+
+
+class LegacyImportedEntry(JobParamsModel):
+    name: str
+    attrs: dict[str, Any]
+
+
+class LegacyImportEntryParams(JobParamsRootModel[list[LegacyImportedEntry]]):
+    pass
+
+
+class ImportEntryParams(JobParamsModel):
+    entity: str
+    entries: list[ImportedEntry] = Field(default_factory=list)
+    # The approved-preview linkage recorded by EntryImportAPI. Optional so a
+    # direct import (no preview) keeps the minimal shape.
+    preview_job_id: int | None = None
+
+
+class ExportEntryParams(JobParamsModel):
+    export_format: Literal["yaml", "csv"]
+    target_id: int
+    join_attrs: list[dict[str, Any]] = Field(default_factory=list)
+
+    @field_validator("target_id", mode="before")
+    @classmethod
+    def coerce_legacy_target_id(cls, value: Any) -> Any:
+        if isinstance(value, str) and value.isdecimal():
+            return int(value)
+        return value
+
+
+class AttrHintParams(JobParamsModel):
+    name: str
+    keyword: str | None = None
+    filter_key: int | None = None
+    exact_match: bool | None = None
+    is_readable: bool | None = None
+
+
+class JoinAttrParams(JobParamsModel):
+    name: str
+    offset: int = 0
+    attrinfo: list[AttrHintParams] = Field(default_factory=list)
+
+
+class SearchExportParams(JobParamsModel):
+    entities: list[int]
+    attrinfo: list[AttrHintParams]
+    export_style: Literal["yaml", "csv"]
+    has_referral: bool = False
+    referral_name: str | None = None
+    entry_name: str | None = None
+    hint_entry: dict[str, Any] | None = None
+    join_attrs: list[JoinAttrParams] = Field(default_factory=list)
+    is_all_entities: bool = False
+
+    @field_validator("entities", mode="before")
+    @classmethod
+    def coerce_legacy_entity_ids(cls, value: Any) -> Any:
+        if isinstance(value, list):
+            return [
+                int(item) if isinstance(item, str) and item.isdecimal() else item for item in value
+            ]
+        return value
+
+
+class ReferralParams(JobParamsModel):
+    pass
+
+
+class GroupReferralParams(JobParamsModel):
+    group_id: int
+
+
+class RoleReferralParams(JobParamsModel):
+    role_id: int
+
+
+class UpdateDocumentParams(JobParamsModel):
+    is_update: bool = False
+
+
+class EntityAttrParams(JobParamsModel):
+    id: int | None = None
+    name: str = Field(max_length=200)
+    type: int
+    is_mandatory: bool = False
+    is_delete_in_chain: bool = False
+    row_index: str = "0"
+    ref_ids: list[int] = Field(default_factory=list)
+    deleted: bool | None = None
+
+    @field_validator("type", mode="before")
+    @classmethod
+    def coerce_legacy_type(cls, value: Any) -> Any:
+        # HTML form submissions historically persisted AttrType as a decimal string.
+        if isinstance(value, str) and value.isdecimal():
+            return int(value)
+        return value
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def coerce_legacy_id(cls, value: Any) -> Any:
+        # HTML form submissions historically persisted ids as decimal strings.
+        if isinstance(value, str) and value.isdecimal():
+            return int(value)
+        return value
+
+
+class CreateEntityParams(JobParamsModel):
+    name: str
+    note: str
+    is_toplevel: bool
+    attrs: list[EntityAttrParams]
+
+
+class EditEntityParams(JobParamsModel):
+    name: str = Field(max_length=200)
+    note: str
+    is_toplevel: bool
+    attrs: list[EntityAttrParams]
+
+
+class WebhookHeaderParams(JobParamsModel):
+    header_key: str
+    header_value: str
+
+
+class WebhookParams(JobParamsModel):
+    id: int | None = None
+    url: str = Field(default="", max_length=200)
+    label: str = ""
+    is_enabled: bool = False
+    headers: list[WebhookHeaderParams] = Field(default_factory=list)
+    is_deleted: bool = False
+
+
+class EntityAttrV2Params(JobParamsModel):
+    id: int | None = None
+    name: str = Field(max_length=200)
+    type: int
+    index: int | None = None
+    is_mandatory: bool = False
+    is_delete_in_chain: bool = False
+    is_summarized: bool = False
+    referral: list[int] = Field(default_factory=list)
+    note: str = ""
+    default_value: str | bool | int | float | None = None
+    choices: list[dict[str, str]] | None = None
+    name_order: int | None = 0
+    name_prefix: str | None = ""
+    name_postfix: str | None = ""
+    display_attr: str = ""
+    deleted: bool | None = None
+    is_deleted: bool = False
+    created_user: Any = Field(default=None, exclude=True)
+
+    @field_validator("referral", mode="before")
+    @classmethod
+    def coerce_serializer_referrals(cls, value: Any) -> Any:
+        return _coerce_model_ids(value)
+
+    @field_validator("choices", mode="after")
+    @classmethod
+    def validate_choices(cls, value: list[dict[str, str]] | None, info: ValidationInfo) -> Any:
+        attr_type = info.data.get("type")
+        if value is None:
+            if attr_type in (AttrType.SELECT, AttrType.MULTI_SELECT):
+                raise ValueError("SELECT type requires a non-empty choices list")
+            return None
+        if attr_type not in (AttrType.SELECT, AttrType.MULTI_SELECT):
+            return None
+        from entity.models import EntityAttr
+
+        EntityAttr.validate_choices(value)
+        return value
+
+    @field_validator("default_value", mode="after")
+    @classmethod
+    def normalize_default_value(cls, value: Any, info: ValidationInfo) -> Any:
+        return _normalize_entity_attr_default(value, info.data.get("type"))
+
+
+class EditEntityAttrV2Params(JobParamsModel):
+    id: int | None = None
+    name: str | None = Field(default=None, max_length=200)
+    type: int | None = None
+    index: int | None = None
+    is_mandatory: bool | None = None
+    is_delete_in_chain: bool | None = None
+    is_summarized: bool | None = None
+    referral: list[int] | None = None
+    note: str | None = None
+    default_value: str | bool | int | float | None = None
+    choices: list[dict[str, str]] | None = None
+    is_deleted: bool = False
+    name_order: int | None = 0
+    name_prefix: str | None = ""
+    name_postfix: str | None = ""
+    display_attr: str | None = None
+    created_user: Any = Field(default=None, exclude=True)
+
+    @field_validator("referral", mode="before")
+    @classmethod
+    def coerce_serializer_referrals(cls, value: Any) -> Any:
+        return _coerce_model_ids(value)
+
+    @field_validator("choices", mode="after")
+    @classmethod
+    def validate_choices(cls, value: list[dict[str, str]] | None, info: ValidationInfo) -> Any:
+        attr_type = info.data.get("type")
+        if value is None:
+            return None
+        if attr_type is not None and attr_type not in (AttrType.SELECT, AttrType.MULTI_SELECT):
+            return None
+        from entity.models import EntityAttr
+
+        EntityAttr.validate_choices(value)
+        return value
+
+    @field_validator("default_value", mode="after")
+    @classmethod
+    def normalize_default_value(cls, value: Any, info: ValidationInfo) -> Any:
+        return _normalize_entity_attr_default(value, info.data.get("type"))
+
+    @model_validator(mode="after")
+    def require_new_attribute_fields(self) -> "EditEntityAttrV2Params":
+        if self.id is None and (self.name is None or self.type is None):
+            raise ValueError("name and type are required for new attribute creation")
+        return self
+
+
+def _normalize_entity_attr_default(value: Any, attr_type: Any) -> Any:
+    """Preserve the established async EntityAttr default normalization contract."""
+
+    if value is None or attr_type is None:
+        return value
+    if attr_type in (AttrType.STRING, AttrType.TEXT):
+        return value if isinstance(value, str) else None
+    if attr_type == AttrType.BOOLEAN:
+        return value if isinstance(value, bool) else None
+    if attr_type == AttrType.NUMBER:
+        return value if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+    return None
+
+
+def _coerce_model_ids(value: Any) -> Any:
+    """Convert DRF related-model values to the ids persisted in a job payload."""
+
+    if not isinstance(value, list):
+        return value
+    return [item.pk if isinstance(getattr(item, "pk", None), int) else item for item in value]
+
+
+class EditWebhookParams(JobParamsModel):
+    id: int | None = None
+    url: str | None = Field(default=None, max_length=200)
+    label: str = ""
+    is_enabled: bool = False
+    headers: list[WebhookHeaderParams] = Field(default_factory=list)
+    is_deleted: bool = False
+
+
+class IsolationConditionParams(JobParamsModel):
+    attr_id: int
+    str_cond: str = ""
+    ref_cond_id: int | None = None
+    bool_cond: bool = False
+    is_unmatch: bool = False
+
+
+class IsolationActionParams(JobParamsModel):
+    is_prevent_all: bool = False
+    prevent_from_id: int | None = None
+
+
+class IsolationRuleParams(JobParamsModel):
+    id: int | None = None
+    is_deleted: bool = False
+    conditions: list[IsolationConditionParams] = Field(default_factory=list)
+    action: IsolationActionParams = Field(default_factory=IsolationActionParams)
+
+
+class CreateEntityV2Params(JobParamsModel):
+    name: str = Field(max_length=200)
+    note: str = ""
+    item_name_pattern: str = ""
+    item_name_type: str = ""
+    is_toplevel: bool = False
+    attrs: list[EntityAttrV2Params] = Field(default_factory=list)
+    webhooks: list[WebhookParams] = Field(default_factory=list)
+    isolation_rules: list[IsolationRuleParams] = Field(default_factory=list)
+    delete_chain_exclude_entities: list[int] = Field(default_factory=list)
+
+
+class EditEntityV2Params(JobParamsModel):
+    id: int | None = None
+    name: str | None = Field(default=None, max_length=200)
+    note: str | None = None
+    item_name_pattern: str | None = None
+    item_name_type: str | None = None
+    is_toplevel: bool | None = None
+    attrs: list[EditEntityAttrV2Params] = Field(default_factory=list)
+    webhooks: list[EditWebhookParams] = Field(default_factory=list)
+    isolation_rules: list[IsolationRuleParams] = Field(default_factory=list)
+    delete_chain_exclude_entities: list[int] = Field(default_factory=list)
+
+
+class EntryV2Params(JobParamsModel):
+    schema_id: int | None = Field(default=None, alias="schema")
+    entity: int | str | None = None
+    name: str | None = None
+    attrs: list[AttributeValue] = Field(default_factory=list)
+    delay_trigger: bool = True
+    call_stacks: list[int] = Field(default_factory=list)
+
+
+class CreateEntryV2Params(EntryV2Params):
+    name: str
+
+    @model_validator(mode="after")
+    def require_entity_schema(self) -> "CreateEntryV2Params":
+        if self.schema_id is None and self.entity is None:
+            raise ValueError("schema is required")
+        return self
+
+
+class RoleImportItem(JobParamsModel):
+    id: int | None = None
+    name: str
+    description: str = ""
+    users: list[str] = Field(default_factory=list)
+    groups: list[str] = Field(default_factory=list)
+    admin_users: list[str] = Field(default_factory=list)
+    admin_groups: list[str] = Field(default_factory=list)
+    permissions: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class RoleImportParams(JobParamsRootModel[list[RoleImportItem]]):
+    pass
+
+
+class TriggerListParams(
+    JobParamsRootModel[list[LegacyCreateAttributeValue | LegacyEditAttributeValue | AttributeValue]]
+):
+    pass
+
+
+class BulkEditParams(JobParamsModel):
+    modelid: int
+    attrinfo: list[AttrHintParams] = Field(default_factory=list)
+    hint_entry: dict[str, Any] | None = None
+    referral_name: str | None = None
+    value: AttributeValue
+
+
+class EntityImportItem(JobParamsModel):
+    id: int | None = None
+    name: str | None = None
+    note: str | None = None
+    item_name_pattern: str | None = None
+    status: int | None = None
+    created_user: str | None = None
+
+
+class EntityAttrImportItem(JobParamsModel):
+    id: int | None = None
+    name: str | None = None
+    type: int | None = None
+    entity: str | None = None
+    is_mandatory: bool | Literal["0", "1"] = False
+    created_user: str | None = None
+    refer: str
+
+
+class ImportEntityPreviewParams(JobParamsModel):
+    Entity: list[EntityImportItem]
+    EntityAttr: list[EntityAttrImportItem]
+
+
+ParamsContract: TypeAlias = type[BaseModel]
+
+
+# Keep the ids literal here to preserve the no-import-cycle property.  The
+# exhaustiveness assertion below makes any JobOperation addition fail closed.
+def _build_core_registry(entries: list[tuple[int, ParamsContract]]) -> dict[int, ParamsContract]:
+    registry = dict(entries)
+    if len(registry) != len(entries):
+        raise RuntimeError("Duplicate core job parameter operation id")
+    return registry
+
+
+CORE_JOB_PARAMS: dict[int, ParamsContract] = _build_core_registry(
+    [
+        (1, LegacyCreateEntryParams),
+        (2, LegacyEditEntryParams),
+        (3, EmptyParams),
+        (4, CopyEntryParams),
+        (5, LegacyImportEntryParams),
+        (6, ExportEntryParams),
+        (7, EmptyParams),
+        (8, SearchExportParams),
+        (9, ReferralParams),
+        (10, CreateEntityParams),
+        (11, EditEntityParams),
+        (12, EmptyParams),
+        (13, EmptyParams),
+        (14, EmptyParams),
+        (15, EmptyParams),
+        (16, DoCopyEntryParams),
+        (17, ImportEntryParams),
+        (18, GroupReferralParams),
+        (19, RoleReferralParams),
+        (20, ExportEntryParams),
+        (21, UpdateDocumentParams),
+        (22, SearchExportParams),
+        (23, TriggerListParams),
+        (24, CreateEntityV2Params),
+        (25, EditEntityV2Params),
+        (26, EmptyParams),
+        (27, CreateEntryV2Params),
+        (28, EntryV2Params),
+        (29, EmptyParams),
+        (30, RoleImportParams),
+        (31, BulkEditParams),
+        (32, ImportEntityPreviewParams),
+        # Same payload shape as IMPORT_ENTRY_V2 (and the optional approved-preview
+        # linkage, which an import job carries but a preview job never sets).
+        (33, ImportEntryParams),
+    ]
+)
+
+_custom_job_params: dict[int, ParamsContract] = {}
+
+
+def register_job_params(operation: int, contract: ParamsContract) -> None:
+    """Register a parameter contract for a custom/plugin operation."""
+
+    operation_id = int(operation)
+    if not isinstance(contract, type) or not issubclass(contract, BaseModel):
+        raise TypeError("Job parameter contract must be a Pydantic model class")
+    if operation_id in CORE_JOB_PARAMS:
+        raise ValueError(f"Cannot replace core job parameter contract for operation {operation_id}")
+    if operation_id in _custom_job_params:
+        raise ValueError(
+            f"Job parameter contract for operation {operation_id} is already registered"
+        )
+    _custom_job_params[operation_id] = contract
+
+
+def unregister_job_params(operation: int) -> None:
+    """Remove a custom contract, primarily for plugin teardown and isolated tests."""
+
+    _custom_job_params.pop(int(operation), None)
+
+
+def get_job_params_contract(operation: int) -> ParamsContract:
+    operation_id = int(operation)
+    if operation_id in CORE_JOB_PARAMS:
+        return CORE_JOB_PARAMS[operation_id]
+    try:
+        return _custom_job_params[operation_id]
+    except KeyError:
+        raise ValueError(f"No job parameter contract for operation {operation_id}") from None
+
+
+def validate_job_params(operation: int, params: Any) -> Any:
+    """Validate Python input and return a Pydantic model (or union member)."""
+
+    return TypeAdapter(get_job_params_contract(operation)).validate_python(params)
+
+
+def parse_job_params(operation: int, params_json: str | bytes | bytearray) -> Any:
+    """Validate JSON persisted in ``Job.params``."""
+
+    # Some historical MAY_INVOKE_TRIGGER jobs stored the old default ``{}``.
+    # Keep that read compatibility isolated from validation of newly created jobs.
+    if int(operation) == 23:
+        encoded = params_json.encode() if isinstance(params_json, str) else bytes(params_json)
+        if encoded.strip() == b"{}":
+            return TriggerListParams([])
+    return TypeAdapter(get_job_params_contract(operation)).validate_json(params_json)
+
+
+def serialize_job_params(operation: int, params: Any) -> str:
+    """Validate and emit deterministic JSON-mode storage representation."""
+
+    contract = TypeAdapter(get_job_params_contract(operation))
+    validated = contract.validate_python(params)
+    json_value = contract.dump_python(validated, mode="json", exclude_unset=True, by_alias=True)
+    return json.dumps(json_value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def assert_core_registry_complete() -> None:
+    """Fail when the enum and contract registry diverge."""
+
+    # Local import is intentional; importing job.models at module load creates a cycle.
+    from job.models import JobOperation
+
+    operation_ids = {int(operation) for operation in JobOperation}
+    registered_ids = set(CORE_JOB_PARAMS)
+    if operation_ids != registered_ids:
+        missing = sorted(operation_ids - registered_ids)
+        unknown = sorted(registered_ids - operation_ids)
+        raise RuntimeError(
+            f"Incomplete core job params registry: missing={missing}, unknown={unknown}"
+        )

--- a/job/tests/test_api_v2.py
+++ b/job/tests/test_api_v2.py
@@ -26,7 +26,10 @@ class ViewTest(AironeViewTest):
         entry = Entry.objects.create(name="entry", created_user=user, schema=entity)
 
         # create three jobs
-        [Job.new_create(user, entry) for _ in range(0, _TEST_MAX_LIST_VIEW)]
+        [
+            Job.new_create(user, entry, params={"entry_name": entry.name, "attrs": []})
+            for _ in range(0, _TEST_MAX_LIST_VIEW)
+        ]
         self.assertEqual(Job.objects.filter(user=user).count(), _TEST_MAX_LIST_VIEW)
 
         # checks number of the returned objects are as expected
@@ -54,7 +57,7 @@ class ViewTest(AironeViewTest):
 
         entity = Entity.objects.create(name="entity", created_user=user)
         entry = Entry.objects.create(name="entry", created_user=user, schema=entity)
-        Job.new_create(user, entry)
+        Job.new_create(user, entry, params={"entry_name": entry.name, "attrs": []})
 
         resp = self.client.get(f"/job/api/v2/jobs?limit={_TEST_MAX_LIST_VIEW + 100}&offset=0")
         self.assertEqual(resp.status_code, 200)
@@ -152,7 +155,7 @@ class ViewTest(AironeViewTest):
     def test_get_non_target_job(self):
         user = self.guest_login()
 
-        Job.new_create(user, None)
+        Job.new_create(user, None, params={"entry_name": "synthetic-entry", "attrs": []})
 
         resp = self.client.get(f"/job/api/v2/jobs?limit={_TEST_MAX_LIST_VIEW + 100}&offset=0")
         self.assertEqual(resp.status_code, 200)
@@ -162,8 +165,13 @@ class ViewTest(AironeViewTest):
         user = self.guest_login()
 
         # create jobs which are related with export
-        (Job.new_export(user),)
-        (Job.new_export_search_result(user),)
+        (Job.new_export(user, params={"export_format": "yaml", "target_id": 0}),)
+        (
+            Job.new_export_search_result(
+                user,
+                params={"entities": [], "attrinfo": [], "export_style": "yaml"},
+            ),
+        )
 
         resp = self.client.get(f"/job/api/v2/jobs?limit={_TEST_MAX_LIST_VIEW + 100}&offset=0")
         self.assertEqual(resp.status_code, 200)
@@ -174,7 +182,7 @@ class ViewTest(AironeViewTest):
 
         entity = Entity.objects.create(name="entity", created_user=user)
         entry = Entry.objects.create(name="entry", created_user=user, schema=entity)
-        job = Job.new_create(user, entry, "hoge")
+        job = Job.new_create(user, entry, "hoge", params={"entry_name": entry.name, "attrs": []})
 
         # match the created_after
         created_after = job.created_at.strftime("%Y-%m-%d")
@@ -202,10 +210,13 @@ class ViewTest(AironeViewTest):
         entry2 = Entry.objects.create(name="entry2", created_user=user, schema=entity)
 
         # create three jobs for entry1
-        [Job.new_create(user, entry1) for _ in range(0, _TEST_MAX_LIST_VIEW)]
+        [
+            Job.new_create(user, entry1, params={"entry_name": entry1.name, "attrs": []})
+            for _ in range(0, _TEST_MAX_LIST_VIEW)
+        ]
         self.assertEqual(Job.objects.filter(user=user).count(), _TEST_MAX_LIST_VIEW)
         # create one job for entry2
-        Job.new_create(user, entry2)
+        Job.new_create(user, entry2, params={"entry_name": entry2.name, "attrs": []})
 
         # checks number of the returned objects are for entry1
         resp = self.client.get(
@@ -224,7 +235,7 @@ class ViewTest(AironeViewTest):
 
         entity = Entity.objects.create(name="entity", created_user=user)
         entry = Entry.objects.create(name="entry", created_user=user, schema=entity)
-        job = Job.new_create(user, entry, "hoge")
+        job = Job.new_create(user, entry, "hoge", params={"entry_name": entry.name, "attrs": []})
 
         resp = self.client.get("/job/api/v2/%d/" % job.id)
         self.assertEqual(resp.status_code, 200)
@@ -246,7 +257,7 @@ class ViewTest(AironeViewTest):
 
         entity = Entity.objects.create(name="entity", created_user=guest)
         entry = Entry.objects.create(name="entry", created_user=guest, schema=entity)
-        job = Job.new_create(guest, entry, "hoge")
+        job = Job.new_create(guest, entry, "hoge", params={"entry_name": entry.name, "attrs": []})
 
         self.admin_login()
 
@@ -265,12 +276,12 @@ class ViewTest(AironeViewTest):
 
         entity = Entity.objects.create(name="entity", created_user=guest)
         entry = Entry.objects.create(name="entry", created_user=guest, schema=entity)
-        Job.new_create(guest, entry)
+        Job.new_create(guest, entry, params={"entry_name": entry.name, "attrs": []})
 
         from user.models import User
 
         other = User.objects.create(username="other", password="passwd", is_superuser=False)
-        other_job = Job.new_create(other, entry)
+        other_job = Job.new_create(other, entry, params={"entry_name": entry.name, "attrs": []})
 
         # all_users=true is silently ignored for non-admin; only own jobs are returned
         resp = self.client.get(
@@ -302,7 +313,7 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.status_code, 400)
 
         # make a cancellable job
-        job = Job.new_create(user, entry)
+        job = Job.new_create(user, entry, params={"entry_name": entry.name, "attrs": []})
         self.assertEqual(job.status, JobStatus.PREPARING)
         resp = self.client.delete("/job/api/v2/%d/" % job.id)
         self.assertEqual(resp.status_code, 204)
@@ -318,7 +329,7 @@ class ViewTest(AironeViewTest):
         )
 
         # Send a request to a job that cannot be downloaded
-        job = Job.new_create(user, None)
+        job = Job.new_create(user, None, params={"entry_name": "synthetic-entry", "attrs": []})
 
         resp = self.client.get("/job/api/v2/%d/download" % job.id)
         self.assertEqual(resp.status_code, 400)
@@ -327,7 +338,7 @@ class ViewTest(AironeViewTest):
         )
 
         # send request to download job when job is not done
-        job = Job.new_export(user, text="hoge")
+        job = Job.new_export(user, text="hoge", params={"export_format": "yaml", "target_id": 0})
 
         resp = self.client.get("/job/api/v2/%d/download" % job.id)
         self.assertEqual(resp.status_code, 400)

--- a/job/tests/test_model.py
+++ b/job/tests/test_model.py
@@ -19,17 +19,21 @@ class ModelTest(AironeTestCase):
         self.admin = User.objects.create(username="admin", password="passwd", is_superuser=True)
         self.entity = Entity.objects.create(name="entity", created_user=self.guest)
         self.entry = Entry.objects.create(name="entry", created_user=self.guest, schema=self.entity)
+        self.create_params = {"entry_name": "entry", "attrs": []}
+        self.edit_params = {"entry_name": "entry", "attrs": []}
+        self.copy_params = {"new_name_list": [], "post_data": {}}
         self.test_data = None
 
     def test_create_object(self):
         jobinfos = [
-            {"method": "new_create", "op": JobOperation.CREATE_ENTRY},
-            {"method": "new_edit", "op": JobOperation.EDIT_ENTRY},
-            {"method": "new_delete", "op": JobOperation.DELETE_ENTRY},
-            {"method": "new_copy", "op": JobOperation.COPY_ENTRY},
+            {"method": "new_create", "op": JobOperation.CREATE_ENTRY, "params": self.create_params},
+            {"method": "new_edit", "op": JobOperation.EDIT_ENTRY, "params": self.edit_params},
+            {"method": "new_delete", "op": JobOperation.DELETE_ENTRY, "params": None},
+            {"method": "new_copy", "op": JobOperation.COPY_ENTRY, "params": self.copy_params},
         ]
         for info in jobinfos:
-            job = getattr(Job, info["method"])(self.guest, self.entry)
+            kwargs = {"params": info["params"]} if info["params"] is not None else {}
+            job = getattr(Job, info["method"])(self.guest, self.entry, **kwargs)
 
             self.assertEqual(job.user, self.guest)
             self.assertEqual(job.target, self.entry)
@@ -39,30 +43,37 @@ class ModelTest(AironeTestCase):
 
     def test_get_object(self):
         params = {
-            "entities": self.entity.id,
-            "attrinfo": {"name": "foo", "keyword": ""},
-            "export_style": '"yaml"',
+            "entities": [self.entity.id],
+            "attrinfo": [{"name": "foo", "keyword": ""}],
+            "export_style": "yaml",
         }
 
         # check there is no job
-        self.assertFalse(Job.get_job_with_params(self.guest, params).exists())
+        self.assertFalse(
+            Job.get_job_with_params(self.guest, JobOperation.EXPORT_SEARCH_RESULT, params).exists()
+        )
 
         # create a new job
-        job = Job.new_export(self.guest, text="hoge", params=params)
+        job = Job.new_export_search_result(self.guest, text="hoge", params=params)
         self.assertEqual(job.target_type, JobTarget.UNKNOWN)
-        self.assertEqual(job.operation, JobOperation.EXPORT_ENTRY)
+        self.assertEqual(job.operation, JobOperation.EXPORT_SEARCH_RESULT)
         self.assertEqual(job.text, "hoge")
 
         # check created job is got by specified params
-        self.assertEqual(Job.get_job_with_params(self.guest, params).count(), 1)
-        self.assertEqual(Job.get_job_with_params(self.guest, params).last(), job)
+        matching_jobs = Job.get_job_with_params(
+            self.guest, JobOperation.EXPORT_SEARCH_RESULT, params
+        )
+        self.assertEqual(matching_jobs.count(), 1)
+        self.assertEqual(matching_jobs.last(), job)
 
         # check the case when different params is specified then it returns None
-        params["attrinfo"]["name"] = ""
-        self.assertFalse(Job.get_job_with_params(self.guest, params).exists())
+        params["attrinfo"][0]["name"] = ""
+        self.assertFalse(
+            Job.get_job_with_params(self.guest, JobOperation.EXPORT_SEARCH_RESULT, params).exists()
+        )
 
     def test_cache(self):
-        job = Job.new_create(self.guest, self.entry)
+        job = Job.new_create(self.guest, self.entry, params=self.create_params)
 
         registering_values = [
             1234,
@@ -75,24 +86,29 @@ class ModelTest(AironeTestCase):
             self.assertEqual(job.get_cache(), json.dumps(value))
 
     def test_dependent_job(self):
-        (job1, job2) = [Job.new_edit(self.guest, self.entry) for x in range(2)]
+        (job1, job2) = [
+            Job.new_edit(self.guest, self.entry, params=self.edit_params) for x in range(2)
+        ]
         self.assertIsNone(job1.dependent_job)
         self.assertEqual(job2.dependent_job, job1)
 
         # When a job don't has target parameter, dependent_job is not set because
         # there is no problem when these tasks are run simultaneouslly.
-        jobs = [Job.new_export(self.guest) for x in range(2)]
+        jobs = [
+            Job._create_new_job(self.guest, None, JobOperation.NOTIFY_UPDATE_ENTRY, "", {})
+            for x in range(2)
+        ]
         self.assertTrue(all([j.dependent_job is None for j in jobs]))
 
         # overwrite timeout timeout value for testing
         settings.AIRONE["JOB_TIMEOUT"] = -1
 
         # Because jobs[1] is created after the expiry of jobs[0]
-        jobs = [Job.new_edit(self.guest, self.entry) for x in range(2)]
+        jobs = [Job.new_edit(self.guest, self.entry, params=self.edit_params) for x in range(2)]
         self.assertTrue(all([j.dependent_job is None for j in jobs]))
 
     def test_job_is_timeout(self):
-        job = Job.new_create(self.guest, self.entry)
+        job = Job.new_create(self.guest, self.entry, params=self.create_params)
         self.assertFalse(job.is_timeout())
 
         # overwrite timeout timeout value for testing
@@ -101,7 +117,7 @@ class ModelTest(AironeTestCase):
         self.assertTrue(job.is_timeout())
 
     def test_is_finished(self):
-        job = Job.new_create(self.guest, self.entry)
+        job = Job.new_create(self.guest, self.entry, params=self.create_params)
 
         for status in [
             JobStatus.DONE,
@@ -115,7 +131,7 @@ class ModelTest(AironeTestCase):
             self.assertTrue(job.is_finished())
 
     def test_is_canceled(self):
-        job = Job.new_create(self.guest, self.entry)
+        job = Job.new_create(self.guest, self.entry, params=self.create_params)
 
         self.assertFalse(job.is_canceled())
 
@@ -126,7 +142,7 @@ class ModelTest(AironeTestCase):
         self.assertTrue(job.is_canceled())
 
     def test_update_method(self):
-        job = Job.new_create(self.guest, self.entry, "original text")
+        job = Job.new_create(self.guest, self.entry, "original text", params=self.create_params)
         self.assertEqual(job.status, JobStatus.PREPARING)
         self.assertEqual(job.operation, JobOperation.CREATE_ENTRY)
         last_updated_time = job.updated_at
@@ -183,7 +199,7 @@ class ModelTest(AironeTestCase):
         self.assertEqual(job.operation, JobOperation.EDIT_ENTRY)
 
     def test_proceed_if_ready(self):
-        job = Job.new_create(self.guest, self.entry)
+        job = Job.new_create(self.guest, self.entry, params=self.create_params)
 
         for status in [
             JobStatus.DONE,
@@ -207,7 +223,9 @@ class ModelTest(AironeTestCase):
         def side_effect():
             self.test_data += 1
 
-        [job1, job2] = [Job.new_create(self.guest, self.entry) for _ in range(2)]
+        [job1, job2] = [
+            Job.new_create(self.guest, self.entry, params=self.create_params) for _ in range(2)
+        ]
 
         # Checks dependent_job parameters of both entries are set properly
         self.assertIsNone(job1.dependent_job)
@@ -247,7 +265,7 @@ class ModelTest(AironeTestCase):
         mock_import_module.side_effect = side_effect
 
         # create a job and call get_task_module method many times
-        job = Job.new_create(self.guest, self.entry)
+        job = Job.new_create(self.guest, self.entry, params=self.create_params)
         for _x in range(3):
             job.get_task_module("hoge")
 
@@ -281,7 +299,7 @@ class ModelTest(AironeTestCase):
         # register custom operation and method
         Job.register_method_table("custom_operation", custom_method)
 
-        job = Job.new_create(self.guest, self.entry)
+        job = Job.new_create(self.guest, self.entry, params=self.create_params)
         job.operation = "custom_operation"
 
         # run job and check custom_method is called properly

--- a/job/tests/test_params.py
+++ b/job/tests/test_params.py
@@ -1,0 +1,323 @@
+import json
+from datetime import date
+
+from django.test import SimpleTestCase
+from pydantic import BaseModel, ConfigDict, RootModel, ValidationError
+
+from job.models import JobOperation
+from job.params import (
+    CORE_JOB_PARAMS,
+    EmptyParams,
+    assert_core_registry_complete,
+    get_job_params_contract,
+    parse_job_params,
+    register_job_params,
+    serialize_job_params,
+    unregister_job_params,
+    validate_job_params,
+)
+
+
+class JobParamsTest(SimpleTestCase):
+    VALID_CORE_PARAMS = {
+        1: {"entry_name": "a", "attrs": [{"id": "1", "value": []}]},
+        2: {
+            "entry_name": "a",
+            "attrs": [{"entity_attr_id": "1", "id": "", "value": []}],
+        },
+        3: {},
+        4: {"new_name_list": ["copy"], "post_data": {}},
+        5: [{"name": "a", "attrs": {}}],
+        6: {"export_format": "yaml", "target_id": 1},
+        7: {},
+        8: {"entities": [1], "attrinfo": [], "export_style": "yaml"},
+        9: {},
+        10: {"name": "E", "note": "", "is_toplevel": False, "attrs": []},
+        11: {"name": "E", "note": "", "is_toplevel": False, "attrs": []},
+        12: {},
+        13: {},
+        14: {},
+        15: {},
+        16: {"new_name_list": ["copy"], "new_name": "copy", "post_data": {}},
+        17: {"entity": "E", "entries": []},
+        18: {"group_id": 1},
+        19: {"role_id": 1},
+        20: {"export_format": "csv", "target_id": 1},
+        21: {"is_update": True},
+        22: {"entities": [1], "attrinfo": [], "export_style": "csv"},
+        23: [],
+        24: {"name": "E"},
+        25: {},
+        26: {},
+        27: {"schema": 1, "name": "a"},
+        28: {},
+        29: {},
+        30: [],
+        31: {"modelid": 1, "value": {"id": 1, "value": None}},
+        32: {"Entity": [], "EntityAttr": []},
+        33: {"entity": "E", "entries": []},
+    }
+
+    def test_all_core_operations_have_contracts(self) -> None:
+        assert_core_registry_complete()
+        self.assertEqual(set(CORE_JOB_PARAMS), {int(operation) for operation in JobOperation})
+
+    def test_every_core_contract_accepts_its_producer_shape(self) -> None:
+        self.assertEqual(set(self.VALID_CORE_PARAMS), set(CORE_JOB_PARAMS))
+        for operation, payload in self.VALID_CORE_PARAMS.items():
+            with self.subTest(operation=operation):
+                validate_job_params(operation, payload)
+
+    def test_every_core_contract_rejects_wrong_root(self) -> None:
+        list_root_operations = {
+            int(JobOperation.IMPORT_ENTRY),
+            int(JobOperation.MAY_INVOKE_TRIGGER),
+            int(JobOperation.IMPORT_ROLE_V2),
+        }
+        for operation in CORE_JOB_PARAMS:
+            wrong_root = {} if operation in list_root_operations else []
+            with self.subTest(operation=operation), self.assertRaises(ValidationError):
+                validate_job_params(operation, wrong_root)
+
+    def test_every_object_root_contract_rejects_unknown_top_level_field(self) -> None:
+        list_root_operations = {
+            int(JobOperation.IMPORT_ENTRY),
+            int(JobOperation.MAY_INVOKE_TRIGGER),
+            int(JobOperation.IMPORT_ROLE_V2),
+        }
+        for operation, payload in self.VALID_CORE_PARAMS.items():
+            if operation in list_root_operations:
+                continue
+            mutated = {**payload, "unknown_job_parameter": True}
+            with self.subTest(operation=operation), self.assertRaises(ValidationError):
+                validate_job_params(operation, mutated)
+
+    def test_required_top_level_fields_cannot_be_removed(self) -> None:
+        for operation, contract in CORE_JOB_PARAMS.items():
+            payload = self.VALID_CORE_PARAMS[operation]
+            if not isinstance(payload, dict):
+                continue
+            required_fields = [
+                field.alias or name
+                for name, field in contract.model_fields.items()
+                if field.is_required()
+            ]
+            for field_name in required_fields:
+                if field_name not in payload:
+                    continue
+                mutated = {key: value for key, value in payload.items() if key != field_name}
+                with (
+                    self.subTest(operation=operation, field=field_name),
+                    self.assertRaises(ValidationError),
+                ):
+                    validate_job_params(operation, mutated)
+
+    def test_empty_params_reject_extra_fields(self) -> None:
+        with self.assertRaises(ValidationError):
+            validate_job_params(JobOperation.DELETE_ENTRY, {"unexpected": True})
+
+    def test_valid_object_root_and_canonical_json(self) -> None:
+        payload = {"is_update": False}
+        validated = validate_job_params(JobOperation.UPDATE_DOCUMENT, payload)
+        self.assertFalse(validated.is_update)
+        self.assertEqual(
+            serialize_job_params(JobOperation.UPDATE_DOCUMENT, payload), '{"is_update":false}'
+        )
+
+    def test_invalid_object_root(self) -> None:
+        with self.assertRaises(ValidationError):
+            validate_job_params(JobOperation.UPDATE_DOCUMENT, {"is_update": "not-a-bool"})
+
+    def test_bool_is_not_accepted_as_integer_id(self) -> None:
+        with self.assertRaises(ValidationError):
+            validate_job_params(JobOperation.GROUP_REGISTER_REFERRAL, {"group_id": True})
+        with self.assertRaises(ValidationError):
+            validate_job_params(
+                JobOperation.EXPORT_ENTRY,
+                {"export_format": "yaml", "target_id": False},
+            )
+
+    def test_list_root(self) -> None:
+        payload = [{"name": "operators", "description": "Operations"}]
+        validated = validate_job_params(JobOperation.IMPORT_ROLE_V2, payload)
+        self.assertEqual(validated.root[0].name, "operators")
+        self.assertEqual(
+            serialize_job_params(JobOperation.IMPORT_ROLE_V2, payload),
+            '[{"description":"Operations","name":"operators"}]',
+        )
+
+    def test_root_list_rejects_object(self) -> None:
+        with self.assertRaises(ValidationError):
+            validate_job_params(JobOperation.IMPORT_ROLE_V2, {"name": "operators"})
+
+    def test_trigger_accepts_list_and_legacy_persisted_empty_object(self) -> None:
+        list_value = validate_job_params(JobOperation.MAY_INVOKE_TRIGGER, [{"id": 1, "value": 2}])
+        map_value = parse_job_params(JobOperation.MAY_INVOKE_TRIGGER, "{}")
+        self.assertEqual(list_value.root[0].value, 2)
+        self.assertEqual(map_value.root, [])
+        with self.assertRaises(ValidationError):
+            validate_job_params(JobOperation.MAY_INVOKE_TRIGGER, {})
+
+    def test_legacy_entry_fixture_preserves_explicit_string_ids(self) -> None:
+        payload = {
+            "entry_name": "server-01",
+            "attrs": [
+                {
+                    "entity_attr_id": "12",
+                    "id": "",
+                    "value": [{"data": "active", "index": "0"}],
+                    "referral_key": [],
+                }
+            ],
+        }
+        validated = validate_job_params(JobOperation.EDIT_ENTRY, payload)
+        self.assertEqual(validated.attrs[0].entity_attr_id, "12")
+        self.assertEqual(validated.attrs[0].value[0].index, 0)
+        with self.assertRaises(ValidationError):
+            validate_job_params(
+                JobOperation.EDIT_ENTRY,
+                {**payload, "attrs": [{**payload["attrs"][0], "entity_attr_id": 12}]},
+            )
+
+    def test_copy_fixture_accepts_opaque_callback_post_data(self) -> None:
+        payload = {
+            "new_name_list": ["copy-1"],
+            "post_data": {"copy_entry_names": ["copy-1"], "plugin_option": {"x": 1}},
+        }
+        validated = validate_job_params(JobOperation.COPY_ENTRY, payload)
+        self.assertEqual(validated.post_data["plugin_option"], {"x": 1})
+
+    def test_legacy_and_v2_import_fixtures_use_distinct_roots(self) -> None:
+        legacy = [{"name": "server-01", "attrs": {"status": "active"}}]
+        v2 = {
+            "entity": "Server",
+            "entries": [{"name": "server-01", "attrs": [{"name": "status", "value": "active"}]}],
+        }
+        self.assertEqual(
+            validate_job_params(JobOperation.IMPORT_ENTRY, legacy).root[0].name, "server-01"
+        )
+        self.assertEqual(validate_job_params(JobOperation.IMPORT_ENTRY_V2, v2).entity, "Server")
+
+    def test_import_params_preserve_approved_preview_linkage(self) -> None:
+        """An import approved from a preview carries preview_job_id; keep it round-trippable."""
+
+        payload = {"entity": "Server", "entries": [], "preview_job_id": 7}
+        validated = validate_job_params(JobOperation.IMPORT_ENTRY_V2, payload)
+        self.assertEqual(validated.preview_job_id, 7)
+        # The preview job itself never sets the linkage, and it stays optional.
+        self.assertIsNone(
+            validate_job_params(JobOperation.IMPORT_ENTRY_V2, {"entity": "Server"}).preview_job_id
+        )
+        self.assertIsNone(
+            validate_job_params(
+                JobOperation.IMPORT_ENTRY_PREVIEW, {"entity": "Server"}
+            ).preview_job_id
+        )
+        serialized = json.loads(serialize_job_params(JobOperation.IMPORT_ENTRY_V2, payload))
+        self.assertEqual(serialized["preview_job_id"], 7)
+
+    def test_preview_fixture_matches_import_serializer_root(self) -> None:
+        payload = {
+            "Entity": [{"id": 1, "name": "Server", "created_user": "admin"}],
+            "EntityAttr": [
+                {
+                    "id": 2,
+                    "name": "status",
+                    "type": 1,
+                    "entity": "Server",
+                    "created_user": "admin",
+                    "refer": "",
+                }
+            ],
+        }
+        validated = validate_job_params(JobOperation.IMPORT_ENTITY_PREVIEW, payload)
+        self.assertEqual(validated.EntityAttr[0].entity, "Server")
+
+    def test_role_import_fixture_matches_yaml_contract(self) -> None:
+        payload = [
+            {
+                "name": "operators",
+                "users": ["alice"],
+                "groups": ["operations"],
+                "admin_users": ["admin"],
+                "admin_groups": [],
+                "permissions": [{"obj_id": 1, "permission": "full"}],
+            }
+        ]
+        validated = validate_job_params(JobOperation.IMPORT_ROLE_V2, payload)
+        self.assertEqual(validated.root[0].users, ["alice"])
+
+    def test_trigger_fixtures_accept_v1_and_v2_attribute_shapes(self) -> None:
+        v1 = [{"entity_attr_id": "12", "id": "", "value": [], "referral_key": []}]
+        v2 = [{"id": 12, "value": {"id": 34, "name": "target"}}]
+        self.assertEqual(validate_job_params(JobOperation.MAY_INVOKE_TRIGGER, v1).root[0].id, "")
+        self.assertEqual(validate_job_params(JobOperation.MAY_INVOKE_TRIGGER, v2).root[0].id, 12)
+
+    def test_parse_persisted_json(self) -> None:
+        parsed = parse_job_params(JobOperation.COPY_ENTRY, '{"new_name_list":["copy"]}')
+        self.assertEqual(parsed.new_name_list, ["copy"])
+
+    def test_parse_rejects_malformed_json(self) -> None:
+        with self.assertRaises(ValidationError):
+            parse_job_params(JobOperation.COPY_ENTRY, '{"new_name_list":')
+
+    def test_json_mode_serializes_dates(self) -> None:
+        class JsonModeProbe(BaseModel):
+            value: date
+
+        operation = 10_001
+        register_job_params(operation, JsonModeProbe)
+        self.addCleanup(unregister_job_params, operation)
+        self.assertEqual(
+            serialize_job_params(operation, {"value": date(2026, 8, 29)}),
+            '{"value":"2026-08-29"}',
+        )
+
+    def test_serialization_preserves_explicit_none(self) -> None:
+        class NullableParams(BaseModel):
+            value: str | None = "default"
+
+        operation = 10_004
+        register_job_params(operation, NullableParams)
+        self.addCleanup(unregister_job_params, operation)
+        serialized = serialize_job_params(operation, {"value": None})
+        self.assertEqual(serialized, '{"value":null}')
+        self.assertIsNone(parse_job_params(operation, serialized).value)
+
+    def test_validated_models_and_root_models_are_frozen(self) -> None:
+        object_value = validate_job_params(JobOperation.UPDATE_DOCUMENT, {"is_update": True})
+        root_value = validate_job_params(JobOperation.IMPORT_ROLE_V2, [])
+        with self.assertRaises(ValidationError):
+            object_value.is_update = False
+        with self.assertRaises(ValidationError):
+            root_value.root = []
+
+    def test_custom_contract_registration(self) -> None:
+        class CustomParams(BaseModel):
+            model_config = ConfigDict(extra="forbid")
+            names: list[str]
+
+        operation = 10_002
+        register_job_params(operation, CustomParams)
+        self.addCleanup(unregister_job_params, operation)
+        self.assertIs(get_job_params_contract(operation), CustomParams)
+        self.assertEqual(validate_job_params(operation, {"names": ["a"]}).names, ["a"])
+        with self.assertRaises(ValueError):
+            register_job_params(operation, CustomParams)
+
+    def test_custom_root_contract(self) -> None:
+        class CustomRoot(RootModel[list[int]]):
+            pass
+
+        operation = 10_003
+        register_job_params(operation, CustomRoot)
+        self.addCleanup(unregister_job_params, operation)
+        self.assertEqual(parse_job_params(operation, "[1,2]").root, [1, 2])
+
+    def test_core_contract_cannot_be_replaced(self) -> None:
+        with self.assertRaises(ValueError):
+            register_job_params(JobOperation.DELETE_ENTRY, EmptyParams)
+
+    def test_unknown_operation_fails_closed(self) -> None:
+        with self.assertRaises(ValueError):
+            validate_job_params(999_999, {})

--- a/job/tests/test_task_params.py
+++ b/job/tests/test_task_params.py
@@ -1,0 +1,194 @@
+import inspect
+from unittest import mock
+
+from django.test import TestCase
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from airone.lib.job import _handle_task
+from entity.models import Entity
+from entry.models import Entry
+from job.models import Job, JobOperation, JobStatus, JobTarget
+from job.params import (
+    UpdateDocumentParams,
+    register_job_params,
+    unregister_job_params,
+)
+from user.models import User
+
+
+class JobParamsBoundaryTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create(username="job-params-user")
+
+    def test_invalid_enqueue_does_not_create_row(self):
+        with self.assertRaises(ValidationError):
+            Job._create_new_job(
+                self.user,
+                None,
+                JobOperation.UPDATE_DOCUMENT,
+                "",
+                {"is_update": "not-a-bool"},
+            )
+
+        self.assertEqual(Job.objects.count(), 0)
+
+    def test_canonical_serialization_and_operation_aware_deduplication(self):
+        job = Job._create_new_job(
+            self.user,
+            None,
+            JobOperation.UPDATE_DOCUMENT,
+            "",
+            {"is_update": True},
+        )
+
+        self.assertEqual(job.params, '{"is_update":true}')
+        self.assertEqual(
+            Job.get_job_with_params(
+                self.user, JobOperation.UPDATE_DOCUMENT, {"is_update": True}
+            ).get(),
+            job,
+        )
+        self.assertFalse(
+            Job.get_job_with_params(self.user, JobOperation.NOTIFY_UPDATE_ENTRY, {}).exists()
+        )
+
+    def test_deduplication_finds_pre_deployment_json_representation(self):
+        legacy_job = Job.objects.create(
+            user=self.user,
+            target_type=JobTarget.UNKNOWN,
+            status=JobStatus.PREPARING,
+            operation=JobOperation.UPDATE_DOCUMENT,
+            text="",
+            params='{"is_update": true}',
+        )
+
+        self.assertEqual(
+            Job.get_job_with_params(
+                self.user,
+                JobOperation.UPDATE_DOCUMENT,
+                {"is_update": True},
+            ).get(),
+            legacy_job,
+        )
+
+    def test_typed_params_are_cached_and_expected_contract_is_checked(self):
+        job = Job._create_new_job(
+            self.user,
+            None,
+            JobOperation.UPDATE_DOCUMENT,
+            "",
+            {"is_update": True},
+        )
+
+        parser = job.get_typed_params.__globals__["parse_job_params"]
+        with mock.patch("job.models.parse_job_params", wraps=parser) as parse:
+            first = job.get_typed_params(UpdateDocumentParams)
+            second = job.get_typed_params(UpdateDocumentParams)
+
+        self.assertIs(first, second)
+        parse.assert_called_once()
+        with self.assertRaises(TypeError):
+            job.get_typed_params(dict)
+
+    @mock.patch("airone.lib.job.mail_admins")
+    def test_invalid_legacy_row_fails_before_processing_without_mail_or_handler(
+        self, mail_admins: mock.Mock
+    ):
+        job = Job.objects.create(
+            user=self.user,
+            target_type=JobTarget.UNKNOWN,
+            status=JobStatus.PREPARING,
+            operation=JobOperation.UPDATE_DOCUMENT,
+            text="",
+            params='{"is_update":"secret-invalid-value"}',
+        )
+        handler = mock.Mock()
+
+        with mock.patch("job.models.Logger.error") as logger:
+            _handle_task(object(), handler, job)
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, JobStatus.ERROR)
+        handler.assert_not_called()
+        mail_admins.assert_not_called()
+        self.assertNotIn("secret-invalid-value", str(logger.call_args))
+
+    def test_registered_custom_contract_is_checked_by_common_readiness_boundary(self):
+        class CustomParams(BaseModel):
+            model_config = ConfigDict(strict=True)
+            count: int
+
+        operation = 10_005
+        register_job_params(operation, CustomParams)
+        self.addCleanup(unregister_job_params, operation)
+        job = Job.objects.create(
+            user=self.user,
+            target_type=JobTarget.UNKNOWN,
+            status=JobStatus.PREPARING,
+            operation=operation,
+            text="",
+            params='{"count":"invalid-secret"}',
+        )
+
+        with mock.patch("job.models.Logger.error") as logger:
+            self.assertFalse(job.proceed_if_ready())
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, JobStatus.ERROR)
+        self.assertNotIn("invalid-secret", str(logger.call_args))
+
+    def test_processing_transition_rejects_invalid_params_when_readiness_is_skipped(self):
+        job = Job.objects.create(
+            user=self.user,
+            target_type=JobTarget.UNKNOWN,
+            status=JobStatus.PREPARING,
+            operation=JobOperation.UPDATE_DOCUMENT,
+            text="",
+            params='{"is_update":"invalid-secret"}',
+        )
+
+        with self.assertRaises(ValueError), mock.patch("job.models.Logger.error") as logger:
+            job.update(JobStatus.PROCESSING)
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, JobStatus.ERROR)
+        self.assertNotIn("invalid-secret", str(logger.call_args))
+
+    def test_operation_update_persists_canonical_params(self):
+        job = Job._create_new_job(
+            self.user,
+            None,
+            JobOperation.CREATE_ENTRY,
+            "",
+            {"entry_name": "entry", "attrs": []},
+        )
+        job.params = '{"entry_name": "entry", "attrs": []}'
+        job.save(update_fields=["params"])
+
+        job.update(operation=JobOperation.EDIT_ENTRY)
+
+        job.refresh_from_db()
+        self.assertEqual(job.operation, JobOperation.EDIT_ENTRY)
+        self.assertEqual(job.params, '{"attrs":[],"entry_name":"entry"}')
+
+    def test_legacy_custom_view_staging_pattern_remains_supported(self):
+        entity = Entity.objects.create(name="entity", created_user=self.user)
+        entry = Entry.objects.create(name="entry", schema=entity, created_user=self.user)
+        custom_operation = 10_006
+        handler = mock.Mock()
+
+        job = Job.new_create(self.user, entry)
+        with mock.patch.object(Job, "method_table", return_value={custom_operation: handler}):
+            job.update(operation=custom_operation)
+
+        job.refresh_from_db()
+        self.assertEqual(job.operation, custom_operation)
+        self.assertEqual(job.params, '{"attrs":[],"entry_name":"entry"}')
+
+    def test_factories_have_no_mutable_defaults(self):
+        for name, member in inspect.getmembers(Job, predicate=callable):
+            if not name.startswith("new_"):
+                continue
+            for parameter in inspect.signature(member).parameters.values():
+                self.assertNotIsInstance(parameter.default, (dict, list, set), name)

--- a/job/tests/test_view.py
+++ b/job/tests/test_view.py
@@ -32,7 +32,10 @@ class ViewTest(AironeViewTest):
         entry = Entry.objects.create(name="entry", created_user=user, schema=entity)
 
         # create three jobs
-        [Job.new_create(user, entry) for _ in range(0, _TEST_MAX_LIST_VIEW + 1)]
+        [
+            Job.new_create(user, entry, params={"entry_name": entry.name, "attrs": []})
+            for _ in range(0, _TEST_MAX_LIST_VIEW + 1)
+        ]
         self.assertEqual(Job.objects.filter(user=user).count(), _TEST_MAX_LIST_VIEW + 1)
 
         # checks number of the returned objects are as expected
@@ -70,7 +73,7 @@ class ViewTest(AironeViewTest):
 
         entity = Entity.objects.create(name="entity", created_user=user)
         entry = Entry.objects.create(name="entry", created_user=user, schema=entity)
-        Job.new_create(user, entry)
+        Job.new_create(user, entry, params={"entry_name": entry.name, "attrs": []})
 
         resp = self.client.get("/job/")
         self.assertEqual(resp.status_code, 200)
@@ -107,7 +110,7 @@ class ViewTest(AironeViewTest):
     def test_get_non_target_job(self):
         user = self.guest_login()
 
-        Job.new_create(user, None)
+        Job.new_create(user, None, params={"entry_name": "synthetic-entry", "attrs": []})
 
         resp = self.client.get("/job/")
         self.assertEqual(resp.status_code, 200)
@@ -117,8 +120,13 @@ class ViewTest(AironeViewTest):
         user = self.guest_login()
 
         # create jobs which are related with export
-        (Job.new_export(user),)
-        (Job.new_export_search_result(user),)
+        (Job.new_export(user, params={"export_format": "yaml", "target_id": 0}),)
+        (
+            Job.new_export_search_result(
+                user,
+                params={"entities": [], "attrinfo": [], "export_style": "yaml"},
+            ),
+        )
 
         resp = self.client.get("/job/")
         self.assertEqual(resp.status_code, 200)
@@ -128,7 +136,7 @@ class ViewTest(AironeViewTest):
         user = self.guest_login()
         entity = Entity.objects.create(name="entity", created_user=user)
 
-        job = Job.new_create(user, entity, "hoge")
+        job = Job.new_create(user, entity, "hoge", params={"entry_name": entity.name, "attrs": []})
 
         # When user send a download request of Job with invalid Job-id, then HTTP 400 is returned
         resp = self.client.get("/job/download/%d" % (job.id + 1))
@@ -141,14 +149,14 @@ class ViewTest(AironeViewTest):
         self.assertEqual(resp.content.decode(), "Target Job has no value to return")
 
         # The case user sends a download request for a job which doesn't have a result
-        job = Job.new_export(user, text="fuga")
+        job = Job.new_export(user, text="fuga", params={"export_format": "yaml", "target_id": 0})
         resp = self.client.get("/job/download/%d" % job.id)
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.content.decode(), "This result is no longer available")
 
         # When user send a download request of export Job by differenct user from creating one,
         # then HTTP 400 is returned
-        job = Job.new_export(user, text="fuga")
+        job = Job.new_export(user, text="fuga", params={"export_format": "yaml", "target_id": 0})
         user = self.admin_login()
         resp = self.client.get("/job/download/%d" % job.id)
         self.assertEqual(resp.status_code, 400)
@@ -158,7 +166,7 @@ class ViewTest(AironeViewTest):
         user = self.guest_login()
 
         # initialize an export Job
-        job = Job.new_export(user, text="hoge")
+        job = Job.new_export(user, text="hoge", params={"export_format": "yaml", "target_id": 0})
         job.set_cache("abcd")
 
         # check job contents could be downloaded
@@ -171,7 +179,11 @@ class ViewTest(AironeViewTest):
         user = self.guest_login()
 
         # initialize an export Job
-        job = Job.new_export_search_result(user, text="hoge")
+        job = Job.new_export_search_result(
+            user,
+            text="hoge",
+            params={"entities": [], "attrinfo": [], "export_style": "yaml"},
+        )
         job.set_cache("abcd")
 
         # check job contents could be downloaded
@@ -190,7 +202,7 @@ class ViewTest(AironeViewTest):
         Job.new_register_referrals(user, entry)
 
         # create an unhidden job
-        Job.new_create(user, entry)
+        Job.new_create(user, entry, params={"entry_name": entry.name, "attrs": []})
 
         # access job list page and check only unhidden jobs are returned
         resp = self.client.get("/job/")

--- a/plugin/sdk/pagoda_plugin_sdk/protocols.py
+++ b/plugin/sdk/pagoda_plugin_sdk/protocols.py
@@ -263,6 +263,19 @@ class JobProtocol(Protocol):
     ) -> None: ...
     def to_json(self) -> dict[str, Any]: ...
     def run(self, will_delay: bool = True) -> None: ...
+    def get_typed_params(self, expected_type: type[Any] | None = None) -> Any: ...
+
+    @classmethod
+    def new_custom_job(
+        cls,
+        user: UserProtocol,
+        operation: int,
+        *,
+        params: Any,
+        target: EntryProtocol | None = None,
+        text: str = "",
+        depend_on: Any = None,
+    ) -> "JobProtocol": ...
 
     @classmethod
     def method_table(cls) -> dict[str, Any]: ...


### PR DESCRIPTION
Centralize the Pydantic contracts of all core Job operations into job/params.py (CORE_JOB_PARAMS registry) and enforce them at the Job model boundary instead of ad-hoc parsing inside task modules.

Now it just accepts blinked dict as a job parameter. This PR validate that on creating a job.