### PR TITLE
Use typed job params on the worker side.

### DIFF
--- a/airone/lib/drf.py
+++ b/airone/lib/drf.py
@@ -4,8 +4,9 @@ from typing import IO, Any
 
 import yaml
 from django.conf import settings
+from pydantic import ValidationError as PydanticValidationError
 from rest_framework import serializers
-from rest_framework.exceptions import APIException, ParseError, ValidationError
+from rest_framework.exceptions import APIException, ErrorDetail, ParseError, ValidationError
 from rest_framework.parsers import BaseParser
 from rest_framework.renderers import BaseRenderer
 from rest_framework.response import Response
@@ -112,7 +113,38 @@ class FileIsNotExistsError(ValidationError):
     default_code = "AE-280000"
 
 
+class InvalidJobParameterError(ValidationError):
+    """A job payload did not satisfy its operation parameter contract."""
+
+    default_code = "AE-121000"
+
+
+def _as_drf_validation_error(exc: PydanticValidationError) -> InvalidJobParameterError:
+    """Translate pydantic field errors into the AirOne API error shape.
+
+    Job parameter contracts (``job/params.py``) raise pydantic errors that the
+    default DRF handler does not understand, which would turn a bad request
+    into an HTTP 500.  Surface them as a 400 with the offending field path and
+    an AirOne error code instead.
+    """
+
+    details: dict[str, list[ErrorDetail]] = {}
+    for error in exc.errors():
+        location = ".".join(str(part) for part in error.get("loc", ())) or "__root__"
+        # A missing field keeps the "required parameter" code; every other
+        # contract violation is reported as an incorrect type or value.
+        code = "AE-113000" if error.get("type") == "missing" else "AE-121000"
+        details.setdefault(location, []).append(
+            ErrorDetail(error.get("msg", "Invalid value"), code=code)
+        )
+    return InvalidJobParameterError(details)
+
+
 def custom_exception_handler(exc: Exception, context: dict[str, Any]) -> Response | None:
+    # Pydantic contract violations are client errors, not server errors.
+    if isinstance(exc, PydanticValidationError):
+        exc = _as_drf_validation_error(exc)
+
     def _convert_error_code(detail: Any) -> Any:
         if isinstance(detail, list):
             return [_convert_error_code(item) for item in detail]

--- a/airone/lib/job.py
+++ b/airone/lib/job.py
@@ -38,8 +38,6 @@ Job ID: {job.id}
 Job Target ID: {job.target_id}
 Job Target Type: {job.target_type}
 Job Operaion ID: {job.operation}
