### PR TITLE
add automatic naming of Date type

### DIFF
--- a/entity/models.py
+++ b/entity/models.py
@@ -297,7 +297,7 @@ class Entity(ACLBase):
     STATUS_EDITING = 1 << 2
 
     # This describes which Attribute types are selectable when itm_name_type is ATTR
-    ITEM_NAME_SELECTABLE_TYPES = [AttrType.STRING, AttrType.OBJECT, AttrType.NUMBER]
+    ITEM_NAME_SELECTABLE_TYPES = [AttrType.STRING, AttrType.OBJECT, AttrType.NUMBER, AttrType.DATE]
 
     note = models.CharField(max_length=200, blank=True)
 

--- a/entity/tests/test_api_v2_serializers.py
+++ b/entity/tests/test_api_v2_serializers.py
@@ -459,7 +459,7 @@ class EntityAttrSerializerTest(AironeViewTest):
                 serializer.is_valid(raise_exception=True)
 
     def test_create_attr_with_name_order_and_unsupported_type_raises_error(self):
-        for unsupported_type in [AttrType.TEXT, AttrType.BOOLEAN, AttrType.DATE, AttrType.GROUP]:
+        for unsupported_type in [AttrType.TEXT, AttrType.BOOLEAN, AttrType.GROUP]:
             data = {"name": "test_attr", "type": unsupported_type, "name_order": 1}
             serializer = EntityAttrCreateSerializer(
                 data=data, context=self._get_serializer_context()

--- a/entry/models.py
+++ b/entry/models.py
@@ -1936,9 +1936,13 @@ class Entry(ACLBase):
 
                 # NUMBER type returns float; represent whole numbers without decimal point
                 str_value = (
-                    str(int(value))
-                    if isinstance(value, float) and value.is_integer()
-                    else str(value)
+                    value.strftime("%Y-%m-%d")
+                    if attr.schema.type == AttrType.DATE
+                    else (
+                        str(int(value))
+                        if isinstance(value, float) and value.is_integer()
+                        else str(value)
+                    )
                 )
                 username += attr.schema.name_prefix + str_value + attr.schema.name_postfix
 

--- a/entry/tests/test_model_validation.py
+++ b/entry/tests/test_model_validation.py
@@ -1493,6 +1493,29 @@ class ModelValidationTest(BaseModelTest):
         )
         self.assertEqual(lb_sg1.autoname, "[LB0001] pagoda-test.example.com:80 #100")
 
+    def test_autoname_date_attribute(self):
+        model = self.create_entity(
+            self._user,
+            "DateAutoName",
+            attrs=[
+                {
+                    "name": "start_date",
+                    "type": AttrType.DATE,
+                    "name_order": 1,
+                    "name_prefix": "date=",
+                }
+            ],
+            item_name_type=ItemNameType.ATTR,
+        )
+        item = self.add_entry(
+            self._user,
+            "temporary",
+            model,
+            values={"start_date": date(2026, 9, 8)},
+        )
+
+        self.assertEqual(item.autoname, "date=2026-09-08")
+
     def test_save_autoname_with_duplicated_values(self):
         model = self.create_entity(
             self._user,

--- a/frontend/src/components/entity/entityForm/AttributeField.tsx
+++ b/frontend/src/components/entity/entityForm/AttributeField.tsx
@@ -57,6 +57,7 @@ const AUTONAME_SELECTABLE_TYPES = [
   AttributeTypes.string.type,
   AttributeTypes.object.type,
   AttributeTypes.number.type,
+  AttributeTypes.date.type,
 ];
 
 // Attribute types eligible as display_attr on a referred entry (mirrors backend

--- a/frontend/src/components/entity/entityForm/AttributesFields.test.tsx
+++ b/frontend/src/components/entity/entityForm/AttributesFields.test.tsx
@@ -125,6 +125,35 @@ describe("AttributesFields", () => {
     expect(screen.getAllByTestId("attr-drag-handle")).toHaveLength(1);
   });
 
+  test("enables auto-naming for date attributes", async () => {
+    renderFields({
+      ...defaultValues,
+      attrs: [
+        {
+          name: "date-attr",
+          type: AttributeTypes.date.type,
+          isMandatory: false,
+          isDeleteInChain: false,
+          isSummarized: false,
+          isWritable: true,
+          referral: [],
+          note: "",
+          nameOrder: "0",
+          namePrefix: "",
+          namePostfix: "",
+          displayAttr: "",
+        },
+      ],
+    });
+
+    await act(async () => {
+      screen.getByRole("button", { name: "1 番目の属性の詳細メニューを開く" }).click();
+    });
+
+    expect(screen.getByRole("button", { name: /自動命名/ })).not.toBeDisabled();
+  });
+
+
   test("disables the drag handle for a non-writable attribute", () => {
     renderFields({
       ...defaultValues,

--- a/frontend/src/components/entity/entityForm/AttributesFields.test.tsx
+++ b/frontend/src/components/entity/entityForm/AttributesFields.test.tsx
@@ -147,12 +147,13 @@ describe("AttributesFields", () => {
     });
 
     await act(async () => {
-      screen.getByRole("button", { name: "1 番目の属性の詳細メニューを開く" }).click();
+      screen
+        .getByRole("button", { name: "1 番目の属性の詳細メニューを開く" })
+        .click();
     });
 
     expect(screen.getByRole("button", { name: /自動命名/ })).not.toBeDisabled();
   });
-
 
   test("disables the drag handle for a non-writable attribute", () => {
     renderFields({

--- a/job/params.py
+++ b/job/params.py
@@ -253,7 +253,7 @@ class EntityAttrV2Params(JobParamsModel):
     is_summarized: bool = False
     referral: list[int] = Field(default_factory=list)
     note: str = ""
-    default_value: str | bool | int | float | None = None
+    default_value: str | bool | int | float | list[int] | None = None
     choices: list[dict[str, str]] | None = None
     name_order: int | None = 0
     name_prefix: str | None = ""
@@ -299,7 +299,7 @@ class EditEntityAttrV2Params(JobParamsModel):
     is_summarized: bool | None = None
     referral: list[int] | None = None
     note: str | None = None
-    default_value: str | bool | int | float | None = None
+    default_value: str | bool | int | float | list[int] | None = None
     choices: list[dict[str, str]] | None = None
     is_deleted: bool = False
     name_order: int | None = 0

--- a/job/params.py
+++ b/job/params.py
@@ -349,6 +349,20 @@ def _normalize_entity_attr_default(value: Any, attr_type: Any) -> Any:
         return value if isinstance(value, bool) else None
     if attr_type == AttrType.NUMBER:
         return value if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+    if attr_type == AttrType.OBJECT:
+        return (
+            value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else None
+        )
+    if attr_type == AttrType.ARRAY_OBJECT:
+        if (
+            isinstance(value, list)
+            and all(
+                isinstance(item, int) and not isinstance(item, bool) and item > 0 for item in value
+            )
+            and len(value) == len(set(value))
+        ):
+            return value or None
+        return None
     return None
 
 


### PR DESCRIPTION
issue: https://github.com/dmm-com/airone/issues/3659
## Description

Enable auto-naming for `DATE` attributes.

When a `DATE` attribute is selected for auto-naming, its value is formatted as `YYYY-MM-DD` and used as part of the item name.

### Changes

- Added `DATE` to the backend auto-naming selectable attribute types.
- Added `DATE` to the frontend auto-naming selectable types.
- Formatted date values as `YYYY-MM-DD` when generating item names.
- Added backend and frontend tests for DATE auto-naming.