### PR TITLE
Adding read-only users to the user management screen: Frontend implementation

### DIFF
--- a/frontend/src/components/user/UserForm.test.tsx
+++ b/frontend/src/components/user/UserForm.test.tsx
@@ -151,6 +151,20 @@ describe("UserForm", () => {
     );
   });
 
+  test("should render created read-only users as links", function () {
+    renderUserForm(
+      {
+        ...userInfo,
+        coUsers: [{ id: 2, username: "user1-readonly" }],
+      } as UserRetrieve,
+      false,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "user1-readonly" }),
+    ).toHaveAttribute("href", "/ui/users/2");
+  });
+
   test("should show placeholders when the user belongs to nothing", function () {
     renderUserForm({ ...userInfo, groups: [], roles: [] }, false);
 

--- a/frontend/src/components/user/UserForm.tsx
+++ b/frontend/src/components/user/UserForm.tsx
@@ -38,9 +38,15 @@ import { Schema } from "./userForm/UserFormSchema";
 
 import { AironeLink } from "components/common/AironeLink";
 import { FlexBox } from "components/common/FlexBox";
-import { groupPath, rolePath } from "routes/Routes";
+import { groupPath, rolePath, userPath } from "routes/Routes";
 import { ServerContext } from "services/ServerContext";
 import { User } from "services/ServerContext";
+
+type CoUserLink = { id: number; username: string };
+
+type UserWithCoUsers = UserRetrieve & {
+  coUsers?: CoUserLink[];
+};
 
 const StyledTableRow = styled(TableRow)(() => ({
   "&:nth-of-type(odd)": {
@@ -400,6 +406,35 @@ const ElemRoles: FC<ReadonlyProps> = ({ user }) => {
   );
 };
 
+const ElemCoUsers: FC<ReadonlyProps> = ({ user }) => {
+  const coUsers = (user as UserWithCoUsers).coUsers ?? [];
+  if (coUsers.length === 0) return null;
+
+  return (
+    <StyledTableRow>
+      <TableCell sx={{ width: "400px", wordBreak: "break-word" }}>
+        作成したRead-Onlyユーザー
+      </TableCell>
+      <TableCell sx={{ width: "750px", p: "0px", wordBreak: "break-word" }}>
+        {
+          <ChipBox>
+            {coUsers.map((coUser) => (
+              <Chip
+                key={coUser.id}
+                label={coUser.username}
+                size="small"
+                component={AironeLink}
+                to={userPath(coUser.id)}
+                clickable
+              />
+            ))}
+          </ChipBox>
+        }
+      </TableCell>
+    </StyledTableRow>
+  );
+};
+
 const ElemUserPassword: FC<Props> = ({ control }) => {
   return (
     <StyledTableRow>
@@ -516,6 +551,7 @@ export const UserForm: FC<UserFormProps> = ({
               <>
                 <ElemGroups user={user} />
                 <ElemRoles user={user} />
+                <ElemCoUsers user={user} />
               </>
             )}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "GPLv2",
       "dependencies": {
+        "@dmm-com/airone-apiclient-typescript-fetch": "0.29.6",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -74,7 +75,7 @@
         "zod": "^3.24.2"
       },
       "optionalDependencies": {
-        "@dmm-com/airone-apiclient-typescript-fetch": "^0.29.5"
+        "@dmm-com/airone-apiclient-typescript-fetch": "0.29.6"
       },
       "peerDependencies": {
         "@mui/material": "^6.0.0",
@@ -2072,13 +2073,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/@dmm-com/airone-apiclient-typescript-fetch": {
-      "version": "0.29.5",
-      "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.29.5/45e47da3f85463bcbecd45db99fcc50fa074cf6d",
-      "integrity": "sha512-drXL2Jvlp5/GTmS3pAiI3B7AgTylsB6yRkedEQfai1tI14OjLZxoaTaEgidimA6MyjfHBykar/w2BKnv7m9NZw==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
@@ -13582,12 +13576,6 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
-    },
-    "@dmm-com/airone-apiclient-typescript-fetch": {
-      "version": "0.29.5",
-      "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.29.5/45e47da3f85463bcbecd45db99fcc50fa074cf6d",
-      "integrity": "sha512-drXL2Jvlp5/GTmS3pAiI3B7AgTylsB6yRkedEQfai1tI14OjLZxoaTaEgidimA6MyjfHBykar/w2BKnv7m9NZw==",
-      "optional": true
     },
     "@dnd-kit/accessibility": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "GPLv2",
       "dependencies": {
-        "@dmm-com/airone-apiclient-typescript-fetch": "0.29.6",
+        "@dmm-com/airone-apiclient-typescript-fetch": "^0.29.6",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -2073,6 +2073,13 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@dmm-com/airone-apiclient-typescript-fetch": {
+      "version": "0.29.6",
+      "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.29.6/e541529da126b17cd9783f7341c9b81f19c31477",
+      "integrity": "sha512-KR8AAehhwHwEbFxg5uC7JuWFZwW9OkudTYF/YGI+jU6x+7Xlwd3gKwDvOgsEQwE2fBiRfSAQ3ZPNOXr/VP13SQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
@@ -13576,6 +13583,12 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
+    },
+    "@dmm-com/airone-apiclient-typescript-fetch": {
+      "version": "0.29.6",
+      "resolved": "https://npm.pkg.github.com/download/@dmm-com/airone-apiclient-typescript-fetch/0.29.6/e541529da126b17cd9783f7341c9b81f19c31477",
+      "integrity": "sha512-KR8AAehhwHwEbFxg5uC7JuWFZwW9OkudTYF/YGI+jU6x+7Xlwd3gKwDvOgsEQwE2fBiRfSAQ3ZPNOXr/VP13SQ==",
+      "optional": true
     },
     "@dnd-kit/accessibility": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "GPLv2",
       "dependencies": {
-        "@dmm-com/airone-apiclient-typescript-fetch": "^0.29.6",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "react-dom": "^19.2.0"
   },
   "optionalDependencies": {
-    "@dmm-com/airone-apiclient-typescript-fetch": "^0.29.5"
+    "@dmm-com/airone-apiclient-typescript-fetch": "0.29.6"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
issue: https://github.com/dmm-com/airone/issues/3666

Update the user management frontend to keep the user edit page open after updating an existing user, while redirecting to the user list after creating a new user.

Also prevent the unsaved-changes confirmation dialog from appearing during successful user creation and allow users to edit and save multiple times without leaving the page.