-Job Params: {job.params}
-
 raised exception:
 {traceback.format_exc()}
 """

--- a/airone/tests/test_drf.py
+++ b/airone/tests/test_drf.py
@@ -1,0 +1,53 @@
+from django.test import SimpleTestCase
+from pydantic import ValidationError as PydanticValidationError
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+
+from airone.lib.drf import custom_exception_handler
+from job.params import EntityAttrV2Params, ExportEntryParams
+
+
+class PydanticValidationErrorHandlerTest(SimpleTestCase):
+    def _handle_pydantic(self, payload: dict) -> Response:
+        with self.assertRaises(PydanticValidationError) as context:
+            ExportEntryParams.model_validate(payload)
+        response = custom_exception_handler(context.exception, {})
+        assert response is not None
+        return response
+
+    def test_incorrect_type_is_a_400_with_ae_121000(self):
+        response = self._handle_pydantic({"export_format": "yaml", "target_id": True})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["target_id"][0]["code"], "AE-121000")
+
+    def test_missing_field_is_a_400_with_ae_113000(self):
+        response = self._handle_pydantic({})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["export_format"][0]["code"], "AE-113000")
+        self.assertEqual(response.data["target_id"][0]["code"], "AE-113000")
+
+    def test_extra_field_reports_its_location(self):
+        response = self._handle_pydantic(
+            {"export_format": "yaml", "target_id": 1, "unexpected": "x"}
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["unexpected"][0]["code"], "AE-121000")
+
+    def test_nested_field_location_is_preserved(self):
+        with self.assertRaises(PydanticValidationError) as context:
+            EntityAttrV2Params.model_validate({"name": "attr", "type": 1, "referral": ["x"]})
+        response = custom_exception_handler(context.exception, {})
+
+        assert response is not None
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["referral.0"][0]["code"], "AE-121000")
+
+    def test_plain_drf_validation_error_still_maps(self):
+        response = custom_exception_handler(ValidationError("plain error"), {})
+
+        assert response is not None
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data[0]["code"], "AE-121000")

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -1,6 +1,5 @@
 import csv
 import io
-import json
 from typing import Any
 
 import yaml
@@ -13,6 +12,7 @@ from airone.lib.job import may_schedule_until_job_is_ready, register_job_task
 from airone.lib.types import AttrType
 from entry.services import AdvancedSearchService
 from job.models import Job, JobOperation
+from job.params import SearchExportParams
 
 
 def _csv_export(
@@ -193,7 +193,8 @@ def _yaml_export(
 @may_schedule_until_job_is_ready
 def export_search_result(self: Any, job: Job) -> None:
     user = job.user
-    recv_data = json.loads(job.params)
+    params = job.get_typed_params(SearchExportParams)
+    recv_data = params.model_dump(mode="json", by_alias=True, exclude_unset=True)
 
     # Do not care whether the "has_referral" value is
     has_referral: bool = recv_data.get("has_referral", False)

--- a/docs/content/advanced/plugin_architecture_diagrams.md
+++ b/docs/content/advanced/plugin_architecture_diagrams.md
@@ -511,7 +511,7 @@ sequenceDiagram
     API->>Registry: get_operation_id("plugin-id", "task_name")
     Registry-->>API: operation_id (e.g., 5001)
 
-    API->>Job: _create_new_job(user, operation_id, params)
+    API->>Job: new_custom_job(user, operation_id, params)
     Job->>Job: Set status = PREPARING
     Job-->>API: Job instance
 

--- a/docs/content/advanced/plugin_quickstart_guide.md
+++ b/docs/content/advanced/plugin_quickstart_guide.md
@@ -337,6 +337,11 @@ If your plugin needs to run long-running operations (e.g., data export, batch pr
 # my_first_plugin/config.py
 import enum
 from airone.lib.plugin_task import PluginTaskConfig
+from pydantic import BaseModel, ConfigDict
+
+class ProcessDataParams(BaseModel):
+    model_config = ConfigDict(strict=True, extra="forbid")
+    input: str | None = None
 
 class MyFirstPluginOperation(int, enum.Enum):
     """Operation offsets for job tasks"""
@@ -348,6 +353,7 @@ PLUGIN_TASK_CONFIG = PluginTaskConfig(
     tasks={
         "process_data": (MyFirstPluginOperation.PROCESS_DATA, "process_data"),
     },
+    parameter_models={"process_data": ProcessDataParams},
     # Optional: specify task behavior
     cancelable_operations=["process_data"],  # Allow user cancellation
 )
@@ -362,7 +368,7 @@ import time
 from airone.celery import app
 from airone.lib.plugin_task import register_plugin_job_task
 from job.models import Job, JobStatus
-from my_first_plugin.config import MyFirstPluginOperation
+from my_first_plugin.config import MyFirstPluginOperation, ProcessDataParams
 
 logger = logging.getLogger(__name__)
 
@@ -391,8 +397,8 @@ def process_data(self, job_id: int):
 
     try:
         # Get job parameters
-        params = job.params
-        input_data = params.get("input")
+        params = job.get_typed_params(ProcessDataParams)
+        input_data = params.input
 
         logger.info(f"Processing job {job_id} with input: {input_data}")
 
@@ -456,7 +462,7 @@ class ProcessDataView(PluginAPIViewMixin):
             )
 
             # Create new job
-            job = Job._create_new_job(
+            job = Job.new_custom_job(
                 user=request.user,
                 target=None,
                 operation=operation_id,

--- a/docs/content/advanced/plugin_system.md
+++ b/docs/content/advanced/plugin_system.md
@@ -589,6 +589,11 @@ Create a configuration file defining task offsets and metadata:
 # my_plugin/config.py
 import enum
 from airone.lib.plugin_task import PluginTaskConfig
+from pydantic import BaseModel, ConfigDict
+
+class TaskAParams(BaseModel):
+    model_config = ConfigDict(strict=True, extra="forbid")
+    input_data: str | None = None
 
 class MyPluginOperation(int, enum.Enum):
     """Operation offsets for my-plugin tasks"""
@@ -604,6 +609,7 @@ PLUGIN_TASK_CONFIG = PluginTaskConfig(
         "task_a": (MyPluginOperation.TASK_A, "task_a"),
         "task_b": (MyPluginOperation.TASK_B, "task_b"),
     },
+    parameter_models={"task_a": TaskAParams},
     # Optional: specify task behavior
     hidden_operations=["task_b"],      # Hide from UI
     cancelable_operations=["task_a"],  # Allow user cancellation
@@ -620,7 +626,7 @@ import logging
 from airone.celery import app
 from airone.lib.plugin_task import register_plugin_job_task
 from job.models import Job, JobStatus
-from my_plugin.config import MyPluginOperation
+from my_plugin.config import MyPluginOperation, TaskAParams
 
 logger = logging.getLogger(__name__)
 
@@ -649,8 +655,8 @@ def task_a(self, job_id: int):
 
     try:
         # Your long-running task logic here
-        params = job.params  # Access job parameters
-        logger.info(f"Processing job {job_id} with params: {params}")
+        params = job.get_typed_params(TaskAParams)
+        logger.info(f"Processing job {job_id} with input: {params.input_data}")
 
         # Example: process data
         import time
@@ -669,6 +675,7 @@ def task_a(self, job_id: int):
 
 - **Double Decorator**: Use both `@register_plugin_job_task(offset)` and `@app.task(bind=True)`
 - **Status Checks**: Always check `is_canceled()` and `proceed_if_ready()`
+- **Typed Parameters**: Register `parameter_models` and consume them with `get_typed_params()`
 - **Status Updates**: Update job status to PROCESSING, DONE, or ERROR
 - **Error Handling**: Catch exceptions and update status to ERROR
 
@@ -720,7 +727,7 @@ class TaskView(PluginAPIViewMixin):
             )
 
             # Create new job
-            job = Job._create_new_job(
+            job = Job.new_custom_job(
                 user=request.user,
                 target=None,  # Optional: ACL object for permission checks
                 operation=operation_id,
@@ -753,7 +760,7 @@ Jobs follow a standard lifecycle with automatic state transitions:
 ```
 API Request
     ↓
-Job._create_new_job()
+Job.new_custom_job()
     ↓ (status = PREPARING)
     ↓
 job.run()
@@ -830,17 +837,19 @@ except Exception as e:
 
 ```python
 # Good: Descriptive job text
-job = Job._create_new_job(
+job = Job.new_custom_job(
     user=request.user,
     operation=operation_id,
     text=f"Processing {entity_name} export ({len(entries)} entries)",
+    params={},
 )
 
 # Bad: Generic text
-job = Job._create_new_job(
+job = Job.new_custom_job(
     user=request.user,
     operation=operation_id,
     text="Processing",
+    params={},
 )
 ```
 

--- a/entity/tasks.py
+++ b/entity/tasks.py
@@ -1,376 +1,62 @@
 from __future__ import annotations
 
-import json
-from typing import Any, Optional, Self
+from typing import Any
 
 from celery import Task
-from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
 from airone.celery import app
 from airone.lib import custom_view
 from airone.lib.job import may_schedule_until_job_is_ready, register_job_task
-from airone.lib.log import Logger
 from airone.lib.types import AttrType
 from entity.api_v2.serializers import EntityCreateSerializer, EntityUpdateSerializer
 from entity.models import Entity, EntityAttr
 from job.models import Job, JobOperation, JobStatus
+from job.params import (
+    CreateEntityParams,
+    CreateEntityV2Params,
+    EditEntityAttrV2Params,
+    EditEntityParams,
+    EditEntityV2Params,
+    EditWebhookParams,
+    EmptyParams,
+    EntityAttrParams,
+    EntityAttrV2Params,
+    ImportEntityPreviewParams,
+    IsolationActionParams,
+    IsolationConditionParams,
+    IsolationRuleParams,
+    WebhookHeaderParams,
+    WebhookParams,
+)
 from user.models import History, User
 
-# ============================================================================
-# Pydantic Models for Job Parameters
-# ============================================================================
+CreateEntityAttr = EntityAttrParams
+EditEntityAttr = EntityAttrParams
+CreateEntityV2Attr = EntityAttrV2Params
+EditEntityV2Attr = EditEntityAttrV2Params
+CreateEntityV2Webhook = WebhookParams
+EditEntityV2Webhook = EditWebhookParams
+IsolationActionParam = IsolationActionParams
+IsolationConditionParam = IsolationConditionParams
+IsolationRuleParam = IsolationRuleParams
+WebhookHeader = WebhookHeaderParams
 
-
-class CreateEntityAttr(BaseModel):
-    """Attribute definition for CREATE_ENTITY (V1) task."""
-
-    name: str = Field(..., max_length=200)
-    type: int
-    is_mandatory: bool
-    is_delete_in_chain: bool
-    row_index: str
-    ref_ids: list[int] = Field(default_factory=list)
-
-    @field_validator("type", mode="before")
-    @classmethod
-    def validate_type(cls, v: int | str) -> int:
-        """Convert string type to int if needed."""
-        if isinstance(v, str):
-            try:
-                return int(v)
-            except ValueError:
-                raise ValueError(f"Invalid type value: {v}")
-        return v
-
-
-class CreateEntityParams(BaseModel):
-    """Parameters for CREATE_ENTITY (V1) task."""
-
-    attrs: list[CreateEntityAttr]
-
-
-class EditEntityAttr(BaseModel):
-    """Attribute definition for EDIT_ENTITY (V1) task."""
-
-    id: Optional[int] = None
-    name: str = Field(..., max_length=200)
-    type: int
-    is_mandatory: bool
-    is_delete_in_chain: bool
-    row_index: str
-    ref_ids: list[int] = Field(default_factory=list)
-    deleted: Optional[bool] = None
-
-    @field_validator("type", mode="before")
-    @classmethod
-    def validate_type(cls, v: int | str) -> int:
-        """Convert string type to int if needed."""
-        if isinstance(v, str):
-            try:
-                return int(v)
-            except ValueError:
-                raise ValueError(f"Invalid type value: {v}")
-        return v
-
-
-class EditEntityParams(BaseModel):
-    """Parameters for EDIT_ENTITY (V1) task."""
-
-    name: str = Field(..., max_length=200)
-    note: str
-    attrs: list[EditEntityAttr]
-
-
-class WebhookHeader(BaseModel):
-    """Webhook HTTP header definition."""
-
-    header_key: str
-    header_value: str
-
-
-class CreateEntityV2Webhook(BaseModel):
-    """Webhook definition for CREATE_ENTITY_V2 task."""
-
-    url: str = Field(default="", max_length=200)
-    label: str = ""
-    is_enabled: bool = False
-    headers: list[WebhookHeader] = Field(default_factory=list)
-
-
-class CreateEntityV2Attr(BaseModel):
-    """Attribute definition for CREATE_ENTITY_V2 task."""
-
-    name: str = Field(..., max_length=200)
-    type: int
-    index: Optional[int] = None
-    is_mandatory: bool = False
-    is_delete_in_chain: bool = False
-    is_summarized: bool = False
-    referral: list[int] = Field(default_factory=list)
-    note: str = ""
-    default_value: Any = None
-    choices: Optional[list[dict[str, str]]] = None
-    name_order: Optional[int] = 0  # for internal use only
-    name_prefix: Optional[str] = ""  # for internal use only
-    name_postfix: Optional[str] = ""  # for internal use only
-    display_attr: str = ""
-
-    @model_validator(mode="after")
-    def validate_choices_shape(self) -> Self:
-        """Reuse the EntityAttr authoritative choices validator so the Celery
-        path applies the same invariants (non-empty, unique value, unique label,
-        non-empty strings) as the synchronous serializer path."""
-        if self.choices is None:
-            if self.type in (AttrType.SELECT, AttrType.MULTI_SELECT):
-                raise ValueError("SELECT type requires a non-empty choices list")
-            return self
-        if self.type not in (AttrType.SELECT, AttrType.MULTI_SELECT):
-            self.choices = None
-            return self
-        from entity.models import EntityAttr
-
-        EntityAttr.validate_choices(self.choices)
-        return self
-
-    @model_validator(mode="after")
-    def validate_default_value_for_type(self) -> Self:
-        """Validate that default_value is compatible with the attribute type."""
-        if self.default_value is None:
-            return self
-
-        supported_types = [
-            AttrType.STRING,
-            AttrType.TEXT,
-            AttrType.BOOLEAN,
-            AttrType.NUMBER,
-            AttrType.OBJECT,
-            AttrType.ARRAY_OBJECT,
-        ]
-
-        # Clear default_value for unsupported types (don't raise error)
-        if self.type not in supported_types:
-            Logger.warning(
-                f"default_value is not supported for type {self.type}. "
-                f"Clearing default_value. Supported types: {supported_types}"
-            )
-            self.default_value = None
-            return self
-
-        # Type-specific validation - clear if invalid type
-        is_valid = True
-        if self.type in [AttrType.STRING, AttrType.TEXT]:
-            if not isinstance(self.default_value, str):
-                is_valid = False
-        elif self.type == AttrType.BOOLEAN:
-            if not isinstance(self.default_value, bool):
-                is_valid = False
-        elif self.type == AttrType.NUMBER:
-            if not isinstance(self.default_value, (int, float)) or isinstance(
-                self.default_value, bool
-            ):
-                is_valid = False
-        elif self.type == AttrType.OBJECT:
-            if (
-                not isinstance(self.default_value, int)
-                or isinstance(self.default_value, bool)
-                or self.default_value <= 0
-            ):
-                is_valid = False
-        elif self.type == AttrType.ARRAY_OBJECT:
-            if (
-                not isinstance(self.default_value, list)
-                or not all(
-                    isinstance(item, int) and not isinstance(item, bool) and item > 0
-                    for item in self.default_value
-                )
-                or len(self.default_value) != len(set(self.default_value))
-            ):
-                is_valid = False
-            elif not self.default_value:
-                self.default_value = None
-
-        if not is_valid:
-            Logger.warning(
-                f"default_value type mismatch for attribute type {self.type}. "
-                f"Clearing default_value. Got: {type(self.default_value)}"
-            )
-            self.default_value = None
-
-        return self
-
-
-class CreateEntityV2Params(BaseModel):
-    """Parameters for CREATE_ENTITY_V2 task."""
-
-    name: str = Field(..., max_length=200)
-    note: str = ""
-    item_name_pattern: str = ""
-    is_toplevel: bool = False
-    attrs: list[CreateEntityV2Attr] = Field(default_factory=list)
-    webhooks: list[CreateEntityV2Webhook] = Field(default_factory=list)
-
-
-class EditEntityV2Webhook(BaseModel):
-    """Webhook definition for EDIT_ENTITY_V2 task."""
-
-    id: Optional[int] = None
-    url: Optional[str] = Field(None, max_length=200)
-    label: str = ""
-    is_enabled: bool = False
-    headers: list[WebhookHeader] = Field(default_factory=list)
-    is_deleted: bool = False
-
-
-class EditEntityV2Attr(BaseModel):
-    """Attribute definition for EDIT_ENTITY_V2 task."""
-
-    id: Optional[int] = None
-    name: Optional[str] = Field(None, max_length=200)
-    type: Optional[int] = None
-    index: Optional[int] = None
-    is_mandatory: Optional[bool] = None
-    is_delete_in_chain: Optional[bool] = None
-    is_summarized: Optional[bool] = None
-    referral: Optional[list[int]] = None
-    note: Optional[str] = None
-    default_value: Any = None
-    choices: Optional[list[dict[str, str]]] = None
-    is_deleted: bool = False
-    name_order: Optional[int] = 0  # for internal use only
-    name_prefix: Optional[str] = ""  # for internal use only
-    name_postfix: Optional[str] = ""  # for internal use only
-    display_attr: Optional[str] = None
-
-    @model_validator(mode="after")
-    def validate_choices_shape(self) -> Self:
-        """Reuse EntityAttr.validate_choices when the payload provides choices."""
-        if self.choices is None:
-            return self
-        if self.type is not None and self.type not in (
-            AttrType.SELECT,
-            AttrType.MULTI_SELECT,
-        ):
-            self.choices = None
-            return self
-        from entity.models import EntityAttr
-
-        EntityAttr.validate_choices(self.choices)
-        return self
-
-    @model_validator(mode="after")
-    def validate_attr_fields(self) -> Self:
-        """Validate that required fields are present based on operation type."""
-        if self.id is None:
-            if self.name is None or self.type is None:
-                raise ValueError("name and type are required for new attribute creation")
-        return self
-
-    @model_validator(mode="after")
-    def validate_default_value_for_type(self) -> Self:
-        """Validate default_value compatibility with attribute type."""
-        if self.default_value is None or self.type is None:
-            return self
-
-        supported_types = [
-            AttrType.STRING,
-            AttrType.TEXT,
-            AttrType.BOOLEAN,
-            AttrType.NUMBER,
-            AttrType.OBJECT,
-            AttrType.ARRAY_OBJECT,
-        ]
-
-        # Clear default_value for unsupported types (don't raise error)
-        if self.type not in supported_types:
-            Logger.warning(
-                f"default_value is not supported for type {self.type}. "
-                f"Clearing default_value. Supported types: {supported_types}"
-            )
-            self.default_value = None
-            return self
-
-        # Type-specific validation - clear if invalid type
-        is_valid = True
-        if self.type in [AttrType.STRING, AttrType.TEXT]:
-            if not isinstance(self.default_value, str):
-                is_valid = False
-        elif self.type == AttrType.BOOLEAN:
-            if not isinstance(self.default_value, bool):
-                is_valid = False
-        elif self.type == AttrType.NUMBER:
-            if not isinstance(self.default_value, (int, float)) or isinstance(
-                self.default_value, bool
-            ):
-                is_valid = False
-        elif self.type == AttrType.OBJECT:
-            if (
-                not isinstance(self.default_value, int)
-                or isinstance(self.default_value, bool)
-                or self.default_value <= 0
-            ):
-                is_valid = False
-        elif self.type == AttrType.ARRAY_OBJECT:
-            if (
-                not isinstance(self.default_value, list)
-                or not all(
-                    isinstance(item, int) and not isinstance(item, bool) and item > 0
-                    for item in self.default_value
-                )
-                or len(self.default_value) != len(set(self.default_value))
-            ):
-                is_valid = False
-            elif not self.default_value:
-                self.default_value = None
-
-        if not is_valid:
-            Logger.warning(
-                f"default_value type mismatch for attribute type {self.type}. "
-                f"Clearing default_value. Got: {type(self.default_value)}"
-            )
-            self.default_value = None
-
-        return self
-
-
-class IsolationConditionParam(BaseModel):
-    """Condition definition for an isolation rule."""
-
-    attr_id: int
-    str_cond: str = ""
-    ref_cond_id: Optional[int] = None
-    bool_cond: bool = False
-    is_unmatch: bool = False
-
-
-class IsolationActionParam(BaseModel):
-    """Action definition for an isolation rule."""
-
-    is_prevent_all: bool = False
-    prevent_from_id: Optional[int] = None
-
-
-class IsolationRuleParam(BaseModel):
-    """Isolation rule definition for EDIT_ENTITY_V2 task."""
-
-    id: Optional[int] = None
-    is_deleted: bool = False
-    conditions: list[IsolationConditionParam] = Field(default_factory=list)
-    action: IsolationActionParam = Field(default_factory=IsolationActionParam)
-
-
-class EditEntityV2Params(BaseModel):
-    """Parameters for EDIT_ENTITY_V2 task."""
-
-    id: Optional[int] = None
-    name: Optional[str] = Field(None, max_length=200)
-    note: Optional[str] = None
-    item_name_pattern: Optional[str] = None
-    is_toplevel: Optional[bool] = None
-    attrs: list[EditEntityV2Attr] = Field(default_factory=list)
-    webhooks: list[EditEntityV2Webhook] = Field(default_factory=list)
-    isolation_rules: list[IsolationRuleParam] = Field(default_factory=list)
-    delete_chain_exclude_entities: list[int] = Field(default_factory=list)
-
+__all__ = [
+    "CreateEntityAttr",
+    "CreateEntityParams",
+    "CreateEntityV2Attr",
+    "CreateEntityV2Params",
+    "CreateEntityV2Webhook",
+    "EditEntityAttr",
+    "EditEntityParams",
+    "EditEntityV2Attr",
+    "EditEntityV2Params",
+    "EditEntityV2Webhook",
+    "IsolationActionParam",
+    "IsolationConditionParam",
+    "IsolationRuleParam",
+    "WebhookHeader",
+]
 
 # ============================================================================
 # Task Functions
@@ -393,12 +79,7 @@ def create_entity(self: Task[Any, Any], job: Job) -> JobStatus:
     # for history record
     entity._history_user = user
 
-    # Validate and parse job parameters using Pydantic
-    try:
-        params = CreateEntityParams.model_validate_json(job.params)
-    except ValidationError as e:
-        Logger.error(f"Invalid parameters for CREATE_ENTITY job {job.id}: {e}")
-        return JobStatus.ERROR
+    params = job.get_typed_params(CreateEntityParams)
 
     # register history to modify Entity
     history = user.seth_entity_add(entity)
@@ -444,12 +125,7 @@ def edit_entity(self: Task[Any, Any], job: Job) -> JobStatus:
     # for history record
     entity._history_user = user
 
-    # Validate and parse job parameters using Pydantic
-    try:
-        params = EditEntityParams.model_validate_json(job.params)
-    except ValidationError as e:
-        Logger.error(f"Invalid parameters for EDIT_ENTITY job {job.id}: {e}")
-        return JobStatus.ERROR
+    params = job.get_typed_params(EditEntityParams)
 
     # register history to modify Entity
     history = user.seth_entity_mod(entity)
@@ -547,6 +223,7 @@ def edit_entity(self: Task[Any, Any], job: Job) -> JobStatus:
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def delete_entity(self: Task[Any, Any], job: Job) -> JobStatus:
+    job.get_typed_params(EmptyParams)
     if job.target is None:
         return JobStatus.CANCELED
     user = User.objects.filter(id=job.user.id).first()
@@ -581,21 +258,23 @@ def create_entity_v2(self: Task[Any, Any], job: Job) -> JobStatus:
     if not entity:
         return JobStatus.ERROR
 
-    # Validate and parse job parameters using Pydantic
-    try:
-        params = CreateEntityV2Params.model_validate_json(job.params)
-    except ValidationError as e:
-        Logger.error(f"Invalid parameters for CREATE_ENTITY_V2 job {job.id}: {e}")
+    params = job.get_typed_params(CreateEntityV2Params)
+
+    params_dict = params.model_dump(mode="json", by_alias=True, exclude_unset=True)
+
+    # The request path has already created the Entity, so validating its name again
+    # would report that very instance as a duplicate. Validate the remaining payload
+    # as a partial update while retaining the create-specific nested validators.
+    remaining_data = {key: value for key, value in params_dict.items() if key != "name"}
+    serializer = EntityCreateSerializer(
+        instance=entity,
+        data=remaining_data,
+        partial=True,
+        context={"_user": job.user},
+    )
+    if not serializer.is_valid():
         return JobStatus.ERROR
-
-    # Convert Pydantic model to dict for serializer
-    # (EntityCreateSerializer expects dict input)
-    # Use exclude_none=True to avoid passing None values that may violate DB constraints
-    params_dict = params.model_dump(exclude_none=True)
-
-    # pass to validate the params because the entity should be already created
-    serializer = EntityCreateSerializer(data=params_dict, context={"_user": job.user})
-    serializer.create_remaining(entity, serializer.initial_data)
+    serializer.create_remaining(entity, serializer.validated_data)
 
     # update job status and save it
     return JobStatus.DONE
@@ -611,12 +290,7 @@ def edit_entity_v2(self: Task[Any, Any], job: Job) -> JobStatus:
     if not entity:
         return JobStatus.ERROR
 
-    # Validate and parse job parameters using Pydantic
-    try:
-        params = EditEntityV2Params.model_validate_json(job.params)
-    except ValidationError as e:
-        Logger.error(f"Invalid parameters for EDIT_ENTITY_V2 job {job.id}: {e}")
-        return JobStatus.ERROR
+    params = job.get_typed_params(EditEntityV2Params)
 
     # Convert Pydantic model to dict for serializer
     # (EntityUpdateSerializer expects dict input)
@@ -626,7 +300,7 @@ def edit_entity_v2(self: Task[Any, Any], job: Job) -> JobStatus:
     # default_value: null to remove an EntityAttr's default value; dropping
     # that null made it impossible to clear a default once set, because
     # update_or_create keeps the stored value for absent fields.
-    params_dict = params.model_dump(exclude_unset=True)
+    params_dict = params.model_dump(mode="json", by_alias=True, exclude_unset=True)
 
     serializer = EntityUpdateSerializer(
         instance=entity, data=params_dict, context={"_user": job.user}
@@ -643,6 +317,7 @@ def edit_entity_v2(self: Task[Any, Any], job: Job) -> JobStatus:
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def delete_entity_v2(self: Task[Any, Any], job: Job) -> JobStatus:
+    job.get_typed_params(EmptyParams)
     if job.target is None:
         return JobStatus.ERROR
     entity: Entity | None = Entity.objects.filter(id=job.target.id, is_active=True).first()
@@ -679,8 +354,10 @@ def import_entities_preview_v2(self: Task[Any, Any], job: Job) -> JobStatus:
     """
     from entity.api_v2.serializers import EntityImportExportRootSerializer
 
