### PR TITLE
Fix referral model filter placeholder labels

### DIFF
--- a/frontend/src/components/entry/SearchResultControlMenuForReferral.test.tsx
+++ b/frontend/src/components/entry/SearchResultControlMenuForReferral.test.tsx
@@ -48,9 +48,7 @@ describe("SearchResultControlMenuForReferral", () => {
       { wrapper: TestWrapper },
     );
 
-    expect(
-      screen.getByPlaceholderText("次のモデルを含む"),
-    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("次のモデルを含む")).toBeInTheDocument();
     expect(
       screen.getByPlaceholderText("次のモデルを含まない"),
     ).toBeInTheDocument();

--- a/frontend/src/components/entry/SearchResultControlMenuForReferral.test.tsx
+++ b/frontend/src/components/entry/SearchResultControlMenuForReferral.test.tsx
@@ -1,7 +1,7 @@
 /**
  */
 
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 import { SearchResultControlMenuForReferral } from "./SearchResultControlMenuForReferral";
 
@@ -36,6 +36,24 @@ describe("SearchResultControlMenuForReferral", () => {
     );
 
     expect(container).toBeInTheDocument();
+  });
+
+  test("should show distinct placeholders for included and excluded models", () => {
+    const anchorElem = document.createElement("button");
+    render(
+      <SearchResultControlMenuForReferral
+        {...defaultProps}
+        anchorElem={anchorElem}
+      />,
+      { wrapper: TestWrapper },
+    );
+
+    expect(
+      screen.getByPlaceholderText("次のモデルを含む"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("次のモデルを含まない"),
+    ).toBeInTheDocument();
   });
 
   test("should not render menu when anchorElem is null", () => {

--- a/frontend/src/components/entry/SearchResultControlMenuForReferral.tsx
+++ b/frontend/src/components/entry/SearchResultControlMenuForReferral.tsx
@@ -206,7 +206,7 @@ export const SearchResultControlMenuForReferral: FC<Props> = ({
           <TextField
             {...params}
             variant="outlined"
-            placeholder="次のモデルを含む"
+            placeholder="次のモデルを含まない"
             size="small"
           />
         )}


### PR DESCRIPTION
## Summary
Fix the placeholder labels for referral model filters in the advanced search control menu (`SearchResultControlMenuForReferral`).

- 1st Autocomplete (`referralIncludeModelIds`): `次のモデルを含む`
- 2nd Autocomplete (`referralExcludeModelIds`): `次のモデルを含まない`

Previously, both fields displayed "次のモデルを含む".

## Changes
- [frontend/src/components/entry/SearchResultControlMenuForReferral.tsx](frontend/src/components/entry/SearchResultControlMenuForReferral.tsx#L209): Updated the placeholder of the exclude model filter to "次のモデルを含まない".
- [frontend/src/components/entry/SearchResultControlMenuForReferral.test.tsx](frontend/src/components/entry/SearchResultControlMenuForReferral.test.tsx#L41-L57): Added unit test verifying both placeholders are rendered distinctly.

<img width="1737" height="774" alt="image" src="https://github.com/user-attachments/assets/78275406-6fac-4e28-9172-76c342ce3eb2" />
