### PR TITLE
remove duplicate calls

### DIFF
--- a/frontend/src/hooks/usePage.tsx
+++ b/frontend/src/hooks/usePage.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useCallback, useEffect, useState } from "react";
+import { startTransition, useCallback, useMemo } from "react";
 import { useNavigate, useLocation } from "react-router";
 
 type UsePageReturn = {
@@ -15,17 +15,16 @@ export const usePage = (): UsePageReturn => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const [page, setPage] = useState<number>(1);
-  const [query, setQuery] = useState<string>("");
-
-  useEffect(() => {
+  const { page, query } = useMemo(() => {
     const params = new URLSearchParams(location.search);
     const pageParam = params.get("page");
     const pageNumber = pageParam ? Number(pageParam) : 1;
-    setPage(isNaN(pageNumber) ? 1 : pageNumber);
-    setQuery(
-      params.has("query") ? decodeURIComponent(params.get("query") ?? "") : "",
-    );
+    return {
+      page: isNaN(pageNumber) ? 1 : pageNumber,
+      query: params.has("query")
+        ? decodeURIComponent(params.get("query") ?? "")
+        : "",
+    };
   }, [location.search]);
 
   const changePage = useCallback(

--- a/frontend/src/pages/AdvancedSearchResultsPage.test.tsx
+++ b/frontend/src/pages/AdvancedSearchResultsPage.test.tsx
@@ -1,7 +1,13 @@
 /**
  */
 
-import { render, screen, act, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  act,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 
@@ -53,6 +59,32 @@ const server = setupServer(
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
+
+test("should call advanced search once when changing to the next page", async () => {
+  const requests: Array<Record<string, unknown>> = [];
+  server.use(
+    http.post(
+      "http://localhost/entry/api/v2/advanced_search/",
+      async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        requests.push(body);
+        return HttpResponse.json({ count: 1, total_count: 101, values: [] });
+      },
+    ),
+  );
+
+  await act(async () => {
+    render(<AdvancedSearchResultsPage />, { wrapper: TestWrapper });
+  });
+  await waitFor(() =>
+    expect(screen.queryByTestId("loading")).not.toBeInTheDocument(),
+  );
+  fireEvent.click(screen.getByLabelText("Go to page 2"));
+
+  await waitFor(() => expect(requests).toHaveLength(2));
+  expect(requests[0].entry_offset).toBe(0);
+  expect(requests[1].entry_offset).toBe(100);
+});
 
 test("should match snapshot", async () => {
   Object.defineProperty(window, "django_context", {

--- a/frontend/src/pages/AdvancedSearchResultsPage.tsx
+++ b/frontend/src/pages/AdvancedSearchResultsPage.tsx
@@ -226,7 +226,7 @@ export const AdvancedSearchResultsPage: FC = () => {
         if (myId !== requestIdRef.current) return;
         setSearchResults((prev) => ({ ...prev, isInProcessing: false }));
       });
-  }, [page, toggle, location.search]);
+  }, [toggle, location.search]);
 
   const handleExport = async (exportStyle: "yaml" | "csv") => {
     try {


### PR DESCRIPTION
issue: https://github.com/dmm-com/airone/issues/3648

Fix duplicate API requests when paginating Advanced Search results.

The `entry/api/v2/advanced_search/` API was called twice when navigating to page 2 or later because the page number was managed separately in the URL and React state. Centralize page management in the URL so that each page change triggers only one API request.

Add a regression test to verify that navigating to the second page results in exactly one additional API call.