+    params = job.get_typed_params(ImportEntityPreviewParams)
     serializer = EntityImportExportRootSerializer(
-        data=json.loads(job.params), context={"request": _JobRequest(job.user)}
+        data=params.model_dump(mode="json", by_alias=True, exclude_unset=True),
+        context={"request": _JobRequest(job.user)},
     )
     if not serializer.is_valid():
         return JobStatus.ERROR

--- a/entity/tests/test_tasks.py
+++ b/entity/tests/test_tasks.py
@@ -55,7 +55,7 @@ class CreateEntityAttrTest(TestCase):
                 is_delete_in_chain=False,
                 row_index="1",
             )
-        self.assertIn("Invalid type value", str(context.exception))
+        self.assertIn("valid integer", str(context.exception))
 
     def test_name_max_length_validation(self):
         """Test that name exceeding max length raises ValidationError."""
@@ -75,6 +75,9 @@ class CreateEntityParamsTest(TestCase):
     def test_valid_params(self):
         """Test creating valid entity params."""
         params = CreateEntityParams(
+            name="test entity",
+            note="",
+            is_toplevel=False,
             attrs=[
                 {
                     "name": "attr1",
@@ -84,14 +87,14 @@ class CreateEntityParamsTest(TestCase):
                     "row_index": "1",
                     "ref_ids": [],
                 }
-            ]
+            ],
         )
         self.assertEqual(len(params.attrs), 1)
         self.assertEqual(params.attrs[0].name, "attr1")
 
     def test_empty_attrs(self):
         """Test that empty attrs list is valid."""
