### PR TITLE
Changed the offset limit to the maximum number of items.

### DIFF
--- a/frontend/src/pages/AdvancedSearchResultsPage.test.tsx
+++ b/frontend/src/pages/AdvancedSearchResultsPage.test.tsx
@@ -12,7 +12,10 @@ import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 
 import { TestWrapper } from "TestWrapper";
-import { AdvancedSearchResultsPage } from "pages/AdvancedSearchResultsPage";
+import {
+  AdvancedSearchResultsPage,
+  getDisplayedSearchResultCount,
+} from "pages/AdvancedSearchResultsPage";
 
 const server = setupServer(
   // getEntityAttrs
@@ -84,6 +87,12 @@ test("should call advanced search once when changing to the next page", async ()
   await waitFor(() => expect(requests).toHaveLength(2));
   expect(requests[0].entry_offset).toBe(0);
   expect(requests[1].entry_offset).toBe(100);
+});
+
+test("should cap the displayed loaded count at the total count", () => {
+  expect(getDisplayedSearchResultCount(2, 160, 100)).toBe(160);
+  expect(getDisplayedSearchResultCount(2, 200, 100)).toBe(200);
+  expect(getDisplayedSearchResultCount(1, 160, 100)).toBe(100);
 });
 
 test("should match snapshot", async () => {

--- a/frontend/src/pages/AdvancedSearchResultsPage.tsx
+++ b/frontend/src/pages/AdvancedSearchResultsPage.tsx
@@ -121,6 +121,12 @@ export const getIsFiltered = (filterKey?: number, keyword?: string) => {
   return false;
 };
 
+export const getDisplayedSearchResultCount = (
+  page: number,
+  totalCount: number,
+  maxRowCount: number,
+) => Math.min(page * maxRowCount, totalCount);
+
 interface AirOneAdvancedSearchResult extends AdvancedSearchResult {
   page: number;
   isInProcessing: boolean;
@@ -450,8 +456,12 @@ export const AdvancedSearchResultsPage: FC = () => {
                     <ArrowDropDownIcon />
                   </IconButton>
                   <Typography>
-                    {page * AdvancedSerarchResultListParam.MAX_ROW_COUNT} /{" "}
-                    {searchResults.totalCount} 件
+                    {getDisplayedSearchResultCount(
+                      page,
+                      searchResults.totalCount,
+                      AdvancedSerarchResultListParam.MAX_ROW_COUNT,
+                    )}{" "}
+                    / {searchResults.totalCount} 件
                   </Typography>
                 </CenterAlignedBox>
               )}


### PR DESCRIPTION
issue: https://github.com/dmm-com/airone/issues/3654

Fix advanced search result count display so the displayed count never exceeds the total number of search results when loading paginated joined-search results.