### PR TITLE
Implementation of search that handles full-width and half-width characters

### DIFF
--- a/airone/lib/text.py
+++ b/airone/lib/text.py
@@ -1,0 +1,6 @@
+import unicodedata
+
+
+def normalize_search_text(value: str) -> str:
+    """Normalize text for case- and width-insensitive search."""
+    return unicodedata.normalize("NFKC", value).casefold()

--- a/airone/tests/test_text.py
+++ b/airone/tests/test_text.py
@@ -1,0 +1,15 @@
+import unittest
+
+from airone.lib.text import normalize_search_text
+
+
+class NormalizeSearchTextTest(unittest.TestCase):
+    def test_normalizes_width_and_case(self) -> None:
+        self.assertEqual(
+            normalize_search_text("ﾊﾝｶｸ-ＢＩＧ-LARGE"),
+            "ハンカク-big-large",
+        )
+
+    def test_normalizes_japanese_search_text(self) -> None:
+        value = normalize_search_text("ﾊﾝｶｸ-ＢＩＧ-LARGE")
+        self.assertIn(normalize_search_text("ハンカク-big"), value)

--- a/category/api_v2/views.py
+++ b/category/api_v2/views.py
@@ -8,9 +8,11 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
+from rest_framework.views import APIView
 
 from airone.lib.acl import ACLType
 from airone.lib.drf import ObjectNotExistsError
+from airone.lib.text import normalize_search_text
 from category.api_v2.serializers import (
     CategoryCreateSerializer,
     CategoryListSerializer,
@@ -21,10 +23,30 @@ from entity.api_v2.views import EntityPermission
 from user.models import User
 
 
+class CategorySearchFilter(filters.SearchFilter):
+    def filter_queryset(self, request: Request, queryset: Any, view: APIView) -> Any:
+        terms = self.get_search_terms(request)
+        if not terms:
+            return queryset
+
+        normalized_terms = [normalize_search_text(term) for term in terms]
+        return [
+            category
+            for category in queryset
+            if all(
+                any(
+                    term in normalize_search_text(value)
+                    for value in [category.name, *(category.models.values_list("name", flat=True))]
+                )
+                for term in normalized_terms
+            )
+        ]
+
+
 class CategoryAPI(viewsets.ModelViewSet[Category]):
     pagination_class = LimitOffsetPagination
     permission_classes = [IsAuthenticated & EntityPermission]
-    filter_backends = [DjangoFilterBackend, filters.OrderingFilter, filters.SearchFilter]
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter, CategorySearchFilter]
     search_fields = ["name", "models__name"]
     ordering = ["-priority", "name"]
 

--- a/entity/api_v2/views.py
+++ b/entity/api_v2/views.py
@@ -1,6 +1,5 @@
 import copy
 import logging
-import unicodedata
 from typing import Any, List, cast
 
 from django.db.models import F, QuerySet
@@ -22,6 +21,7 @@ from airone.lib.acl import ACLType, get_permitted_objects
 from airone.lib.drf import EntryIsNotEmptyError, ObjectNotExistsError, YAMLParser, YAMLRenderer
 from airone.lib.http import http_get
 from airone.lib.plugin_dispatch import PluginOverrideMixin
