### PR TITLE
preserve item name filter when adding attribute join

### DIFF
--- a/frontend/src/components/entry/AdvancedSearchJoinModal.test.tsx
+++ b/frontend/src/components/entry/AdvancedSearchJoinModal.test.tsx
@@ -6,6 +6,7 @@ import {
   EntryAttributeTypeTypeEnum,
 } from "@dmm-com/airone-apiclient-typescript-fetch";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 
 import { AdvancedSearchJoinModal } from "./AdvancedSearchJoinModal";
 
@@ -43,9 +44,10 @@ const joinAttrs: AdvancedSearchJoinAttrInfo[] = [
 vi.mock("hooks/usePagodaSWR", () => ({
   usePagodaSWR: () => ({ data: ["attrA", "attrB", "attrC"] }),
 }));
+const navigateMock = vi.hoisted(() => vi.fn());
 vi.mock("react-router", async () => ({
   ...((await vi.importActual("react-router")) as object),
-  useNavigate: () => vi.fn(),
+  useNavigate: () => navigateMock,
 }));
 vi.spyOn(aironeApiClient, "getEntityAttrs")
   //.mockResolvedValue(["attrA", "attrB", "attrC"]);
@@ -86,6 +88,31 @@ describe("AdvancedSearchJoinModal", () => {
     );
     fireEvent.click(screen.getByText("キャンセル"));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  test("should preserve item-name filter when adding a join", () => {
+    const hintEntry = encodeURIComponent(
+      JSON.stringify({ filterKey: 1, keyword: "target-item" }),
+    );
+    render(
+      <MemoryRouter
+        initialEntries={[`/ui/advanced-search-results?hint_entry=${hintEntry}`]}
+      >
+        <AdvancedSearchJoinModal
+          targetEntityIds={[1]}
+          searchAllEntities={false}
+          targetAttrname="ref_item"
+          joinAttrs={joinAttrs}
+          handleClose={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText("保存"));
+
+    const navigation = navigateMock.mock.calls.at(-1)?.[0];
+    expect(navigation.search).toContain("hint_entry=");
+    expect(decodeURIComponent(navigation.search)).toContain("target-item");
   });
 
   test("should not render modal when targetAttrname is empty", () => {

--- a/frontend/src/components/entry/AdvancedSearchJoinModal.tsx
+++ b/frontend/src/components/entry/AdvancedSearchJoinModal.tsx
@@ -4,12 +4,15 @@ import {
 } from "@dmm-com/airone-apiclient-typescript-fetch";
 import { Autocomplete, Box, Button, TextField } from "@mui/material";
 import { FC, useState } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 
 import { AironeModal } from "components/common/AironeModal";
 import { usePagodaSWR } from "hooks/usePagodaSWR";
 import { aironeApiClient } from "repository/AironeApiClient";
-import { formatAdvancedSearchParams } from "services/entry/AdvancedSearch";
+import {
+  extractAdvancedSearchParams,
+  formatAdvancedSearchParams,
+} from "services/entry/AdvancedSearch";
 
 interface Props {
   targetEntityIds: number[];
@@ -27,6 +30,7 @@ export const AdvancedSearchJoinModal: FC<Props> = ({
   handleClose,
 }) => {
   const navigate = useNavigate();
+  const location = useLocation();
   // This is join attributes that have been already been selected before.
   const currentAttrInfo: AdvancedSearchJoinAttrInfo | undefined =
     joinAttrs.find((attr) => attr.name === targetAttrname);
@@ -50,6 +54,9 @@ export const AdvancedSearchJoinModal: FC<Props> = ({
   ];
 
   const handleUpdatePageURL = () => {
+    const { hintEntry } = extractAdvancedSearchParams(
+      new URLSearchParams(location.search),
+    );
     // to prevent duplication of same name parameter
     const currentJoinAttrs = joinAttrs.filter(
       (attr) => attr.name !== targetAttrname,
@@ -71,6 +78,7 @@ export const AdvancedSearchJoinModal: FC<Props> = ({
     const params = formatAdvancedSearchParams({
       baseParams: new URLSearchParams(location.search),
       joinAttrs: newJoinAttrs,
+      hintEntry,
     });
 
     // Update Page URL parameters


### PR DESCRIPTION
issue: https://github.com/dmm-com/airone/issues/3634

### Summary
Preserve the existing item name filter when adding an attribute join in Advanced Search.

### Changes
- Keep the current hint_entry search condition when updating join attributes.
- Added a regression test to verify that the item name filter is preserved.