-        params = CreateEntityParams(attrs=[])
+        params = CreateEntityParams(name="test entity", note="", is_toplevel=False, attrs=[])
         self.assertEqual(len(params.attrs), 0)
 
 

--- a/entry/services.py
+++ b/entry/services.py
@@ -1,4 +1,3 @@
-import json
 from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
@@ -28,6 +27,7 @@ from entity.models import Entity, EntityAttr
 from entry.api_v2.serializers import EntryCreateSerializer, EntryUpdateSerializer
 from entry.models import Attribute, AttributeValue, Entry
 from job.models import Job, JobOperation, JobStatus
+from job.params import ImportEntryParams
 from trigger.models import TriggerCondition
 from user.models import User
 
@@ -864,7 +864,7 @@ def _load_preview_baselines(job: Job) -> dict[str, dict[str, Any]] | None:
     a file long enough to be truncated records no values for the rows it could
     not list, and those rows import the way they always have.
     """
-    preview_job_id = json.loads(job.params).get("preview_job_id")
+    preview_job_id = job.get_typed_params(ImportEntryParams).preview_job_id
     if not preview_job_id:
         return None
 

--- a/entry/tasks.py
+++ b/entry/tasks.py
@@ -1,6 +1,5 @@
 import csv
 import io
-import json
 from datetime import date, datetime
 from typing import Any, Callable, List, TypeAlias
 
@@ -46,13 +45,28 @@ from entry.api_v2.serializers import (
     ExportedEntryAttributePrimitiveValue,
     ExportedEntryAttributeValue,
     ExportedEntryAttributeValueObject,
-    ExportTaskParams,
     ReferralEntry,
 )
 from entry.models import Attribute, Entry
 from entry.services import AdvancedSearchService, EntryImportPreviewService
 from group.models import Group
 from job.models import Job, JobOperation, JobStatus, JobTarget
+from job.params import (
+    BulkEditParams,
+    CopyEntryParams,
+    CreateEntryV2Params,
+    DoCopyEntryParams,
+    EmptyParams,
+    EntryV2Params,
+    ExportEntryParams,
+    ImportEntryParams,
+    LegacyCreateEntryParams,
+    LegacyEditEntryParams,
+    LegacyImportEntryParams,
+    ReferralParams,
+    SearchExportParams,
+    UpdateDocumentParams,
+)
 from role.models import Role
 from trigger.models import TriggerCondition
 from user.models import User
@@ -151,7 +165,10 @@ def _convert_data_value(attr: Attribute, info: dict[str, Any]) -> Any:
 def _do_import_entries(job: Job) -> None:
     user: User = job.user
     entity: Entity = Entity.objects.get(id=job.target.id)
-    import_data = json.loads(job.params)
+    import_data = [
+        entry.model_dump(mode="json", by_alias=True, exclude_unset=True)
+        for entry in job.get_typed_params(LegacyImportEntryParams).root
+    ]
 
     # get custom_view method to prevent executing check method in every loop processing
     custom_view_handler = None
@@ -442,7 +459,8 @@ def create_entry_attrs(self: Task, job: Job) -> JobStatus | None:
         # Abort when specified entry doesn't exist
         return JobStatus.CANCELED
 
-    recv_data = json.loads(job.params)
+    params = job.get_typed_params(LegacyCreateEntryParams)
+    recv_data = params.model_dump(mode="json", by_alias=True, exclude_unset=True)
     # Create new Attributes objects based on the specified value
     for entity_attr in entry.schema.attrs.filter(is_active=True):
         # This creates Attibute object that contains AttributeValues.
@@ -506,7 +524,8 @@ def edit_entry_attrs(self: Task, job: Job) -> JobStatus:
     # for history record
     entry._history_user = user
 
-    recv_data = json.loads(job.params)
+    params = job.get_typed_params(LegacyEditEntryParams)
+    recv_data = params.model_dump(mode="json", by_alias=True, exclude_unset=True)
 
     for info in recv_data["attrs"]:
         if info["id"]:
@@ -554,6 +573,7 @@ def edit_entry_attrs(self: Task, job: Job) -> JobStatus:
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def delete_entry(self: Task, job: Job) -> JobStatus:
+    job.get_typed_params(EmptyParams)
     entry = Entry.objects.get(id=job.target.id)
 
     # for history record
@@ -575,6 +595,7 @@ def delete_entry(self: Task, job: Job) -> JobStatus:
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def restore_entry(self: Task, job: Job) -> JobStatus:
+    job.get_typed_params(EmptyParams)
     entry = Entry.objects.get(id=job.target.id)
 
     # for history record
@@ -602,9 +623,9 @@ def restore_entry(self: Task, job: Job) -> JobStatus:
 def copy_entry(self: Task, job: Job) -> tuple[JobStatus, str, None] | None:
     src_entry = Entry.objects.get(id=job.target.id)
 
-    params = json.loads(job.params)
-    total_count = len(params["new_name_list"])
-    for index, new_name in enumerate(params["new_name_list"]):
+    params = job.get_typed_params(CopyEntryParams)
+    total_count = len(params.new_name_list)
+    for index, new_name in enumerate(params.new_name_list):
         # abort processing when job is canceled
         if job.is_canceled():
             job.text = "Copy completed [%5d/%5d]" % (index, total_count)
@@ -614,8 +635,11 @@ def copy_entry(self: Task, job: Job) -> tuple[JobStatus, str, None] | None:
         job.text = "Now copying... (progress: [%5d/%5d])" % (index + 1, total_count)
         job.save(update_fields=["text"])
 
-        params["new_name"] = new_name
-        job_do_copy_entry = Job.new_do_copy(job.user, src_entry, new_name, params)
+        do_copy_params = {
+            **params.model_dump(mode="json", by_alias=True, exclude_unset=True),
+            "new_name": new_name,
+        }
+        job_do_copy_entry = Job.new_do_copy(job.user, src_entry, new_name, do_copy_params)
         job_do_copy_entry.run(will_delay=False)
 
     # update job status and save it
@@ -627,19 +651,19 @@ def copy_entry(self: Task, job: Job) -> tuple[JobStatus, str, None] | None:
 @may_schedule_until_job_is_ready
 def do_copy_entry(self: Task, job: Job) -> tuple[JobStatus, str, None]:
     src_entry = Entry.objects.get(id=job.target.id)
-    params = json.loads(job.params)
+    params = job.get_typed_params(DoCopyEntryParams)
 
     # abort this job when there is duplicated Alias exists
-    if not src_entry.schema.is_available(params["new_name"]):
+    if not src_entry.schema.is_available(params.new_name):
         return (
             JobStatus.ERROR,
-            "Duplicated Alias(name=%s) exists in this model" % params["new_name"],
+            "Duplicated Alias(name=%s) exists in this model" % params.new_name,
             src_entry,
         )
 
-    dest_entry = Entry.objects.filter(schema=src_entry.schema, name=params["new_name"]).first()
+    dest_entry = Entry.objects.filter(schema=src_entry.schema, name=params.new_name).first()
     if not dest_entry:
-        dest_entry = src_entry.clone(job.user, name=params["new_name"])
+        dest_entry = src_entry.clone(job.user, name=params.new_name)
 
         # for updating its name from attribute values
         dest_entry.save_autoname()
@@ -654,7 +678,7 @@ def do_copy_entry(self: Task, job: Job) -> tuple[JobStatus, str, None]:
             job.user,
             src_entry,
             dest_entry,
-            params["post_data"],
+            params.post_data,
         )
 
     # create and run event notification job
@@ -682,8 +706,11 @@ def import_entries(self: Task, job: Job) -> tuple[JobStatus, str, None] | None:
 def import_entries_v2(self: Task, job: Job) -> tuple[JobStatus, str, None] | None:
     user: User = job.user
     entity = Entity.objects.get(id=job.target.id)
-    import_serializer = EntryImportEntitySerializer(data=json.loads(job.params))
-    import_serializer.is_valid()
+    params = job.get_typed_params(ImportEntryParams)
+    import_serializer = EntryImportEntitySerializer(
+        data=params.model_dump(mode="json", by_alias=True, exclude_unset=True)
+    )
+    import_serializer.is_valid(raise_exception=True)
     context = {"request": DRFRequest(user)}
 
     total_count = len(import_serializer.validated_data["entries"])
@@ -749,7 +776,7 @@ def import_entries_v2(self: Task, job: Job) -> tuple[JobStatus, str, None] | Non
 def export_entries(self: Task, job: Job) -> None:
     user = job.user
     entity = Entity.objects.get(id=job.target.id)
-    params = json.loads(job.params)
+    params = job.get_typed_params(ExportEntryParams)
 
     exported_data = []
 
@@ -774,7 +801,7 @@ def export_entries(self: Task, job: Job) -> None:
         export_item_counter += 1
 
     output = None
-    if params["export_format"] == "csv":
+    if params.export_format == "csv":
         # newline is blank because csv module performs universal newlines
         # https://docs.python.org/ja/3/library/csv.html#id3
         output = io.StringIO(newline="")
@@ -815,7 +842,7 @@ def export_entries(self: Task, job: Job) -> None:
 def export_entries_v2(self: Task, job: Job) -> None:
     user = job.user
     entity = Entity.objects.get(id=job.target.id)
-    params = ExportTaskParams.model_validate_json(job.params)
+    params = job.get_typed_params(ExportEntryParams)
     with_entity = params.export_format != "csv"
 
     exported_entity: list[ExportedEntityEntries] = []
@@ -974,7 +1001,10 @@ def _csv_export_v2(
 @may_schedule_until_job_is_ready
 def export_search_result_v2(self: Any, job: Job) -> tuple[JobStatus, str, ACLBase | None] | None:
     user = job.user
-    serializer = AdvancedSearchResultExportSerializer(data=json.loads(job.params))
+    typed_params = job.get_typed_params(SearchExportParams)
+    serializer = AdvancedSearchResultExportSerializer(
+        data=typed_params.model_dump(mode="json", by_alias=True, exclude_unset=True)
+    )
     serializer.is_valid(raise_exception=True)
     params: dict[str, Any] = serializer.validated_data
     join_attrs = params.get("join_attrs", [])
@@ -1046,6 +1076,7 @@ def export_search_result_v2(self: Any, job: Job) -> tuple[JobStatus, str, ACLBas
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def register_referrals(self: Task, job: Job) -> None:
+    job.get_typed_params(ReferralParams)
     # register entries data which refer target entry to elasticsearch
     entry = Entry.objects.filter(id=job.target.id, is_active=True).first()
     if entry:
@@ -1070,10 +1101,10 @@ def _notify_event(
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def update_es_documents(self: Task, job: Job) -> JobStatus:
-    params = json.loads(job.params)
+    params = job.get_typed_params(UpdateDocumentParams)
 
     entity = Entity.objects.get(id=job.target.id)
-    AdvancedSearchService.update_documents(entity, params.get("is_update", False))
+    AdvancedSearchService.update_documents(entity, params.is_update)
 
     return JobStatus.DONE
 
@@ -1082,6 +1113,7 @@ def update_es_documents(self: Task, job: Job) -> JobStatus:
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def notify_create_entry(self: Task, job: Job) -> tuple[JobStatus, str, None] | None:
+    job.get_typed_params(EmptyParams)
     return _notify_event(notify_entry_create, job.target.id, job.user)
 
 
@@ -1089,6 +1121,7 @@ def notify_create_entry(self: Task, job: Job) -> tuple[JobStatus, str, None] | N
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def notify_update_entry(self: Task, job: Job) -> tuple[JobStatus, str, None] | None:
+    job.get_typed_params(EmptyParams)
     return _notify_event(notify_entry_update, job.target.id, job.user)
 
 
@@ -1096,6 +1129,7 @@ def notify_update_entry(self: Task, job: Job) -> tuple[JobStatus, str, None] | N
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def notify_delete_entry(self: Task, job: Job) -> tuple[JobStatus, str, None] | None:
+    job.get_typed_params(EmptyParams)
     return _notify_event(notify_entry_delete, job.target.id, job.user)
 
 
@@ -1103,7 +1137,11 @@ def notify_delete_entry(self: Task, job: Job) -> tuple[JobStatus, str, None] | N
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def create_entry_v2(self: Task, job: Job) -> JobStatus:
-    serializer = EntryCreateSerializer(data=json.loads(job.params), context={"_user": job.user})
+    params = job.get_typed_params(CreateEntryV2Params)
+    serializer = EntryCreateSerializer(
+        data=params.model_dump(mode="json", by_alias=True, exclude_unset=True),
+        context={"_user": job.user},
+    )
     if not serializer.is_valid():
         return JobStatus.ERROR
 
@@ -1128,8 +1166,11 @@ def edit_entry_v2(self: Task, job: Job) -> JobStatus:
     if not entry:
         return JobStatus.ERROR
 
+    params = job.get_typed_params(EntryV2Params)
     serializer = EntryUpdateSerializer(
-        instance=entry, data=json.loads(job.params), context={"_user": job.user}
+        instance=entry,
+        data=params.model_dump(mode="json", by_alias=True, exclude_unset=True),
+        context={"_user": job.user},
     )
     if not serializer.is_valid():
         return JobStatus.ERROR
@@ -1143,6 +1184,7 @@ def edit_entry_v2(self: Task, job: Job) -> JobStatus:
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def delete_entry_v2(self: Task, job: Job) -> JobStatus:
+    job.get_typed_params(EmptyParams)
     entry: Entry | None = Entry.objects.filter(id=job.target.id, is_active=True).first()
     if not entry:
         return JobStatus.ERROR
@@ -1171,7 +1213,8 @@ def delete_entry_v2(self: Task, job: Job) -> JobStatus:
 def bulk_update_entries(
     self: Any, job: Job
 ) -> JobStatus | tuple[JobStatus, str, ACLBase | None] | None:
-    job_params = json.loads(job.params)
+    params = job.get_typed_params(BulkEditParams)
+    job_params = params.model_dump(mode="json", by_alias=True, exclude_unset=True)
 
     # get target items from ES by job_params.attr_info parameter
     resp = AdvancedSearchService.search_entries(
@@ -1233,7 +1276,8 @@ def import_entries_preview_v2(self: Task, job: Job) -> JobStatus:
     progress, onto the job row it runs as. See EntryImportPreviewService.
     """
     entity = Entity.objects.get(id=job.target.id)