+from airone.lib.text import normalize_search_text
 from entity.api_v2.serializers import (
     EntityAttrNameSerializer,
     EntityCreateSerializer,
@@ -162,6 +162,18 @@ class NameCaseInsensitiveSearchFilter(filters.SearchFilter):
     def get_search_terms(self, request: Request) -> list[str]:
         return [term.lower() for term in super().get_search_terms(request)]
 
+    def filter_queryset(self, request: Request, queryset: Any, view: APIView) -> Any:
+        terms = self.get_search_terms(request)
+        if not terms:
+            return queryset
+
+        normalized_terms = [normalize_search_text(term) for term in terms]
+        return [
+            entity
+            for entity in queryset
+            if all(term in normalize_search_text(entity.name) for term in normalized_terms)
+        ]
+
 
 @extend_schema(
     parameters=[
@@ -271,14 +283,14 @@ class AliasSearchFilter(filters.SearchFilter):
         if not terms:
             return queryset
 
-        normalized_terms = [unicodedata.normalize("NFKC", term).casefold() for term in terms]
+        normalized_terms = [normalize_search_text(term) for term in terms]
         with_alias = bool(request.query_params.get("with_alias"))
         return [
             entry
             for entry in queryset
             if all(
                 any(
-                    term in unicodedata.normalize("NFKC", value).casefold()
+                    term in normalize_search_text(value)
                     for value in (
                         [entry.name]
                         + ([alias.name for alias in entry.aliases.all()] if with_alias else [])

--- a/frontend/src/components/group/GroupForm.tsx
+++ b/frontend/src/components/group/GroupForm.tsx
@@ -22,6 +22,7 @@ import { Schema } from "./groupForm/GroupFormSchema";
 
 import { Loading } from "components/common/Loading";
 import { aironeApiClient } from "repository/AironeApiClient";
+import { fuzzyMatch, normalizeToMatch } from "services/StringUtil";
 
 interface Props {
   control: Control<Schema>;
@@ -33,7 +34,10 @@ export const GroupForm: FC<Props> = ({ control, setValue, groupId }) => {
   const [userKeyword, setUserKeyword] = useState("");
 
   const { data: users } = usePagodaSWR(["users", 1, userKeyword], async () => {
-    const _users = await aironeApiClient.getUsers(1, userKeyword);
+    const _users = await aironeApiClient.getUsers(
+      1,
+      normalizeToMatch(userKeyword),
+    );
     return _users.results?.map(
       (user): GroupMember => ({ id: user.id, username: user.username }),
     );
@@ -97,6 +101,11 @@ export const GroupForm: FC<Props> = ({ control, setValue, groupId }) => {
                     {...field}
                     options={users ?? []}
                     getOptionLabel={(option: GroupMember) => option.username}
+                    filterOptions={(options, state) =>
+                      options.filter((option) =>
+                        fuzzyMatch(option.username, state.inputValue),
+                      )
+                    }
                     isOptionEqualToValue={(option: GroupMember, value) =>
                       option.id === value.id
                     }

--- a/frontend/src/components/role/RoleForm.tsx
+++ b/frontend/src/components/role/RoleForm.tsx
@@ -28,6 +28,8 @@ import { aironeApiClient } from "../../repository/AironeApiClient";
 
 import { Schema } from "./roleForm/RoleFormSchema";
 
+import { fuzzyMatch } from "services/StringUtil";
+
 interface Props {
   control: Control<Schema>;
   setValue: UseFormSetValue<Schema>;
@@ -325,6 +327,11 @@ export const RoleForm: FC<Props> = ({ control, setValue }) => {
                         {...field}
                         options={adminUsers ?? []}
                         getOptionLabel={(option: RoleUser) => option.username}
+                        filterOptions={(options, state) =>
+                          options.filter((option) =>
+                            fuzzyMatch(option.username, state.inputValue),
+                          )
+                        }
                         isOptionEqualToValue={(option, value) =>
                           option.id === value.id
                         }
@@ -397,6 +404,11 @@ export const RoleForm: FC<Props> = ({ control, setValue }) => {
                         {...field}
                         options={users ?? []}
                         getOptionLabel={(option: RoleUser) => option.username}
+                        filterOptions={(options, state) =>
+                          options.filter((option) =>
+                            fuzzyMatch(option.username, state.inputValue),
+                          )
+                        }
                         isOptionEqualToValue={(option, value) =>
                           option.id === value.id
                         }

--- a/frontend/src/pages/GroupListPage.tsx
+++ b/frontend/src/pages/GroupListPage.tsx
@@ -27,6 +27,7 @@ import { aironeApiClient } from "repository/AironeApiClient";
 import { newGroupPath, topPath } from "routes/Routes";
 import { TITLE_TEMPLATES } from "services";
 import { ServerContext } from "services/ServerContext";
+import { fuzzyMatch } from "services/StringUtil";
 
 const StyledContainer = styled(Container)({
   paddingTop: "16px",
@@ -70,11 +71,8 @@ const GroupListContent: FC = () => {
   );
 
   const filteredUsersInGroup = useMemo(() => {
-    const keywordLower = keyword.toLowerCase();
     return (
-      usersInGroup?.filter((user) =>
-        user.username.toLowerCase().includes(keywordLower),
-      ) ?? []
+      usersInGroup?.filter((user) => fuzzyMatch(user.username, keyword)) ?? []
     );
   }, [usersInGroup, keyword]);
 

--- a/frontend/src/services/StringUtil.test.ts
+++ b/frontend/src/services/StringUtil.test.ts
@@ -4,6 +4,7 @@ test("text should includes substring keyword with fuzzy conversions", () => {
   expect(normalizeToMatch("test")).toBe("test");
   expect(normalizeToMatch("TEST")).toBe("test");
   expect(normalizeToMatch("ｔｅｓｔ")).toBe("test");
+  expect(normalizeToMatch("ﾊﾝｶｸ-ＢＩＧ-LARGE")).toBe("ハンカク-big-large");
 });
 
 test("text should includes substring keyword with fuzzy conversions", () => {
@@ -16,5 +17,8 @@ test("text should includes substring keyword with fuzzy conversions", () => {
   expect(fuzzyMatch("ｔｅｓｔ", "test")).toBe(true);
   expect(fuzzyMatch("test", "ｔｅｓｔ")).toBe(true);
 
+  // Half-width Katakana, full-width uppercase, and half-width uppercase.
+  expect(fuzzyMatch("ﾊﾝｶｸ-ＢＩＧ-LARGE", "ハンカク-big")).toBe(true);
+  expect(fuzzyMatch("ﾊﾝｶｸ-ＢＩＧ-LARGE", "ﾊﾝｶｸ")).toBe(true);
   expect(fuzzyMatch("unrelated text", "test")).toBe(false);
 });

--- a/frontend/src/services/StringUtil.ts
+++ b/frontend/src/services/StringUtil.ts
@@ -10,12 +10,14 @@ function toHalfWidth(origin: string): string {
 }
 
 export function normalizeToMatch(keyword: string): string {
-  return toHalfWidth(keyword.toLowerCase());
+  return toHalfWidth(keyword.normalize("NFKC").toLowerCase());
 }
 
 export function fuzzyMatch(text: string, keyword: string): boolean {
-  const normalizedText = toHalfWidth(text.toLowerCase());
-  const normalizedKeyword = toHalfWidth(keyword.toLowerCase());
+  const normalizedText = toHalfWidth(text.normalize("NFKC").toLowerCase());
+  const normalizedKeyword = toHalfWidth(
+    keyword.normalize("NFKC").toLowerCase(),
+  );
 
   return normalizedText.indexOf(normalizedKeyword) !== -1;
 }

--- a/group/api_v2/views.py
+++ b/group/api_v2/views.py
@@ -1,3 +1,4 @@
+import unicodedata
 from typing import Any, cast
 
 from django.db.models import Prefetch
@@ -34,6 +35,23 @@ class UserPermission(BasePermission):
         return permisson.get(getattr(view, "action", ""), False)
 
 
+class GroupSearchFilter(filters.SearchFilter):
+    def filter_queryset(self, request: Request, queryset: Any, view: APIView) -> Any:
+        terms = self.get_search_terms(request)
+        if not terms:
+            return queryset
+
+        normalized_terms = [unicodedata.normalize("NFKC", term).casefold() for term in terms]
+        return [
+            group
+            for group in queryset
+            if all(
+                term in unicodedata.normalize("NFKC", group.name).casefold()
+                for term in normalized_terms
+            )
+        ]
+
+
 class GroupAPI(viewsets.ModelViewSet[Group]):
     queryset = Group.objects.filter(is_active=True).prefetch_related(  # type: ignore[assignment,misc]
         Prefetch(
@@ -44,7 +62,7 @@ class GroupAPI(viewsets.ModelViewSet[Group]):
     )
     permission_classes = [IsAuthenticated & UserPermission]
     pagination_class = PageNumberPagination
-    filter_backends = [DjangoFilterBackend, filters.OrderingFilter, filters.SearchFilter]
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter, GroupSearchFilter]
     ordering = ["name"]
     search_fields = ["name"]
 
@@ -60,7 +78,7 @@ class GroupAPI(viewsets.ModelViewSet[Group]):
 class GroupTreeAPI(viewsets.ReadOnlyModelViewSet[Group]):
     queryset = Group.objects.filter(parent_group__isnull=True, is_active=True)  # type: ignore[assignment,misc]
     serializer_class = GroupTreeSerializer
-    filter_backends = [DjangoFilterBackend, filters.OrderingFilter, filters.SearchFilter]
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter, GroupSearchFilter]
     ordering = ["name"]
     search_fields = ["name"]
 

--- a/user/api_v2/views.py
+++ b/user/api_v2/views.py
@@ -20,10 +20,12 @@ from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer, Serializer
+from rest_framework.views import APIView
 
 from airone.exceptions.model import UnexpectedAttributeType
 from airone.lib.acl import ACLType
 from airone.lib.drf import YAMLParser, YAMLRenderer
+from airone.lib.text import normalize_search_text
 from airone.lib.types import AttrType
 from entry.models import AttributeValue, Entry
 from group.models import Group
@@ -392,11 +394,25 @@ class UserActivityAPI(viewsets.GenericViewSet[User]):
         return Response(activities)
 
 
+class UserSearchFilter(filters.SearchFilter):
+    def filter_queryset(self, request: Request, queryset: Any, view: APIView) -> Any:
+        terms = self.get_search_terms(request)
+        if not terms:
+            return queryset
+
+        normalized_terms = [normalize_search_text(term) for term in terms]
+        return [
+            user
+            for user in queryset
+            if all(term in normalize_search_text(user.username) for term in normalized_terms)
+        ]
+
+
 class UserAPI(viewsets.ModelViewSet[User]):
     queryset = User.objects.filter(is_active=True)
     permission_classes = [IsAuthenticated & UserPermission]
     pagination_class = PageNumberPagination
-    filter_backends = [DjangoFilterBackend, filters.OrderingFilter, filters.SearchFilter]
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter, UserSearchFilter]
     ordering = ["username"]
     search_fields = ["username"]
 


### PR DESCRIPTION
issue: https://github.com/dmm-com/airone/issues/3660

Add case- and width-insensitive filtering for user search candidates in group and role management screens, including full-width and half-width Katakana support.