### PR TITLE
Reduce report-coverage job parallelism in build-core.yml

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -145,20 +145,17 @@ jobs:
 
   report-coverage:
     runs-on: ubuntu-24.04
-    needs: [setup_python, test]
+    needs: test
     permissions:
       contents: read
       pull-requests: write
-    strategy:
-      fail-fast: false
-      matrix:
-        target: ${{ fromJson(needs.setup_python.outputs.targets) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Download coverage report
+      - name: Download coverage reports
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: coverage-${{ matrix.target }}
+          pattern: coverage-*
+          path: coverage-reports
       - name: octocov
         uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1
         with:

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,7 +1,7 @@
 coverage:
   paths:
-    - coverage.xml              # Python coverage from coverage.py
-    - coverage/lcov.info         # Frontend coverage from Vitest
+    - coverage-reports/**/coverage.xml  # Python coverage from coverage.py (one report per test matrix target)
+    - coverage/lcov.info                # Frontend coverage from Vitest
 comment:
   if: true                     # Always comment on PRs
 report:


### PR DESCRIPTION
## Summary

- 8419496506ae951c2d9d2a293f6f131b97e06e05 separated octocov into a `report-coverage` job for minimal permissions, but that job kept the same `matrix.target` as `test`, so it now runs one extra job per target (test N + report-coverage N instead of N).
- Collapse `report-coverage` into a single job. It downloads all per-target `coverage-*` artifacts into `coverage-reports/<target>/coverage.xml`, and `.octocov.yml`'s `coverage.paths` now uses a glob (`coverage-reports/**/coverage.xml`) so octocov merges them, matching the single-job shape `report-coverage` already has in build-frontend.yml.
- The permission-minimization intent from the original change (`test` no longer holds `pull-requests: write`) is unchanged.

## Test plan

- [ ] CI (build-core.yml) passes on this PR
- [ ] `report-coverage` runs as a single job and posts exactly one coverage comment on the PR
- [ ] The coverage numbers in that comment are unchanged from before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)