-    raw_data = json.loads(job.params)
+    params = job.get_typed_params(ImportEntryParams)
+    raw_data = params.model_dump(mode="json", by_alias=True, exclude_unset=True)
 
     import_serializer = EntryImportEntitySerializer(data=raw_data)
     if not import_serializer.is_valid():

--- a/group/tasks.py
+++ b/group/tasks.py
@@ -1,18 +1,18 @@
-import json
 from typing import Any, cast
 
 from airone.celery import app
 from airone.lib.job import may_schedule_until_job_is_ready, register_job_task
 from group.models import Group
 from job.models import Job, JobOperation, JobStatus
+from job.params import GroupReferralParams
 
 
 @register_job_task(JobOperation.GROUP_REGISTER_REFERRAL)
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def edit_group_referrals(self: Any, job: Job) -> JobStatus:
-    params = json.loads(job.params)
-    group = cast(Group, Group.objects.get(id=params["group_id"]))
+    params = job.get_typed_params(GroupReferralParams)
+    group = cast(Group, Group.objects.get(id=params.group_id))
 
     for entry in [x for x in group.get_referred_entries()]:
         entry.register_es()

--- a/job/tests/test_no_direct_job_params_reads.py
+++ b/job/tests/test_no_direct_job_params_reads.py
@@ -1,0 +1,230 @@
+"""Forbid production code from reading persisted job parameters directly.
+
+Job parameters are persisted as JSON, but task modules must consume the
+validated DTO exposed by ``Job.get_typed_params``.  Their ``params`` attribute
+is reserved so aliases and alternative parsers cannot bypass the operation
+registry.  Outside task modules, explicitly Job-named values are also checked.
+
+This invariant lives in the test suite rather than a standalone CI step: the
+repository scan below runs as part of ``manage.py test job``.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import tempfile
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+_SKIPPED_PARTS = frozenset(
+    {
+        ".git",
+        ".agents",
+        ".claude",
+        ".codex",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "__pycache__",
+        "migrations",
+        "node_modules",
+        "tests",
+        "virtualenv_old",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A direct Job.params read found in a production Python module."""
+
+    path: Path
+    line: int
+    column: int
+    expression: str
+
+    def format(self, root: Path) -> str:
+        """Render a violation in a format understood by CI log viewers."""
+
+        try:
+            path = self.path.relative_to(root)
+        except ValueError:
+            path = self.path
+        return f"{path}:{self.line}:{self.column}: direct Job.params access ({self.expression})"
+
+
+def find_violations(source: str, path: Path) -> list[Violation]:
+    """Return direct reads of the reserved params attribute in one source file."""
+
+    tree = ast.parse(source, filename=str(path))
+    is_task_module = path.name == "tasks.py" or "tasks" in path.parts
+    violations: list[Violation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute) or node.attr != "params":
+            continue
+        if not is_task_module:
+            if not isinstance(node.value, ast.Name):
+                continue
+            name = node.value.id
+            if name != "job" and not name.endswith("_job"):
+                continue
+        violations.append(
+            Violation(
+                path=path,
+                line=node.lineno,
+                column=node.col_offset + 1,
+                expression=ast.unparse(node),
+            )
+        )
+    return violations
+
+
+def _is_production_file(path: Path) -> bool:
+    parts = set(path.parts)
+    if parts & _SKIPPED_PARTS:
+        return False
+    return not path.name.startswith("test_")
+
+
+def iter_production_python_files(root: Path) -> Iterable[Path]:
+    """Yield production Python files while excluding test and generated trees."""
+
+    for current_root, directories, files in os.walk(root):
+        directories[:] = [name for name in directories if name not in _SKIPPED_PARTS]
+        directory = Path(current_root)
+        for name in files:
+            if name.endswith(".py"):
+                path = directory / name
+                if _is_production_file(path):
+                    yield path
+
+
+def check_repository(root: Path) -> list[Violation]:
+    """Scan production Python files under ``root``."""
+
+    violations: list[Violation] = []
+    for path in iter_production_python_files(root):
+        # The model itself owns the raw field and is deliberately exempt.
+        if path.relative_to(root) == Path("job/models.py"):
+            continue
+        violations.extend(find_violations(path.read_text(encoding="utf-8"), path))
+    return sorted(violations, key=lambda item: (item.path, item.line, item.column))
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class DirectJobParamsReadTest(SimpleTestCase):
+    def test_detects_json_and_pydantic_parsers(self) -> None:
+        source = """
+import json
+
+def task(job):
+    first = json.loads(job.params)
+    second = Params.model_validate_json(job.params)
+    third = Params.parse_raw(data=job.params)
+    return first, second, third
+"""
+
+        violations = find_violations(source, Path("job/tasks.py"))
+
+        self.assertEqual(len(violations), 3)
+        self.assertEqual([violation.line for violation in violations], [5, 6, 7])
+        self.assertEqual([violation.expression for violation in violations], ["job.params"] * 3)
+
+    def test_detects_imported_json_loads_alias(self) -> None:
+        source = """
+import json as jsonlib
+from json import loads as decode_json
+
+def task(job):
+    return decode_json(payload=jsonlib.loads(job.params))
+"""
+
+        self.assertEqual(len(find_violations(source, Path("job/tasks.py"))), 1)
+
+    def test_detects_job_alias_intermediate_value_and_alternative_json_module(self) -> None:
+        source = """
+import json
+import orjson
+
+def task(task_job):
+    raw = task_job.params
+    first = json.loads(raw)
+    queued = task_job
+    second = orjson.loads(queued.params)
+    return first, second
+"""
+
+        violations = find_violations(source, Path("plugin/tasks.py"))
+
+        self.assertEqual(len(violations), 2)
+        self.assertEqual([violation.line for violation in violations], [6, 9])
+
+    def test_task_modules_reserve_params_for_any_variable_name(self) -> None:
+        source = """
+def task(current, job_config):
+    return current.params, job_config.params
+"""
+
+        violations = find_violations(source, Path("plugin/tasks.py"))
+
+        self.assertEqual(len(violations), 2)
+
+    def test_non_task_context_params_is_not_a_job_violation(self) -> None:
+        source = """
+def dispatch(context):
+    return context.params
+"""
+
+        self.assertEqual(find_violations(source, Path("plugin/handlers.py")), [])
+
+    def test_allows_validated_dto_and_non_production_fixtures(self) -> None:
+        source = """
+def task(job):
+    params = job.get_typed_params(Params)
+    return params.model_dump()
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "job").mkdir()
+            (root / "job" / "tasks.py").write_text(source, encoding="utf-8")
+            (root / "job" / "tests").mkdir()
+            (root / "job" / "tests" / "test_fixture.py").write_text(
+                "import json\njson.loads(job.params)\n", encoding="utf-8"
+            )
+
+            self.assertEqual(check_repository(root), [])
+
+    def test_repository_reports_violations_outside_tests(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "job").mkdir()
+            (root / "job" / "tasks.py").write_text(
+                "import json\n\ndef task(job):\n    return json.loads(job.params)\n",
+                encoding="utf-8",
+            )
+            (root / "job" / "tests").mkdir()
+            (root / "job" / "tests" / "test_fixture.py").write_text(
+                "import json\njson.loads(job.params)\n", encoding="utf-8"
+            )
+
+            violations = check_repository(root)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].path, root / "job" / "tasks.py")
+
+    def test_production_tree_has_no_direct_job_params_access(self) -> None:
+        """Keep the reserved-attribute invariant enforced by the test suite."""
+
+        violations = check_repository(_REPO_ROOT)
+        self.assertEqual(
+            [violation.format(_REPO_ROOT) for violation in violations],
+            [],
+            "Consume Job parameters through Job.get_typed_params()",
+        )

--- a/plugin/examples/pagoda-hello-world-plugin/pagoda_hello_world_plugin/api_v2/views.py
+++ b/plugin/examples/pagoda-hello-world-plugin/pagoda_hello_world_plugin/api_v2/views.py
@@ -141,7 +141,7 @@ class TaskView(PluginAPIViewMixin):
         try:
             operation_id = PluginTaskRegistry.get_operation_id("hello-world", "hello_world_task")
 
-            job = Job._create_new_job(
+            job = Job.new_custom_job(
                 user=request.user,
                 target=None,
                 operation=operation_id,

--- a/plugin/examples/pagoda-hello-world-plugin/tests/test_api_views.py
+++ b/plugin/examples/pagoda-hello-world-plugin/tests/test_api_views.py
@@ -22,9 +22,11 @@ from pagoda_hello_world_plugin.api_v2.views import (
     GreetView,
     HelloView,
     StatusView,
+    TaskView,
     TestView,
 )
 from rest_framework import status
+from rest_framework.test import force_authenticate
 
 
 class TestHelloView(TestCase):
@@ -514,7 +516,7 @@ class TestHelloViewCeleryTask(TestCase):
     def setUp(self):
         """Set up test fixtures"""
         self.factory = RequestFactory()
-        self.view = HelloView.as_view()
+        self.view = TaskView.as_view()
 
     @patch("pagoda_hello_world_plugin.api_v2.views.PluginTaskRegistry")
     @patch("pagoda_hello_world_plugin.api_v2.views.Job")
@@ -523,7 +525,7 @@ class TestHelloViewCeleryTask(TestCase):
         mock_job = Mock()
         mock_job.id = 1
         mock_job.status = 1
-        mock_job_class._create_new_job.return_value = mock_job
+        mock_job_class.new_custom_job.return_value = mock_job
 
         mock_registry.get_operation_id.return_value = 5001
 
@@ -535,6 +537,7 @@ class TestHelloViewCeleryTask(TestCase):
         request.user = Mock()
         request.user.username = "test_user"
         request.user.is_authenticated = True
+        force_authenticate(request, user=request.user)
 
         response = self.view(request)
 
@@ -544,7 +547,7 @@ class TestHelloViewCeleryTask(TestCase):
         self.assertIn("task_message", response.data)
         self.assertEqual(response.data["task_message"], "Test message")
 
-        mock_job_class._create_new_job.assert_called_once()
+        mock_job_class.new_custom_job.assert_called_once()
         mock_job.run.assert_called_once()
 
     @patch("pagoda_hello_world_plugin.api_v2.views.PluginTaskRegistry")
@@ -560,6 +563,7 @@ class TestHelloViewCeleryTask(TestCase):
         )
         request.user = Mock()
         request.user.is_authenticated = True
+        force_authenticate(request, user=request.user)
 
         response = self.view(request)
 
@@ -572,7 +576,7 @@ class TestHelloViewCeleryTask(TestCase):
     def test_post_with_job_creation_error(self, mock_job_class, mock_registry):
         """Test error handling when Job creation fails"""
         mock_registry.get_operation_id.return_value = 5001
-        mock_job_class._create_new_job.side_effect = Exception("Database error")
+        mock_job_class.new_custom_job.side_effect = Exception("Database error")
 
         request = self.factory.post(
             "/api/v2/plugins/hello-world-plugin/hello/",
@@ -581,6 +585,7 @@ class TestHelloViewCeleryTask(TestCase):
         )
         request.user = Mock()
         request.user.is_authenticated = True
+        force_authenticate(request, user=request.user)
 
         response = self.view(request)
 

--- a/role/tasks.py
+++ b/role/tasks.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 from acl.models import ACLBase
@@ -7,6 +6,7 @@ from airone.lib.job import may_schedule_until_job_is_ready, register_job_task
 from airone.lib.log import Logger
 from group.models import Group
 from job.models import Job, JobOperation, JobStatus
+from job.params import RoleImportParams, RoleReferralParams
 from role.models import Role
 from user.models import User
 
@@ -15,8 +15,8 @@ from user.models import User
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def edit_role_referrals(self: Any, job: Job) -> JobStatus:
-    params = json.loads(job.params)
-    role = Role.objects.get(id=params["role_id"])
+    params = job.get_typed_params(RoleReferralParams)
+    role = Role.objects.get(id=params.role_id)
 
     for entry in [x for x in role.get_referred_entries()]:
         entry.register_es()
@@ -28,7 +28,7 @@ def edit_role_referrals(self: Any, job: Job) -> JobStatus:
 @app.task(bind=True)
 @may_schedule_until_job_is_ready
 def import_role_v2(self: Any, job: Job) -> tuple[JobStatus, str, None] | None:
-    import_data = json.loads(job.params)
+    import_data = job.get_typed_params(RoleImportParams).root
     err_msg = []
     total_count = len(import_data)
 
@@ -42,45 +42,40 @@ def import_role_v2(self: Any, job: Job) -> tuple[JobStatus, str, None] | None:
             job.save(update_fields=["status"])
             return None
 
-        # Skip processing if the role name is not provided
-        if "name" not in role_data:
-            err_msg.append("Role name is required")
-            continue
-
         # Retrieve or create roles
-        if "id" in role_data:
-            role = Role.objects.filter(id=role_data["id"]).first()
+        if role_data.id is not None:
+            role = Role.objects.filter(id=role_data.id).first()
             if not role:
-                err_msg.append(f"Role with ID {role_data['id']} does not exist.")
+                err_msg.append(f"Role with ID {role_data.id} does not exist.")
                 continue
 
-            if (role.name != role_data["name"]) and (
-                Role.objects.filter(name=role_data["name"]).count() > 0
+            if (role.name != role_data.name) and (
+                Role.objects.filter(name=role_data.name).count() > 0
             ):
                 err_msg.append(
                     "New role name is already used(id:%s, group:%s->%s)"
-                    % (role_data["id"], role.name, role_data["name"])
+                    % (role_data.id, role.name, role_data.name)
                 )
                 continue
 
-            role.name = role_data["name"]
+            role.name = role_data.name
         else:
             # Update the group by name
-            role = Role.objects.filter(name=role_data["name"]).first()
+            role = Role.objects.filter(name=role_data.name).first()
             if not role:
                 # create group
-                role = Role.objects.create(name=role_data["name"])
+                role = Role.objects.create(name=role_data.name)
             else:
                 # Clear registered members (users, groups, and administrative ones) for that role
                 for key in ["users", "groups", "admin_users", "admin_groups"]:
                     getattr(role, key).clear()
 
         # Update role information
-        role.description = role_data.get("description", "")
+        role.description = role_data.description
 
         # Configure associated users and groups
         for key in ["users", "admin_users"]:
-            for name in role_data[key]:
+            for name in getattr(role_data, key):
                 instance = User.objects.filter(username=name, is_active=True).first()
                 if not instance:
                     err_msg.append("specified user is not found (username: %s)" % name)
@@ -88,7 +83,7 @@ def import_role_v2(self: Any, job: Job) -> tuple[JobStatus, str, None] | None:
                 getattr(role, key).add(instance)
 
         for key in ["groups", "admin_groups"]:
-            for name in role_data[key]:
+            for name in getattr(role_data, key):
                 group_instance = Group.objects.filter(
                     name=name,
                     is_active=True,  # type: ignore[misc]
@@ -99,7 +94,7 @@ def import_role_v2(self: Any, job: Job) -> tuple[JobStatus, str, None] | None:
                 getattr(role, key).add(group_instance)
 
         # Configure ACL
-        for permission in role_data.get("permissions", []):
+        for permission in role_data.permissions:
             acl = ACLBase.objects.filter(id=permission["obj_id"]).first()
             if not acl:
                 raise ValueError(f"Invalid obj_id: {permission['obj_id']}")
@@ -113,8 +108,8 @@ def import_role_v2(self: Any, job: Job) -> tuple[JobStatus, str, None] | None:
         try:
             role.save()
         except Exception as e:
-            err_msg.append(role_data["name"])
-            Logger.warning("failed to save role: name=%s, error=%s" % (role_data["name"], str(e)))
+            err_msg.append(role_data.name)
+            Logger.warning("failed to save role: name=%s, error=%s" % (role_data.name, str(e)))
 
     # Update the job based on the result of the process
     if err_msg:

--- a/trigger/tasks.py
+++ b/trigger/tasks.py
@@ -1,10 +1,10 @@
-import json
 from typing import Any
 
 from airone.celery import app
 from airone.lib.job import may_schedule_until_job_is_ready, register_job_task
 from entry.models import Entry
 from job.models import Job, JobOperation, JobStatus
+from job.params import TriggerListParams
 from trigger.models import (
     TriggerCondition,
 )
@@ -19,7 +19,10 @@ def may_invoke_trigger(self: Any, job: Job) -> JobStatus:
     user = User.objects.filter(id=job.user.id).first()
     assert job.target is not None
     entry = Entry.objects.filter(id=job.target.id, is_active=True).first()
-    recv_data = json.loads(job.params)
+    recv_data = [
+        param.model_dump(mode="json", by_alias=True, exclude_unset=True)
+        for param in job.get_typed_params(TriggerListParams).root
+    ]
 
     assert user is not None
     assert entry is not None


### PR DESCRIPTION
Use well type checked params on the workers (at the task implementations) to ensure more type safety.